### PR TITLE
travis: Let main push to prod-beta as well

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -4,7 +4,7 @@ set -x
 
 if [ "${TRAVIS_BRANCH}" = "main" ]
 then
-    for env in ci qa stage
+    for env in ci qa stage prod
     do
         echo "PUSHING ${env}-beta"
         rm -rf ./dist/.git
@@ -23,8 +23,9 @@ then
     done
 fi
 
-if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
-    echo "PUSHING ${TRAVIS_BRANCH}"
-    rm -rf ./build/.git
-    .travis/release.sh "${TRAVIS_BRANCH}"
-fi
+# Enable this once we fork prod from stage
+# if [[ "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+#     echo "PUSHING ${TRAVIS_BRANCH}"
+#     rm -rf ./build/.git
+#     .travis/release.sh "${TRAVIS_BRANCH}"
+# fi


### PR DESCRIPTION
Once we fork prod in imagebuilder to be a separate version from stage, let's do the same with the frontend. Until that point let's just have main push to both stage and prod beta.