### PR TITLE
ImagesTable: update empty-table message

### DIFF
--- a/src/SmartComponents/ImagesTable/ImagesTable.js
+++ b/src/SmartComponents/ImagesTable/ImagesTable.js
@@ -88,8 +88,10 @@ class ImagesTable extends Component {
                             Create an image
                         </Title>
                         <EmptyStateBody>
-                            Create RHEL OS images for deployment in Amazon Web Services. Images can include
-                            an activation key to automate the registration process.
+                            Create OS images for deployment in Amazon Web Services,
+                            Microsoft Azure and Google Cloud Platform. Images can
+                            include a custom package set and an activation key to
+                            automate the registration process.
                         </EmptyStateBody>
                         <Link to="/imagewizard" className="pf-c-button pf-m-primary" data-testid="create-image-action">
                         Create image


### PR DESCRIPTION
Update the message now that we support CentOS Stream, Azure+GCP support as well as package selection.