### PR TITLE
src: add package step to wizard

### DIFF
--- a/src/PresentationalComponents/CreateImageWizard/WizardStepPackages.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepPackages.js
@@ -1,0 +1,193 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import {
+    Button, ButtonVariant,
+    DataList, DataListAction, DataListCell, DataListItem, DataListItemRow, DataListItemCells,
+    InputGroup,
+    Pagination,
+    Text, TextContent, TextInput,
+    Title,
+    Toolbar, ToolbarItem, ToolbarContent } from '@patternfly/react-core';
+import { ExternalLinkAltIcon, MinusCircleIcon, PlusCircleIcon, SearchIcon } from '@patternfly/react-icons';
+
+const WizardStepPackages = (props) => {
+    return (
+        <>
+            <TextContent>
+                <Title headingLevel="h2" size="xl">Additional packages</Title>
+                <Text>Add additional packages to your <strong>{props.release}</strong> image</Text>
+                <Button
+                    component="a"
+                    target="_blank"
+                    variant="link"
+                    icon={ <ExternalLinkAltIcon /> }
+                    iconPosition="right"
+                    isInline
+                    href="https://redhat.com">
+                    View packages in base image
+                </Button>
+            </TextContent>
+            <Toolbar id="packages-toolbar">
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <InputGroup>
+                            <TextInput
+                                id="packages-input"
+                                type="search"
+                                aria-label="search packages input"
+                                placeholder="Search for a package"
+                                value={ props.packagesSearchName }
+                                onChange={ props.setPackagesSearchName } />
+                            <Button
+                                variant={ ButtonVariant.control }
+                                aria-label="search icon for search packages input"
+                                onClick={ props.handlePackagesSearch }>
+                                <SearchIcon />
+                            </Button>
+                        </InputGroup>
+                    </ToolbarItem>
+                    <ToolbarItem>
+                        <Button
+                            variant="primary"
+                            aria-label="search button for search packages input"
+                            onClick={ props.handlePackagesSearch }>
+                                Search
+                        </Button>
+                    </ToolbarItem>
+                    {props.showPackagesSearch &&
+                        <>
+                            <ToolbarItem>
+                                <Button
+                                    component="a"
+                                    variant="link"
+                                    isInline
+                                    type="submit"
+                                    onClick={ props.clearPackagesSearch }>
+                                Clear search
+                                </Button>
+                            </ToolbarItem>
+                            <ToolbarItem variant="pagination" align={ { default: 'alignRight' } }>
+                                <Pagination
+                                    itemCount={ 523 }
+                                    perPage={ props.packagesSearchPerPage }
+                                    page={ props.packagesSearchPage }
+                                    onSetPage={ props.setPagePackagesSearch }
+                                    onPerPageSelect={ props.setPerPagePackagesSearch }
+                                    widgetId="pagination-options-package-search"
+                                    isCompact />
+                            </ToolbarItem>
+                        </>
+                    }
+                </ToolbarContent>
+            </Toolbar>
+            {props.showPackagesSearch && (
+                <DataList aria-label="packages data list" isCompact>
+                    {props.packages.map((pack) =>
+                        <DataListItem key={ pack.name } aria-labelledby={ pack.name }>
+                            <DataListItemRow>
+                                <DataListItemCells
+                                    dataListCells={ [
+                                        <DataListCell key="package-details" id="select package details">
+                                            <TextContent>
+                                                <span>{ pack.name }</span>
+                                                <small>{ pack.summary }</small>
+                                            </TextContent>
+                                        </DataListCell>
+                                    ] } />
+                                <DataListAction
+                                    key="package-action"
+                                    aria-label="select package action"
+                                    aria-labelledby="select package details">
+                                    { pack.selected ? (
+                                        <Button variant="link" icon={ <MinusCircleIcon /> } onClick={ () => props.handleRemovePackage(pack) }>
+                                            Remove
+                                        </Button>
+                                    ) : (
+                                        <Button variant="link" icon={ <PlusCircleIcon /> } onClick={ () => props.handleAddPackage(pack) }>
+                                            Add
+                                        </Button>
+                                    )}
+                                </DataListAction>
+                            </DataListItemRow>
+                        </DataListItem>
+                    )}
+                </DataList>
+            )}
+            <Toolbar id="selected-packages-toolbar">
+                <ToolbarContent>
+                    <ToolbarItem>
+                        <Title headingLevel="h3">Additional packages</Title>
+                    </ToolbarItem>
+                    {props.selectedPackages.length > 0 && (
+                        <ToolbarItem variant="pagination" align={ { default: 'alignRight' } }>
+                            <Pagination
+                                itemCount={ 523 }
+                                perPage={ props.packagesSelectedPerPage }
+                                page={ props.packagesSelectedPage }
+                                onSetPage={ props.setPagePackagesSelected }
+                                onPerPageSelect={ props.setPerPagePackagesSelected }
+                                widgetId="pagination-options-packages-selected"
+                                isCompact />
+                        </ToolbarItem>
+                    )}
+                </ToolbarContent>
+            </Toolbar>
+            {props.selectedPackages.length > 0 ? (
+                <DataList aria-label="selected packages data list" isCompact>
+                    {props.selectedPackages.map((pack) =>
+                        <DataListItem key={ pack.name } aria-labelledby={ pack.name }>
+                            <DataListItemRow>
+                                <DataListItemCells
+                                    dataListCells={ [
+                                        <DataListCell key="selected-package-details" id="selected package details">
+                                            <TextContent>
+                                                <span>{ pack.name }</span>
+                                                <small>{ pack.summary }</small>
+                                            </TextContent>
+                                        </DataListCell>
+                                    ] } />
+                                <DataListAction
+                                    key="selected-package-action"
+                                    aria-label="select package action"
+                                    aria-labelledby="selected package details">
+                                    <Button variant="link" icon={ <MinusCircleIcon /> } onClick={ () => props.handleRemovePackage(pack) }>
+                                        Remove
+                                    </Button>
+                                </DataListAction>
+                            </DataListItemRow>
+                        </DataListItem>
+                    )}
+                </DataList>
+            ) : (
+                <TextContent>
+                    <Text>No additional packages added.</Text>
+                    <Text>Search above to add additional packages to your image.</Text>
+                </TextContent>
+            )}
+        </>
+    );
+};
+
+WizardStepPackages.propTypes = {
+    release: PropTypes.string,
+    packages: PropTypes.arrayOf(PropTypes.object),
+    selectedPackages: PropTypes.arrayOf(PropTypes.object),
+    showPackagesSearch: PropTypes.bool,
+    packagesSearchName: PropTypes.string,
+    packagesSearchPage: PropTypes.number,
+    packagesSearchPerPage: PropTypes.number,
+    packagesSelectedPage: PropTypes.number,
+    packagesSelectedPerPage: PropTypes.number,
+    clearPackagesSearch: PropTypes.func,
+    handlePackagesSearch: PropTypes.func,
+    handleAddPackage: PropTypes.func,
+    handleRemovePackage: PropTypes.func,
+    setPackagesSearchName: PropTypes.func,
+    setPagePackagesSearch: PropTypes.func,
+    setPerPagePackagesSearch: PropTypes.func,
+    setPagePackagesSelected: PropTypes.func,
+    setPerPagePackagesSelected: PropTypes.func,
+};
+
+export default WizardStepPackages;

--- a/src/store/packages.json
+++ b/src/store/packages.json
@@ -1,0 +1,129 @@
+{
+  "dummyPackageList": [
+    {
+      "name": "0ad",
+      "summary": "Cross-Platform RTS Game of Ancient Warfare",
+      "description": "0 A.D. (pronounced \"zero ey-dee\") is a free, open-source, cross-platform\nreal-time strategy (RTS) game of ancient warfare. In short, it is a\nhistorically-based war/economy game that allows players to relive or rewrite\nthe history of Western civilizations, focusing on the years between 500 B.C.\nand 500 A.D. The project is highly ambitious, involving state-of-the-art 3D\ngraphics, detailed artwork, sound, and a flexible and powerful custom-built\ngame engine.\n\nThe game has been in development by Wildfire Games (WFG), a group of volunteer,\nhobbyist game developers, since 2001.",
+      "homepage": "http://play0ad.com",
+      "upstream_vcs": "UPSTREAM_VCS",
+      "builds": [
+        {
+          "arch": "x86_64",
+          "build_time": "2020-07-31T23:48:35",
+          "epoch": 0,
+          "release": "21.fc33",
+          "source": {
+            "license": "GPLv2+ and BSD and MIT and IBM",
+            "version": "0.0.23b",
+            "source_ref": "SOURCE_REF",
+            "metadata": {}
+          },
+          "changelog": "CHANGELOG_NEEDED",
+          "build_config_ref": "BUILD_CONFIG_REF",
+          "build_env_ref": "BUILD_ENV_REF",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "name": "0ad-data",
+      "summary": "The Data Files for 0 AD",
+      "description": "0 A.D. (pronounced \"zero ey-dee\") is a free, open-source, cross-platform\nreal-time strategy (RTS) game of ancient warfare. In short, it is a\nhistorically-based war/economy game that allows players to relive or rewrite\nthe history of Western civilizations, focusing on the years between 500 B.C.\nand 500 A.D. The project is highly ambitious, involving state-of-the-art 3D\ngraphics, detailed artwork, sound, and a flexible and powerful custom-built\ngame engine.\n\nThis package contains the 0ad data files.",
+      "homepage": "http://play0ad.com",
+      "upstream_vcs": "UPSTREAM_VCS",
+      "builds": [
+        {
+          "arch": "noarch",
+          "build_time": "2020-07-27T10:16:23",
+          "epoch": 0,
+          "release": "5.fc33",
+          "source": {
+            "license": "CC-BY-SA",
+            "version": "0.0.23b",
+            "source_ref": "SOURCE_REF",
+            "metadata": {}
+          },
+          "changelog": "CHANGELOG_NEEDED",
+          "build_config_ref": "BUILD_CONFIG_REF",
+          "build_env_ref": "BUILD_ENV_REF",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "name": "0xFFFF",
+      "summary": "The Open Free Fiasco Firmware Flasher",
+      "description": "The 'Open Free Fiasco Firmware Flasher' aka 0xFFFF utility implements\na free (GPL3) userspace handler for the NOLO bootloader and related\nutilities for the Nokia Internet Tablets like flashing setting device\noptions, packing/unpacking FIASCO firmware format and more.",
+      "homepage": "https://talk.maemo.org/showthread.php?t=87996",
+      "upstream_vcs": "UPSTREAM_VCS",
+      "builds": [
+        {
+          "arch": "x86_64",
+          "build_time": "2020-07-27T10:12:04",
+          "epoch": 0,
+          "release": "4.fc33",
+          "source": {
+            "license": "GPLv3",
+            "version": "0.8",
+            "source_ref": "SOURCE_REF",
+            "metadata": {}
+          },
+          "changelog": "CHANGELOG_NEEDED",
+          "build_config_ref": "BUILD_CONFIG_REF",
+          "build_env_ref": "BUILD_ENV_REF",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "name": "2048-cli",
+      "summary": "The game 2048 for your Linux terminal",
+      "description": "A cli version of the game 2048 for your Linux terminal.",
+      "homepage": "https://github.com/Tiehuis/2048-cli",
+      "upstream_vcs": "UPSTREAM_VCS",
+      "builds": [
+        {
+          "arch": "x86_64",
+          "build_time": "2020-07-27T10:12:36",
+          "epoch": 0,
+          "release": "10.fc33",
+          "source": {
+            "license": "MIT",
+            "version": "0.9.1",
+            "source_ref": "SOURCE_REF",
+            "metadata": {}
+          },
+          "changelog": "CHANGELOG_NEEDED",
+          "build_config_ref": "BUILD_CONFIG_REF",
+          "build_env_ref": "BUILD_ENV_REF",
+          "metadata": {}
+        }
+      ]
+    },
+    {
+      "name": "2048-cli-nocurses",
+      "summary": "The game 2048 for your Linux terminal (non-ncurses)",
+      "description": "A non-ncurses cli version of the game 2048 for your Linux terminal.",
+      "homepage": "https://github.com/Tiehuis/2048-cli",
+      "upstream_vcs": "UPSTREAM_VCS",
+      "builds": [
+        {
+          "arch": "x86_64",
+          "build_time": "2020-07-27T10:12:36",
+          "epoch": 0,
+          "release": "10.fc33",
+          "source": {
+            "license": "MIT",
+            "version": "0.9.1",
+            "source_ref": "SOURCE_REF",
+            "metadata": {}
+          },
+          "changelog": "CHANGELOG_NEEDED",
+          "build_config_ref": "BUILD_CONFIG_REF",
+          "build_env_ref": "BUILD_ENV_REF",
+          "metadata": {}
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/SmartComponents/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/SmartComponents/CreateImageWizard/CreateImageWizard.test.js
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 
 import React from 'react';
+// eslint-disable-next-line no-unused-vars
 import { screen, getByText, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithReduxRouter } from '../../testUtils';
@@ -175,11 +176,11 @@ describe('Step Registration', () => {
         anchor.click();
     });
 
-    test('clicking Next loads Review', () => {
+    test('clicking Next loads Packages', () => {
         const [ next, , ] = verifyButtons();
         next.click();
 
-        screen.getByText('Review the information and click Create image to create the image using the following criteria.');
+        screen.getByText('Add additional packages to your image');
     });
 
     test('clicking Back loads Upload to AWS', () => {
@@ -231,6 +232,57 @@ describe('Step Registration', () => {
     });
 });
 
+describe('Step Packages', () => {
+    beforeEach(() => {
+        const { _component, history } = renderWithReduxRouter(<CreateImageWizard />);
+        historySpy = jest.spyOn(history, 'push');
+
+        // left sidebar navigation
+        const sidebar = screen.getByRole('navigation');
+        const anchor = getByText(sidebar, 'Packages');
+
+        // load from sidebar
+        anchor.click();
+    });
+
+    test('clicking Next loads Review', () => {
+        const [ next, , ] = verifyButtons();
+        next.click();
+
+        screen.getByText('Review the information and click Create image to create the image using the following criteria.');
+    });
+
+    test('clicking Back loads Register', () => {
+        const back = screen.getByRole('button', { name: /Back/ });
+        back.click();
+
+        screen.getByText('Register the system');
+    });
+
+    test('clicking Cancel loads landing page', () => {
+        const [ , , cancel ] = verifyButtons();
+        verifyCancelButton(cancel, historySpy);
+    });
+
+    test('should allow searching for and adding package', () => {
+        const search = screen.getByRole('searchbox', { name: /search packages input/ });
+        search.click();
+
+        userEvent.type(search, 'test');
+
+        const button = screen.getByRole('button', {
+            name: /search button for search packages input/i
+        });
+        button.click();
+
+        screen.getByText(/cross-platform rts game of ancient warfare/i);
+        const addButtons = screen.getAllByRole('button', {
+            name: 'Add'
+        });
+        userEvent.click(addButtons[0]);
+    });
+});
+
 describe('Step Review', () => {
     beforeEach(() => {
         const { _component, history } = renderWithReduxRouter(<CreateImageWizard />);
@@ -250,11 +302,11 @@ describe('Step Review', () => {
         screen.getByRole('button', { name: /Cancel/ });
     });
 
-    test('clicking Back loads Register', () => {
+    test('clicking Back loads Packages', () => {
         const back = screen.getByRole('button', { name: /Back/ });
         back.click();
 
-        screen.getByText('Register the system');
+        screen.getByText('Add additional packages to your image');
     });
 
     test('clicking Cancel loads landing page', () => {
@@ -287,6 +339,10 @@ describe('Click through all steps', () => {
             .click();
         await screen.findByTestId('subscription-activation');
         userEvent.type(screen.getByTestId('subscription-activation'), '1234567890');
+        next.click();
+
+        // packages
+        screen.getByText('Add additional packages to your image');
         next.click();
 
         // review
@@ -330,6 +386,10 @@ describe('Click through all steps', () => {
         userEvent.clear(screen.getByTestId('subscription-activation'));
         next.click();
 
+        // packages
+        screen.getByText('Add additional packages to your image');
+        next.click();
+
         await screen.
             findByText('Review the information and click Create image to create the image using the following criteria.');
         await screen.findByText('Amazon Web Services');
@@ -360,6 +420,10 @@ describe('Click through all steps', () => {
             .click();
         await screen.findByTestId('subscription-activation');
         userEvent.clear(screen.getByTestId('subscription-activation'));
+        next.click();
+
+        // packages
+        screen.getByText('Add additional packages to your image');
         next.click();
 
         await screen.


### PR DESCRIPTION
The additional package selection step is added to the create image wizard. This step currently uses mock data set in packages.json. There are still a few things needed. Empty and loading state text needs to be added, actual data and routing needs to be supported, pagination needs to actual page through the data list. Tests need to be added.


![selectPackagesV0](https://user-images.githubusercontent.com/11712857/106600642-fb268600-655a-11eb-9ac1-a4f18a974c52.png)
