### PR TITLE
📦 Denote AWS image as raw

### DIFF
--- a/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
+++ b/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
@@ -98,7 +98,7 @@ AmazonUploadComponent.propTypes = {
 
 const UploadComponent = (props) => {
     const uploadTypes = [
-        { value: 'aws', label: 'Amazon Machine Image (.vhdx)' },
+        { value: 'aws', label: 'Amazon Machine Image (.raw)' },
     ];
 
     return (


### PR DESCRIPTION
We had issues in composer a while back with VHDX in AWS and we have been
using raw images since then.

Signed-off-by: Major Hayden <major@redhat.com>