### PR TITLE
add support for CentOS Stream 8

### DIFF
--- a/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.js
@@ -6,6 +6,7 @@ import { Form, FormGroup, FormSelect, FormSelectOption, Title } from '@patternfl
 const WizardStepImageOutput = (props) => {
     const releaseOptions = [
         { value: 'rhel-8', label: 'Red Hat Enterprise Linux (RHEL) 8.3' },
+        { value: 'centos-8', label: 'CentOS Stream 8' },
     ];
     const uploadOptions = [
         { value: 'aws', label: 'Amazon Web Services' },

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
@@ -8,7 +8,8 @@ import './WizardStepReview.scss';
 
 const WizardStepReview = (props) => {
     const releaseOptions = {
-        'rhel-8': 'Red Hat Enterprise Linux (RHEL) 8.3'
+        'rhel-8': 'Red Hat Enterprise Linux (RHEL) 8.3',
+        'centos-8': 'CentOS Stream 8'
     };
     const uploadOptions = {
         aws: 'Amazon Web Services'

--- a/src/PresentationalComponents/ImagesTable/Release.js
+++ b/src/PresentationalComponents/ImagesTable/Release.js
@@ -5,7 +5,8 @@ import { Label } from '@patternfly/react-core';
 
 const Release = (props) => {
     const releaseOptions = {
-        'rhel-8': 'RHEL 8.3'
+        'rhel-8': 'RHEL 8.3',
+        'centos-8': 'CentOS Stream 8'
     };
     const release = releaseOptions[props.release] ? releaseOptions[props.release] : props.release;
     return <Label color='blue'>{release}</Label>;


### PR DESCRIPTION
image-builder has recently got support for building CentOS Stream 8 images.
This commit adds the option to build these images in the frontend.

I'm not entirely sure what I'm doing, so please review carefully. :) Also, I'm not sure if the backend part is deployed yet...