### PR TITLE
Support multiple cloud destinations

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": false,
   "dependencies": {
     "@babel/runtime": "^7.11.0",
-    "@patternfly/patternfly": "^4.67.0",
-    "@patternfly/react-core": "^4.79.4",
-    "@patternfly/react-table": "^4.19.26",
+    "@patternfly/patternfly": "^4.87.2",
+    "@patternfly/react-core": "^4.97.1",
+    "@patternfly/react-table": "^4.23.1",
     "@redhat-cloud-services/frontend-components": "^2.4.23",
     "@redhat-cloud-services/frontend-components-utilities": "^2.2.7",
     "classnames": "^2.2.6",

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.js
@@ -1,40 +1,75 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import { Form, FormGroup, FormSelect, FormSelectOption, Title } from '@patternfly/react-core';
+import { Form, FormGroup, FormSelect, FormSelectOption, Tile, Title } from '@patternfly/react-core';
+
+import './WizardStepImageOutput.scss';
 
 const WizardStepImageOutput = (props) => {
     const releaseOptions = [
         { value: 'rhel-8', label: 'Red Hat Enterprise Linux (RHEL) 8.3' },
     ];
-    const uploadOptions = [
-        { value: 'aws', label: 'Amazon Web Services' },
-    ];
+
     return (
-        <Form>
-            <Title headingLevel="h2" size="xl">Image output</Title>
-            <FormGroup isRequired label="Release" fieldId="release-select">
-                <FormSelect value={ props.value } onChange={ value => props.setRelease(value) } isRequired
-                    aria-label="Select release input" id="release-select" data-testid="release-select">
-                    { releaseOptions.map(option => <FormSelectOption key={ option.value } value={ option.value } label={ option.label } />) }
-                </FormSelect>
-            </FormGroup>
-            <FormGroup isRequired label="Target environment" fieldId="upload-destination">
-                <FormSelect value={ props.upload.type || '' } id="upload-destination"
-                    data-testid="upload-destination" isRequired
-                    onChange={ value => props.setUpload({ type: value, options: props.upload.options }) } aria-label="Select upload destination">
-                    { uploadOptions.map(option => <FormSelectOption key={ option.value } value={ option.value } label={ option.label } />) }
-                </FormSelect>
-            </FormGroup>
-        </Form>
+        <>
+            <Form>
+                <Title headingLevel="h2" size="xl">Image output</Title>
+                <FormGroup isRequired label="Release" fieldId="release-select">
+                    <FormSelect value={ props.value } onChange={ value => props.setRelease(value) } isRequired
+                        aria-label="Select release input" id="release-select" data-testid="release-select">
+                        { releaseOptions.map(option => <FormSelectOption key={ option.value } value={ option.value } label={ option.label } />) }
+                    </FormSelect>
+                </FormGroup>
+                <FormGroup isRequired label="Select target environment" data-testid="target-select">
+                    <div className="tiles">
+                        <Tile
+                            className="tile pf-u-mr-sm"
+                            data-testid="upload-aws"
+                            title="Amazon Web Services"
+                            icon={ <img
+                                className='provider-icon'
+                                src={ '/apps/frontend-assets/partners-icons/aws.svg' } /> }
+                            onClick={ () => props.toggleUploadDestination('aws') }
+                            isSelected={ props.uploadDestinations.aws }
+                            isStacked
+                            isDisplayLarge />
+                        <Tile
+                            className="tile pf-u-mr-sm"
+                            data-testid="upload-azure"
+                            title="Microsoft Azure"
+                            icon={ <img
+                                className='provider-icon'
+                                src={ '/apps/frontend-assets/partners-icons/microsoft-azure-short.svg' } /> }
+                            onClick={ () => props.toggleUploadDestination('azure') }
+                            isSelected={ props.uploadDestinations.azure }
+                            isStacked
+                            isDisplayLarge
+                            isDisabled />
+                        <Tile
+                            className="tile"
+                            data-testid="upload-google"
+                            title="Google Cloud Platform"
+                            icon={ <img
+                                className='provider-icon'
+                                src={ '/apps/frontend-assets/partners-icons/google-cloud-short.svg' } /> }
+                            onClick={ () => props.toggleUploadDestination('google') }
+                            isSelected={ props.uploadDestinations.google }
+                            isStacked
+                            isDisplayLarge
+                            isDisabled />
+                    </div>
+                </FormGroup>
+            </Form>
+        </>
     );
 };
 
 WizardStepImageOutput.propTypes = {
+    toggleUploadAWS: PropTypes.func,
+    uploadDestinations: PropTypes.object,
     setRelease: PropTypes.func,
     value: PropTypes.string,
-    upload: PropTypes.object,
-    setUpload: PropTypes.func,
+    toggleUploadDestination: PropTypes.func,
 };
 
 export default WizardStepImageOutput;

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.scss
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.scss
@@ -1,0 +1,26 @@
+.tiles {
+    display: flex;
+}
+
+.tile {
+    flex: 1 0 0px;
+}
+
+.pf-c-tile:focus {
+    --pf-c-tile__title--Color: var(--pf-c-tile__title--Color);
+    --pf-c-tile__icon--Color: var(---pf-global--Color--100);
+    --pf-c-tile--before--BorderWidth: var(--pf-global--BorderWidth--sm);
+    --pf-c-tile--before--BorderColor: var(--pf-global--BorderColor--100);
+}
+
+.pf-c-tile.pf-m-selected:focus {
+    --pf-c-tile__title--Color: var(--pf-c-tile--focus__title--Color);
+    --pf-c-tile__icon--Color: var(--pf-c-tile--focus__icon--Color);
+    --pf-c-tile--before--BorderWidth: var(--pf-c-tile--focus--before--BorderWidth);
+    --pf-c-tile--before--BorderColor: var(--pf-c-tile--focus--before--BorderColor);
+}
+
+.provider-icon {
+    width: 1em;
+    height: 1em;
+}

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
@@ -15,7 +15,7 @@ const WizardStepReview = (props) => {
     };
     return (
         <>
-            { (Object.keys(props.uploadErrors).length > 0 ||
+            { (Object.keys(props.uploadAWSErrors).length > 0 ||
                Object.keys(props.subscriptionErrors).length > 0) &&
               <Alert variant="danger" className="pf-u-mb-xl" isInline title="Required information is missing" /> }
             <Title headingLevel="h2" size="xl">Create image</Title>
@@ -25,7 +25,7 @@ const WizardStepReview = (props) => {
                     to create the image using the following criteria.
                 </small>
                 <h3>Image output</h3>
-                <dl>
+                <dl data-testid='review-image-output'>
                     <dt>
                         Release
                     </dt>
@@ -36,14 +36,14 @@ const WizardStepReview = (props) => {
                         Target environment
                     </dt>
                     <dd>
-                        { props.upload && <>{ uploadOptions[props.upload.type] }</> }
+                        { props.uploadAWS && <>{ uploadOptions.aws }</> }
                     </dd>
                 </dl>
-                { Object.entries(props.uploadErrors).length > 0 && (
+                { Object.entries(props.uploadAWSErrors).length > 0 && (
                     <h3>Upload to AWS</h3>
                 )}
                 <dl>
-                    { Object.entries(props.uploadErrors).map(([ key, error ]) => {
+                    { Object.entries(props.uploadAWSErrors).map(([ key, error ]) => {
                         return (<React.Fragment key={ key }>
                             <dt>
                                 { error.label }
@@ -85,10 +85,10 @@ const WizardStepReview = (props) => {
 
 WizardStepReview.propTypes = {
     release: PropTypes.string,
-    upload: PropTypes.object,
+    uploadAWS: PropTypes.object,
     subscription: PropTypes.object,
     subscribeNow: PropTypes.bool,
-    uploadErrors: PropTypes.object,
+    uploadAWSErrors: PropTypes.object,
     subscriptionErrors: PropTypes.object,
 };
 

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepUploadAWS.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepUploadAWS.js
@@ -16,10 +16,11 @@ const WizardStepUploadAWS = (props) => {
             <FormGroup isRequired label="AWS account ID" fieldId="aws-account-id"
                 helperTextInvalid={ (props.errors['aws-account-id'] && props.errors['aws-account-id'].value) || '' }
                 validated={ (props.errors['aws-account-id'] && 'error') || 'default' }>
-                <TextInput value={ props.upload.options.share_with_accounts || '' }
+                <TextInput value={ props.uploadAWS.options.share_with_accounts || '' }
                     type="text" aria-label="AWS account ID" id="aws-account-id"
                     data-testid="aws-account-id" isRequired
-                    onChange={ value => props.setUploadOptions(Object.assign(props.upload.options, { share_with_accounts: [ value ]})) } />
+                    onChange={ value =>
+                        props.setUploadOptions('aws', Object.assign(props.uploadAWS.options, { share_with_accounts: [ value ]})) } />
             </FormGroup>
         </Form>
     );
@@ -27,7 +28,7 @@ const WizardStepUploadAWS = (props) => {
 
 WizardStepUploadAWS.propTypes = {
     setUploadOptions: PropTypes.func,
-    upload: PropTypes.object,
+    uploadAWS: PropTypes.object,
     errors: PropTypes.object,
 };
 

--- a/src/SmartComponents/CreateImageWizard/CreateImageWizard.scss
+++ b/src/SmartComponents/CreateImageWizard/CreateImageWizard.scss
@@ -1,0 +1,3 @@
+.pf-c-wizard__nav-list {
+    padding-right: 0px;   
+}

--- a/src/test/SmartComponents/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/SmartComponents/CreateImageWizard/CreateImageWizard.test.js
@@ -1,7 +1,7 @@
 import '@testing-library/jest-dom';
 
 import React from 'react';
-import { screen, getByText, waitForElementToBeRemoved } from '@testing-library/react';
+import { screen, getByText, waitFor, waitForElementToBeRemoved, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithReduxRouter } from '../../testUtils';
 import CreateImageWizard from '../../../SmartComponents/CreateImageWizard/CreateImageWizard';
@@ -82,8 +82,10 @@ describe('Step Image output', () => {
         // left sidebar navigation
         const sidebar = screen.getByRole('navigation');
         const anchor = getByText(sidebar, 'Image output');
-        screen.getByTestId('upload-destination');
 
+        // select aws as upload destination
+        const awsTile = screen.getByTestId('upload-aws');
+        awsTile.click();
         // load from sidebar
         anchor.click();
     });
@@ -116,9 +118,10 @@ describe('Step Image output', () => {
     });
 
     test('target environment is required', () => {
-        const destination = screen.getByTestId('upload-destination');
+        const destination = screen.getByTestId('target-select');
+        const required = within(destination).getByText('*');
         expect(destination).toBeEnabled();
-        expect(destination).toBeRequired();
+        expect(destination).toContainElement(required);
     });
 });
 
@@ -127,9 +130,13 @@ describe('Step Upload to AWS', () => {
         const { _component, history } = renderWithReduxRouter(<CreateImageWizard />);
         historySpy = jest.spyOn(history, 'push');
 
+        // select aws as upload destination
+        const awsTile = screen.getByTestId('upload-aws');
+        awsTile.click();
+
         // left sidebar navigation
         const sidebar = screen.getByRole('navigation');
-        const anchor = getByText(sidebar, 'Upload to AWS');
+        const anchor = getByText(sidebar, 'Amazon Web Services');
 
         // load from sidebar
         anchor.click();
@@ -166,6 +173,10 @@ describe('Step Registration', () => {
     beforeEach(() => {
         const { _component, history } = renderWithReduxRouter(<CreateImageWizard />);
         historySpy = jest.spyOn(history, 'push');
+
+        // select aws as upload destination
+        const awsTile = screen.getByTestId('upload-aws');
+        awsTile.click();
 
         // left sidebar navigation
         const sidebar = screen.getByRole('navigation');
@@ -236,6 +247,10 @@ describe('Step Review', () => {
         const { _component, history } = renderWithReduxRouter(<CreateImageWizard />);
         historySpy = jest.spyOn(history, 'push');
 
+        // select aws as upload destination
+        const awsTile = screen.getByTestId('upload-aws');
+        awsTile.click();
+
         // left sidebar navigation
         const sidebar = screen.getByRole('navigation');
         const anchor = getByText(sidebar, 'Review');
@@ -274,7 +289,7 @@ describe('Click through all steps', () => {
 
         // select image output
         userEvent.selectOptions(screen.getByTestId('release-select'), [ 'rhel-8' ]);
-        userEvent.selectOptions(screen.getByTestId('upload-destination'), [ 'aws' ]);
+        screen.getByTestId('upload-aws').click();
         next.click();
 
         // select upload target
@@ -290,9 +305,10 @@ describe('Click through all steps', () => {
         next.click();
 
         // review
+        const imageOutput = screen.getByTestId('review-image-output');
         await screen.
             findByText('Review the information and click Create image to create the image using the following criteria.');
-        await screen.findByText('Amazon Web Services');
+        await within(imageOutput).findByText('Amazon Web Services');
         await screen.findByText('Register the system on first boot');
 
         // mock the backend API
@@ -307,7 +323,7 @@ describe('Click through all steps', () => {
 
         // returns back to the landing page
         // but jsdom will not render the new page so we can't assert on that
-        await expect(historySpy).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(historySpy).toHaveBeenCalledTimes(1));
         await expect(historySpy).toHaveBeenCalledWith('/landing');
     });
 
@@ -316,7 +332,7 @@ describe('Click through all steps', () => {
 
         // select release
         userEvent.selectOptions(screen.getByTestId('release-select'), [ 'rhel-8' ]);
-        userEvent.selectOptions(screen.getByTestId('upload-destination'), [ 'aws' ]);
+        screen.getByTestId('upload-aws').click();
         next.click();
 
         // leave AWS account id empty
@@ -330,9 +346,10 @@ describe('Click through all steps', () => {
         userEvent.clear(screen.getByTestId('subscription-activation'));
         next.click();
 
+        const imageOutput = screen.getByTestId('review-image-output');
         await screen.
             findByText('Review the information and click Create image to create the image using the following criteria.');
-        await screen.findByText('Amazon Web Services');
+        await within(imageOutput).findByText('Amazon Web Services');
         await screen.findByText('Register the system on first boot');
 
         const errorMessages = await screen.findAllByText('A value is required');
@@ -348,7 +365,7 @@ describe('Click through all steps', () => {
         // select release
         userEvent.selectOptions(screen.getByTestId('release-select'), [ 'rhel-8' ]);
         // select upload target
-        userEvent.selectOptions(screen.getByTestId('upload-destination'), [ 'aws' ]);
+        screen.getByTestId('upload-aws').click();
         next.click();
 
         userEvent.type(screen.getByTestId('aws-account-id'), 'invalid, isNaN');
@@ -362,9 +379,10 @@ describe('Click through all steps', () => {
         userEvent.clear(screen.getByTestId('subscription-activation'));
         next.click();
 
+        const imageOutput = screen.getByTestId('review-image-output');
         await screen.
             findByText('Review the information and click Create image to create the image using the following criteria.');
-        await screen.findByText('Amazon Web Services');
+        await within(imageOutput).findByText('Amazon Web Services');
         await screen.findByText('Register the system on first boot');
 
         const errorMessages = await screen.findAllByText('A value is required');


### PR DESCRIPTION
The user can now select between multiple upload providers. AWS, Azure, and Google. The selection uses tiles and the user can select one or more destinations. Currently, only aws supports setting the upload parameters.

The icons point to files hosted on cloud.redhat.com.