### PR TITLE
📦 package.json: Update scripts section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,15 @@
 language: node_js
 sudo: required
 notifications:
+  email: false
 node_js:
-- '10'
+  - '10'
 install:
-- npm ci
-- npm install -g codecov
+  - npm ci
 script:
-  - npm run travis:verify
+  - npm run verify
+  - npx codecov
 after_success:
-  - codecov
   - curl -sSL https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master/src/bootstrap.sh | bash -s
 env:
   global:

--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+set -e
+set -x
+
+if [ "${TRAVIS_BRANCH}" = "master" ]
+then
+    for env in ci qa
+    do
+        echo "PUSHING ${env}-beta"
+        rm -rf ./dist/.git
+        .travis/release.sh "${env}-beta"
+    done
+fi
+
+
+if [ "${TRAVIS_BRANCH}" = "master-stable" ]
+then
+    for env in ci qa
+    do
+        echo "PUSHING ${env}-stable"
+        rm -rf ./dist/.git
+        .travis/release.sh "${env}-stable"
+    done
+fi
+
+if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+    echo "PUSHING ${TRAVIS_BRANCH}"
+    rm -rf ./build/.git
+    .travis/release.sh "${TRAVIS_BRANCH}"
+fi

--- a/package.json
+++ b/package.json
@@ -70,14 +70,17 @@
   "scripts": {
     "build": "webpack --config config/prod.webpack.config.js",
     "build:prod": "NODE_ENV=production webpack --config config/prod.webpack.config.js",
-    "test": "jest --verbose",
+    "deploy": "npm-run-all build:prod lint test",
     "lint": "npm-run-all lint:*",
     "lint:js": "eslint config src",
     "lint:js:fix": "eslint config src --fix",
     "lint:sass": "stylelint 'src/**/*.scss' --config .stylelintrc.json",
+    "nightly": "npm run deploy",
+    "prod": "NODE_ENV=production webpack-dev-server --config config/dev.webpack.config.js",
+    "server:ctr": "node src/server/generateServerKey.js",
     "start": "NODE_ENV=development webpack-dev-server --config config/dev.webpack.config.js",
-    "travis:verify": "npm-run-all build lint test",
-    "verify": "npm run travis:verify"
+    "test": "jest --verbose",
+    "verify": "npm-run-all build lint test"
   },
   "insights": {
     "appname": "image-builder"


### PR DESCRIPTION
The starter app has been updated over the last few months and new
options are required in the `scripts` section of `package.json`.

Bring the `scripts` section in line with the starter app to fix some
issues around routing requests to `/beta` in CI.

Signed-off-by: Major Hayden <major@redhat.com>