### PR TITLE
App: Wait for user active session before checking permission

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ class App extends Component {
         super();
 
         this.state = {
-            permission: true,
+            permission: false,
         };
     }
 
@@ -23,14 +23,12 @@ class App extends Component {
         this.appNav = insights.chrome.on('APP_NAVIGATION', event => this.props.history.push(`/${event.navId}`));
         insights.chrome.auth.getUser().then(data => {
             this.setState({ identity: data.identity });
+            api.getVersion().then(() => {
+                this.setState({ permission: true });
+            }).catch(() => {
+                this.setState({ permission: false });
+            });
         });
-
-        api.getVersion().then(() => {
-            this.setState({ permission: true });
-        }).catch(() => {
-            this.setState({ permission: false });
-        });
-
     }
 
     componentWillUnmount () {


### PR DESCRIPTION
This should fix the issue where if you go to the page directly, and are not logged in, you'd get the signup form after logging in even if you were authorized to use the service.

Essentially this waits until there's an active session.




https://user-images.githubusercontent.com/11140201/109670265-3aa0bc00-7b73-11eb-8a8e-c47045536dd0.mp4

