### PR TITLE
Adds a Stack layout to have the wizard footer visible

### DIFF
--- a/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
+++ b/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import { actions } from '../redux';
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 
-import { Wizard } from '@patternfly/react-core';
+import { Wizard, Stack, StackItem } from '@patternfly/react-core';
 
 import WizardStepImageOutput from '../../PresentationalComponents/CreateImageWizard/WizardStepImageOutput';
 import WizardStepUploadAWS from '../../PresentationalComponents/CreateImageWizard/WizardStepUploadAWS';
@@ -238,18 +238,22 @@ class CreateImageWizard extends Component {
         ];
 
         return (
-            <>
-                <PageHeader>
-                    <PageHeaderTitle title='Create a new image' />
-                </PageHeader>
-                <Wizard
-                    onNext={ this.onStep }
-                    onGoToStep={ this.onStep }
-                    isInPage
-                    steps={ steps }
-                    onClose={ this.onClose }
-                    onSave={ this.onSave } />
-            </>
+            <Stack className="pf-u-h-100">
+                <StackItem>
+                    <PageHeader>
+                        <PageHeaderTitle title='Create a new image' />
+                    </PageHeader>
+                </StackItem>
+                <StackItem isFilled>
+                    <Wizard
+                        onNext={ this.onStep }
+                        onGoToStep={ this.onStep }
+                        isInPage
+                        steps={ steps }
+                        onClose={ this.onClose }
+                        onSave={ this.onSave } />
+                </StackItem>
+            </Stack>
         );
     }
 }


### PR DESCRIPTION
TLDR; before this update the user always has to scroll to get to
the footer actions in the wizard.

There's a weird nested page section thing happening which results
in the wizard body+footer being 100% of the height of the main content
area, but when you add the wizard header as a separate section above
the 100% height wizard body+footer, the header pushes the wizard
contents down so that the bottom portion of the wizard (equal to the
height of the header, and roughly the height of the footer) is always out
of view. This means that the user always has to scroll to get to the
footer.