### PR TITLE
CreateImageWizard: Change image type to ami

### DIFF
--- a/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
+++ b/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
@@ -136,7 +136,7 @@ class CreateImageWizard extends Component {
             image_requests: [
                 {
                     architecture: 'x86_64',
-                    image_type: 'qcow2',
+                    image_type: 'ami',
                     upload_requests: [{
                         type: 'aws',
                         options: {


### PR DESCRIPTION
Once we have multiple image types we need to make this dynamic based on
upload type. But qcow2 doesn't work under any circumstance so let's use
ami.