### PR TITLE
Table view updates

### DIFF
--- a/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.js
@@ -5,7 +5,7 @@ import { Form, FormGroup, FormSelect, FormSelectOption, Title } from '@patternfl
 
 const WizardStepImageOutput = (props) => {
     const releaseOptions = [
-        { value: 'rhel-8', label: 'Red Hat Enterprise Linux (RHEL) 8.2' },
+        { value: 'rhel-8', label: 'Red Hat Enterprise Linux (RHEL) 8.3' },
     ];
     const uploadOptions = [
         { value: 'aws', label: 'Amazon Web Services' },

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
@@ -8,7 +8,7 @@ import './WizardStepReview.scss';
 
 const WizardStepReview = (props) => {
     const releaseOptions = {
-        'rhel-8': 'Red Hat Enterprise Linux (RHEL) 8.2'
+        'rhel-8': 'Red Hat Enterprise Linux (RHEL) 8.3'
     };
     const uploadOptions = {
         aws: 'Amazon Web Services'
@@ -30,7 +30,7 @@ const WizardStepReview = (props) => {
                         Release
                     </dt>
                     <dd>
-                        { releaseOptions[props.release]}
+                        { releaseOptions[props.release] }
                     </dd>
                     <dt>
                         Target environment

--- a/src/PresentationalComponents/Release/Release.js
+++ b/src/PresentationalComponents/Release/Release.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Label } from '@patternfly/react-core';
+
+const Release = (props) => {
+    const releaseOptions = {
+        'rhel-8': 'RHEL 8.3'
+    };
+    const release = releaseOptions[props.release] ? releaseOptions[props.release] : props.release;
+    return <Label color='blue'>{release}</Label>;
+};
+
+Release.propTypes = {
+    release: PropTypes.string,
+};
+
+export default Release;

--- a/src/SmartComponents/ImagesTable/ImagesTable.js
+++ b/src/SmartComponents/ImagesTable/ImagesTable.js
@@ -60,11 +60,14 @@ class ImagesTable extends Component {
 
     render() {
         let { composes } = this.props;
+        const uploadOptions = {
+            aws: 'Amazon Web Services'
+        };
         const rows = Object.entries(composes).map(([ id, compose ]) => {
             return {
                 cells: [
                     id,
-                    compose.image_type,
+                    uploadOptions[compose.image_type] ? uploadOptions[compose.image_type] : compose.image_type,
                     { title: <Release release={ compose.distribution } /> },
                     { title: <ImageBuildStatus status={ compose.status } /> },
                     ''

--- a/src/SmartComponents/ImagesTable/ImagesTable.js
+++ b/src/SmartComponents/ImagesTable/ImagesTable.js
@@ -7,6 +7,7 @@ import { Table, TableHeader, TableBody, classNames, Visibility } from '@patternf
 import { TableToolbar } from '@redhat-cloud-services/frontend-components';
 
 import ImageBuildStatus from '../../PresentationalComponents/ImageBuildStatus/ImageBuildStatus';
+import Release from '../../PresentationalComponents/Release/Release';
 
 import api from '../../api.js';
 
@@ -64,7 +65,7 @@ class ImagesTable extends Component {
                 cells: [
                     id,
                     compose.image_type,
-                    compose.distribution,
+                    { title: <Release release={ compose.distribution } /> },
                     { title: <ImageBuildStatus status={ compose.status } /> },
                     ''
                 ]

--- a/src/SmartComponents/ImagesTable/ImagesTable.js
+++ b/src/SmartComponents/ImagesTable/ImagesTable.js
@@ -5,6 +5,7 @@ import { actions } from '../redux';
 import { Link } from 'react-router-dom';
 import { Table, TableHeader, TableBody, classNames, Visibility } from '@patternfly/react-table';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components';
+import { ToolbarGroup, ToolbarItem } from '@patternfly/react-core';
 
 import ImageBuildStatus from '../../PresentationalComponents/ImageBuildStatus/ImageBuildStatus';
 import Release from '../../PresentationalComponents/Release/Release';
@@ -77,9 +78,13 @@ class ImagesTable extends Component {
         return (
             <React.Fragment>
                 <TableToolbar>
-                    <Link to="/imagewizard" className="pf-c-button pf-m-primary" data-testid="create-image-action">
-                        Create image
-                    </Link>
+                    <ToolbarGroup>
+                        <ToolbarItem>
+                            <Link to="/imagewizard" className="pf-c-button pf-m-primary" data-testid="create-image-action">
+                                Create image
+                            </Link>
+                        </ToolbarItem>
+                    </ToolbarGroup>
                 </TableToolbar>
                 <Table
                     aria-label="Images"


### PR DESCRIPTION
Updates include:
- Release column:
  - Adding a blue label
  - Adding a user-friendly short label (e.g. RHEL 8 vs rhel-8)
- Target column
  - Adding a user-friendly long label (e.g. Amazon Web Services vs aws)
- Adding more PF toolbar components to update the toolbar layout. This still leaves the clouddot `<TableToolbar>` component, which I'm not 💯% positive is the right component to use over PF's `<Toolbar>`, especially given the large margin before the Create button.

<img width="1037" alt="image" src="https://user-images.githubusercontent.com/21063328/102290250-a24d5080-3f0e-11eb-8a12-36ecb7fbaa6f.png">
