### PR TITLE
Revert "Update travis config file to rebase on master before test running"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,6 @@ node_js:
 cache:
   directories:
   - node_modules
-before_install:
-  - |
-        git config --global user.email "travis@image-builder.frontend"
-        git config --global user.name "Travis CI"
-        git remote add image-builder-frontend https://github.com/${TRAVIS_REPO_SLUG}.git
-        git fetch image-builder-frontend $TRAVIS_BRANCH
-        git log -1 --pretty=format:%H image-builder-frontend/${TRAVIS_BRANCH}
-        git rebase image-builder-frontend/${TRAVIS_BRANCH}
 install:
   - npm install
 script:


### PR DESCRIPTION

This reverts commit bd99a90faa8188eb8c9ada6b68c403fff6a800c2.

While this is common in cockpit's projects, osbuild projects refrain
from rebasing branches.

Rebasing on master as it happens to be when the test is running, leaves
you in a state where you neither know that the branch itself is working,
nor that it will work when you actually do merge it later, because
master might have changed in between.