### PR TITLE
test: Make sure the status of a compose is called status

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -49,7 +49,7 @@ rules:
     - error
     - 4
     - SwitchCase: 1
-      MemberExpression: 0
+      MemberExpression: 1
       ImportDeclaration: 1
       ObjectExpression: 1
   react/jsx-curly-spacing:

--- a/src/SmartComponents/redux/reducers.js
+++ b/src/SmartComponents/redux/reducers.js
@@ -2,8 +2,8 @@ import types from './types';
 
 // Example of action.compose
 // {
-//     "xxxx-xxxx-xxxx-xxxx": {
-//         state: "uploading",
+//     "77e4c693-0497-4b85-936d-b2a3ad69571b": {
+//         status: "uploading",
 //         distribution: "fedora-31",
 //         architecture: "x86_64",
 //         image_type: "qcow2"

--- a/src/test/SmartComponents/redux/actions.test.js
+++ b/src/test/SmartComponents/redux/actions.test.js
@@ -2,8 +2,8 @@ import actions from '../../../SmartComponents/redux/actions';
 import types from '../../../SmartComponents/redux/types';
 
 const compose = {
-    'xxxx-xxxx-xxxx-xxxx': {
-        state: 'uploading',
+    '77e4c693-0497-4b85-936d-b2a3ad69571b': {
+        status: 'uploading',
         distribution: 'fedora-31',
         architecture: 'x86_64',
         image_type: 'qcow2'

--- a/src/test/SmartComponents/redux/reducers.test.js
+++ b/src/test/SmartComponents/redux/reducers.test.js
@@ -2,8 +2,8 @@ import { composeReducer } from '../../../SmartComponents/redux/reducers';
 import types from '../../../SmartComponents/redux/types';
 
 const compose = {
-    'xxxx-xxxx-xxxx-xxxx': {
-        state: 'uploading',
+    '77e4c693-0497-4b85-936d-b2a3ad69571b': {
+        status: 'uploading',
         distribution: 'fedora-31',
         architecture: 'x86_64',
         image_type: 'qcow2'
@@ -29,6 +29,7 @@ describe('composeReducer', () => {
         });
 
         expect(result.testAttr).toBe('test-me');
-        expect(result['xxxx-xxxx-xxxx-xxxx']).toEqual(compose['xxxx-xxxx-xxxx-xxxx']);
+        expect(result['77e4c693-0497-4b85-936d-b2a3ad69571b'])
+            .toEqual(compose['77e4c693-0497-4b85-936d-b2a3ad69571b']);
     });
 });


### PR DESCRIPTION
This was a bit confusing because in the inline documentation I wrote
used state as a key. However this changed to status pretty early on and
I forgot to update it.