### PR TITLE
Select packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@babel/runtime": "^7.11.0",
     "@patternfly/patternfly": "^4.87.2",
-    "@patternfly/react-core": "^4.97.1",
+    "@patternfly/react-core": "^4.97.3",
     "@patternfly/react-table": "^4.23.1",
     "@redhat-cloud-services/frontend-components": "^2.4.23",
     "@redhat-cloud-services/frontend-components-utilities": "^2.2.7",

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepPackages.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepPackages.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Button, DualListSelector, Text, TextContent, Title } from '@patternfly/react-core';
+
+const WizardStepPackages = (props) => {
+    const availableOptionsActions = [
+        <Button
+            aria-label="Search button for available packages"
+            key="availableSearchButton"
+            onClick={ props.handlePackagesSearch }>
+            Search
+        </Button>
+    ];
+
+    return (
+        <>
+            <TextContent>
+                <Title headingLevel="h2" size="xl">Additional packages</Title>
+                <Text>Optionally add additional packages to your <strong>{props.release}</strong> image</Text>
+            </TextContent>
+            <DualListSelector
+                className="pf-u-mt-sm"
+                isSearchable
+                availableOptionsActions={ availableOptionsActions }
+                availableOptions={ props.packagesAvailableComponents }
+                chosenOptions={ props.packagesFilteredComponents }
+                addSelected={ props.packageListChange }
+                removeSelected={ props.packageListChange }
+                addAll={ props.packageListChange }
+                removeAll= { props.packageListChange }
+                onAvailableOptionsSearchInputChanged={ props.setPackagesSearchName }
+                onChosenOptionsSearchInputChanged={ props.handlePackagesFilter }
+                filterOption={ () => true }
+                id="basicSelectorWithSearch" />
+        </>
+    );
+};
+
+WizardStepPackages.propTypes = {
+    packageListChange: PropTypes.func,
+    release: PropTypes.string,
+    packagesAvailableComponents: PropTypes.arrayOf(PropTypes.object),
+    packagesFilteredComponents: PropTypes.arrayOf(PropTypes.object),
+    handlePackagesSearch: PropTypes.func,
+    handlePackagesFilter: PropTypes.func,
+    setPackagesSearchName: PropTypes.func,
+};
+
+export default WizardStepPackages;

--- a/src/api.js
+++ b/src/api.js
@@ -17,6 +17,17 @@ async function getComposeStatus(id) {
     return request.data;
 }
 
+async function getPackages(distribution, architecture, search) {
+    const params = new URLSearchParams({
+        distribution,
+        architecture,
+        search,
+    });
+    let path = '/packages?' + params.toString();
+    const request = await axios.get(IMAGE_BUILDER_API.concat(path));
+    return request.data;
+}
+
 async function getVersion() {
     let path = '/version';
     const request = await axios.get(IMAGE_BUILDER_API.concat(path));
@@ -26,5 +37,6 @@ async function getVersion() {
 export default {
     composeImage,
     getComposeStatus,
+    getPackages,
     getVersion,
 };

--- a/src/test/SmartComponents/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/SmartComponents/CreateImageWizard/CreateImageWizard.test.js
@@ -186,11 +186,11 @@ describe('Step Registration', () => {
         anchor.click();
     });
 
-    test('clicking Next loads Review', () => {
+    test('clicking Next loads Packages', () => {
         const [ next, , ] = verifyButtons();
         next.click();
 
-        screen.getByText('Review the information and click Create image to create the image using the following criteria.');
+        screen.getByText('Optionally add additional packages to your image');
     });
 
     test('clicking Back loads Upload to AWS', () => {
@@ -242,6 +242,50 @@ describe('Step Registration', () => {
     });
 });
 
+describe('Step Packages', () => {
+    beforeEach(() => {
+        const { _component, history } = renderWithReduxRouter(<CreateImageWizard />);
+        historySpy = jest.spyOn(history, 'push');
+
+        // left sidebar navigation
+        const sidebar = screen.getByRole('navigation');
+        const anchor = getByText(sidebar, 'Packages');
+
+        // load from sidebar
+        anchor.click();
+    });
+
+    test('clicking Next loads Review', () => {
+        const [ next, , ] = verifyButtons();
+        next.click();
+
+        screen.getByText('Review the information and click Create image to create the image using the following criteria.');
+    });
+
+    test('clicking Back loads Register', () => {
+        const back = screen.getByRole('button', { name: /Back/ });
+        back.click();
+
+        screen.getByText('Register the system');
+    });
+
+    test('clicking Cancel loads landing page', () => {
+        const [ , , cancel ] = verifyButtons();
+        verifyCancelButton(cancel, historySpy);
+    });
+
+    test('should display search bar and button', () => {
+        const search = screen.getByRole('searchbox', { name: 'Available search input' });
+        search.click();
+
+        userEvent.type(search, 'test');
+
+        screen.getByRole('button', {
+            name: 'Search button for available packages'
+        });
+    });
+});
+
 describe('Step Review', () => {
     beforeEach(() => {
         const { _component, history } = renderWithReduxRouter(<CreateImageWizard />);
@@ -265,11 +309,11 @@ describe('Step Review', () => {
         screen.getByRole('button', { name: /Cancel/ });
     });
 
-    test('clicking Back loads Register', () => {
+    test('clicking Back loads Packages', () => {
         const back = screen.getByRole('button', { name: /Back/ });
         back.click();
 
-        screen.getByText('Register the system');
+        screen.getByText('Optionally add additional packages to your image');
     });
 
     test('clicking Cancel loads landing page', () => {
@@ -302,6 +346,10 @@ describe('Click through all steps', () => {
             .click();
         await screen.findByTestId('subscription-activation');
         userEvent.type(screen.getByTestId('subscription-activation'), '1234567890');
+        next.click();
+
+        // packages
+        screen.getByText('Optionally add additional packages to your image');
         next.click();
 
         // review
@@ -346,9 +394,13 @@ describe('Click through all steps', () => {
         userEvent.clear(screen.getByTestId('subscription-activation'));
         next.click();
 
-        const imageOutput = screen.getByTestId('review-image-output');
+        // packages
+        screen.getByText('Optionally add additional packages to your image');
+        next.click();
+
         await screen.
             findByText('Review the information and click Create image to create the image using the following criteria.');
+        const imageOutput = screen.getByTestId('review-image-output');
         await within(imageOutput).findByText('Amazon Web Services');
         await screen.findByText('Register the system on first boot');
 
@@ -379,9 +431,13 @@ describe('Click through all steps', () => {
         userEvent.clear(screen.getByTestId('subscription-activation'));
         next.click();
 
-        const imageOutput = screen.getByTestId('review-image-output');
+        // packages
+        screen.getByText('Optionally add additional packages to your image');
+        next.click();
+
         await screen.
             findByText('Review the information and click Create image to create the image using the following criteria.');
+        const imageOutput = screen.getByTestId('review-image-output');
         await within(imageOutput).findByText('Amazon Web Services');
         await screen.findByText('Register the system on first boot');
 


### PR DESCRIPTION
The additional package selection step is added to the create image wizard. Users can now query for packages and select them from a list. These packages are not yet passed into the blueprint customizations and are just for display. Tests have been updated and added.

Currently, we are missing the empty state strings and the search bar error for too few characters. I will create issues to capture these but we will probably need to rewrite this component using html and patternfly's css classes so I don't think it is feasible before the demo is due.

@Gundersanne @katierik do you think we should alphabetically sort the list of selected packages or leave it in the user selected order?

![packageSelection](https://user-images.githubusercontent.com/11712857/108993610-1d637d80-769b-11eb-9288-ca7953f36a05.png)
