### PR TITLE
CreateImageWizard: add google upload step

### DIFF
--- a/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepImageOutput.js
@@ -56,8 +56,7 @@ const WizardStepImageOutput = (props) => {
                             onClick={ () => props.toggleUploadDestination('google') }
                             isSelected={ props.uploadDestinations.google }
                             isStacked
-                            isDisplayLarge
-                            isDisabled />
+                            isDisplayLarge />
                     </div>
                 </FormGroup>
             </Form>

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
@@ -32,6 +32,50 @@ const WizardStepReview = (props) => {
         </>
     );
 
+    const googleReview = (
+        <>
+            <Text id="destination-header">Google Cloud Platform</Text>
+            <TextList component={ TextListVariants.dl } data-testid='review-image-upload-google'>
+                {props.uploadGoogle.accountType === 'googleAccount' && (
+                    <>
+                        <TextListItem component={ TextListItemVariants.dt }>Google account</TextListItem>
+                        <TextListItem component={ TextListItemVariants.dd }>{props.uploadGoogle.options.share_with_accounts[0] ?
+                            props.uploadGoogle.options.share_with_accounts[0].user || '' :
+                            ''}
+                        </TextListItem>
+                    </>
+                )}
+                {props.uploadGoogle.accountType === 'serviceAccount' && (
+                    <>
+                        <TextListItem component={ TextListItemVariants.dt }>Service account</TextListItem>
+                        <TextListItem component={ TextListItemVariants.dd }>{props.uploadGoogle.options.share_with_accounts[0] ?
+                            props.uploadGoogle.options.share_with_accounts[0].serviceAccount || '' :
+                            ''}
+                        </TextListItem>
+                    </>
+                )}
+                {props.uploadGoogle.accountType === 'googleGroup' && (
+                    <>
+                        <TextListItem component={ TextListItemVariants.dt }>Google group</TextListItem>
+                        <TextListItem component={ TextListItemVariants.dd }>{props.uploadGoogle.options.share_with_accounts[0] ?
+                            props.uploadGoogle.options.share_with_accounts[0].group || '' :
+                            ''}
+                        </TextListItem>
+                    </>
+                )}
+                {props.uploadGoogle.accountType === 'domain' && (
+                    <>
+                        <TextListItem component={ TextListItemVariants.dt }>Domain</TextListItem>
+                        <TextListItem component={ TextListItemVariants.dd }>{props.uploadGoogle.options.share_with_accounts[0] ?
+                            props.uploadGoogle.options.share_with_accounts[0].domain || '' :
+                            ''}
+                        </TextListItem>
+                    </>
+                )}
+            </TextList>
+        </>
+    );
+
     let subscriptionReview = <TextListItem component={ TextListItemVariants.dd }>Register the system later</TextListItem>;
     if (props.subscribeNow) {
         subscriptionReview = (<>
@@ -67,6 +111,7 @@ const WizardStepReview = (props) => {
                 </TextList>
                 <Text component={ TextVariants.h3 }>Target environment</Text>
                 {props.uploadDestinations.aws && awsReview }
+                {props.uploadDestinations.google && googleReview }
                 <Text component={ TextVariants.h3 }>Registration</Text>
                 <TextList component={ TextListVariants.dl } data-testid='review-image-registration'>
                     <TextListItem component={ TextListItemVariants.dt }>Subscription</TextListItem>
@@ -80,6 +125,7 @@ const WizardStepReview = (props) => {
 WizardStepReview.propTypes = {
     release: PropTypes.string,
     uploadAWS: PropTypes.object,
+    uploadGoogle: PropTypes.object,
     uploadDestinations: PropTypes.object,
     subscription: PropTypes.object,
     subscribeNow: PropTypes.bool,

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepUploadGoogle.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepUploadGoogle.js
@@ -1,0 +1,148 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Form, FormGroup, TextList, TextListItem, Popover, Radio, TextContent, Text, TextInput, Title } from '@patternfly/react-core';
+import { HelpIcon } from '@patternfly/react-icons';
+
+const WizardStepUploadGoogle = (props) => {
+    const accountTypePopover = (
+        <Popover
+            hasAutoWidth
+            maxWidth='35rem'
+            headerContent={ 'Valid account types' }
+            bodyContent={ <TextContent>
+                <Text>The following account types can have an image shared with them:</Text>
+                <TextList>
+                    <TextListItem>
+                        <strong>Google account:</strong> A Google account represents a developer, an administrator,
+                        or any other person who interacts with Google Cloud. e.g., <em>`alice@gmail.com`</em>.
+                    </TextListItem>
+                    <TextListItem>
+                        <strong>Service account:</strong> A service account is an account for an application instead
+                        of an individual end user. e.g., <em>`myapp@appspot.gserviceaccount.com`</em>.
+                    </TextListItem>
+                    <TextListItem>
+                        <strong>Google group:</strong> A Google group is a named collection of Google accounts and
+                        and service accounts. e.g., <em>`admins@example.com`</em>.
+                    </TextListItem>
+                    <TextListItem>
+                        <strong>Google workspace domain/Cloud identity domain:</strong> A Google workspace or cloud identity
+                        domain represents a virtual group of all the Google accounts in an organization. These domains
+                        represent your organization&apos;s internet domain name. e.g., <em>`mycompany.com`</em>.
+                    </TextListItem>
+                </TextList>
+            </TextContent> }>
+            <button
+                type="button"
+                aria-label="Account info"
+                aria-describedby="google-account-type"
+                className="pf-c-form__group-label-help">
+                <HelpIcon />
+            </button>
+        </Popover>
+    );
+
+    return (
+        <Form>
+            <Title headingLevel="h2" size="xl">Target Environment - Google Cloud Platform</Title>
+            <p>
+            Your image will be uploaded to an account on Google Cloud Platform. <br />
+            The image will be shared with the email you provide below. <br />
+            Within the next 14 days you will need to copy the shared image to your own account.
+            After 14 days it will be unavailable and will have to be regenerated.
+            </p>
+            <FormGroup isRequired label="Type" labelIcon={ accountTypePopover } fieldId="google-account-type">
+                <Radio
+                    onChange={ props.setGoogleAccountType }
+                    isChecked={ props.uploadGoogle.accountType === 'googleAccount' }
+                    label="Google account"
+                    id="radio-google-account"
+                    test-id
+                    value="googleAccount" />
+                <Radio
+                    onChange={ props.setGoogleAccountType }
+                    isChecked={ props.uploadGoogle.accountType === 'serviceAccount' }
+                    label="Service account"
+                    id="radio-service-account"
+                    value="serviceAccount" />
+                <Radio
+                    onChange={ props.setGoogleAccountType }
+                    isChecked={ props.uploadGoogle.accountType === 'googleGroup' }
+                    label="Google group"
+                    id="radio-google-group"
+                    value="googleGroup" />
+                <Radio
+                    onChange={ props.setGoogleAccountType }
+                    isChecked={ props.uploadGoogle.accountType === 'domain' }
+                    label="Google Workspace Domain or Cloud Identity Domain"
+                    id="radio-domain"
+                    value="domain" />
+            </FormGroup>
+            {props.uploadGoogle.accountType === 'googleAccount' && (
+                <FormGroup isRequired label="Email address" fieldId="user">
+                    <TextInput
+                        value={ props.uploadGoogle.options.share_with_accounts[0] ?
+                            props.uploadGoogle.options.share_with_accounts[0].user || '' :
+                            '' }
+                        type="text" aria-label="Google email address" id="input-google-user"
+                        data-testid="input-google-user" isRequired
+                        onChange={ value => props.setUploadOptions(
+                            'google',
+                            Object.assign(props.uploadGoogle.options, { share_with_accounts: [{ user: value }]})
+                        ) } />
+                </FormGroup>
+            )}
+            {props.uploadGoogle.accountType === 'serviceAccount' && (
+                <FormGroup isRequired label="Email address" fieldId="service-account">
+                    <TextInput
+                        value={ props.uploadGoogle.options.share_with_accounts[0] ?
+                            props.uploadGoogle.options.share_with_accounts[0].serviceAccount || '' :
+                            '' }
+                        type="text" aria-label="Google email address" id="input-google-service-account"
+                        data-testid="input-google-service-account" isRequired
+                        onChange={ value => props.setUploadOptions(
+                            'google',
+                            Object.assign(props.uploadGoogle.options, { share_with_accounts: [{ serviceAccount: value }]})
+                        ) } />
+                </FormGroup>
+            )}
+            {props.uploadGoogle.accountType === 'googleGroup' && (
+                <FormGroup isRequired label="Email address" fieldId="group">
+                    <TextInput
+                        value={ props.uploadGoogle.options.share_with_accounts[0] ?
+                            props.uploadGoogle.options.share_with_accounts[0].group || '' :
+                            '' }
+                        type="text" aria-label="Google email address" id="input-google-group"
+                        data-testid="input-google-group" isRequired
+                        onChange={ value => props.setUploadOptions(
+                            'google',
+                            Object.assign(props.uploadGoogle.options, { share_with_accounts: [{ group: value }]})
+                        ) } />
+                </FormGroup>
+            )}
+            {props.uploadGoogle.accountType === 'domain' && (
+                <FormGroup isRequired label="Domain" fieldId="domain">
+                    <TextInput
+                        value={ props.uploadGoogle.options.share_with_accounts[0] ?
+                            props.uploadGoogle.options.share_with_accounts[0].domain || '' :
+                            '' }
+                        type="text" aria-label="Google domain" id="input-google-domain"
+                        data-testid="input-google-domain" isRequired
+                        onChange={ value => props.setUploadOptions(
+                            'google',
+                            Object.assign(props.uploadGoogle.options, { share_with_accounts: [{ domain: value }]})
+                        ) } />
+                </FormGroup>
+            )}
+        </Form>
+    );
+};
+
+WizardStepUploadGoogle.propTypes = {
+    setUploadOptions: PropTypes.func,
+    setGoogleAccountType: PropTypes.func,
+    uploadGoogle: PropTypes.object,
+    errors: PropTypes.object,
+};
+
+export default WizardStepUploadGoogle;


### PR DESCRIPTION
The user can now specify their authentication settings for Google Cloud Platform.

Tests and validation are still needed for this PR.


![emptyGoogle](https://user-images.githubusercontent.com/11712857/109026546-26b31100-76c0-11eb-9485-9abacc415bc9.png)
![googleDomain](https://user-images.githubusercontent.com/11712857/109026553-29156b00-76c0-11eb-9047-60ca6a854fba.png)
![googlePopover](https://user-images.githubusercontent.com/11712857/109026564-2a469800-76c0-11eb-8167-79609e48dc07.png)


