### PR TITLE
test: Add test for ImagesTable.js

### DIFF
--- a/src/SmartComponents/ImagesTable/ImagesTable.js
+++ b/src/SmartComponents/ImagesTable/ImagesTable.js
@@ -102,7 +102,7 @@ function mapDispatchToProps(dispatch) {
 }
 
 ImagesTable.propTypes = {
-    composes: PropTypes.object,
+    composes: PropTypes.array,
     updateCompose: PropTypes.func,
 };
 

--- a/src/test/SmartComponents/ImagesTable/ImagesTable.test.js
+++ b/src/test/SmartComponents/ImagesTable/ImagesTable.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithReduxRouter } from '../../testUtils';
+
+import ImagesTable from '../../../SmartComponents/ImagesTable/ImagesTable';
+
+describe('ImagesTable Page', () => {
+    beforeEach(() => {
+        const mockedStore = {
+            composes: [
+                {
+                    image_type: 'qcow2',
+                    distribution: 'fedora-33'
+                }
+            ]
+        };
+        renderWithReduxRouter(<ImagesTable />, mockedStore);
+    });
+    test('renders images table', () => {
+        // check images table
+        screen.getByTestId('images-table');
+
+        // check props render
+        screen.getByText(/fedora-33/i,);
+        screen.getByText(/qcow2/i,);
+    });
+});

--- a/src/test/testUtils.js
+++ b/src/test/testUtils.js
@@ -6,7 +6,7 @@ import { createMemoryHistory } from 'history';
 import configureStore from 'redux-mock-store';
 
 const defaultStore = {
-    composes: {}
+    composes: []
 };
 
 export const renderWithReduxRouter = (component, mockedStore = defaultStore, route = '/') => {


### PR DESCRIPTION
1. Add images table render test
2. Update composes prop type to array and change composes default value to empty array instead of empty object in testUtils.renderWithReduxRouter

API calling part will be in another PR (which needs mock)