### PR TITLE
Validate subscription activation key

### DIFF
--- a/src/PresentationalComponents/CreateImageWizard/ImageWizardFooter.js
+++ b/src/PresentationalComponents/CreateImageWizard/ImageWizardFooter.js
@@ -23,6 +23,10 @@ const ImageWizardFooter = (props) => {
                             nextButtonIsDisabled = true;
                         }
 
+                        if ((activeStep.name === 'Registration'  || activeStep.name === 'Review') && !props.isValidSubscription) {
+                            nextButtonIsDisabled = true;
+                        }
+
                         return (
                             <>
                                 <Button aria-label={ activeStep.name === 'Review' ? 'Create' : 'Next' } variant={ ButtonVariant.primary }
@@ -54,6 +58,7 @@ const ImageWizardFooter = (props) => {
 ImageWizardFooter.propTypes = {
     isValidUploadDestination: PropTypes.bool,
     isSaveInProgress: PropTypes.bool,
+    isValidSubscription: PropTypes.bool,
     error: PropTypes.string,
 };
 

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepRegistration.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepRegistration.js
@@ -18,21 +18,26 @@ const WizardStepRegistration = (props) => {
                     data-testid="register-later-radio-button" />
             </FormGroup>
             { props.subscribeNow &&
-              <>
-                  <FormGroup label="Organization ID" fieldId="subscription-organization">
-                      <TextInput isDisabled value={ props.subscription.organization || '' } type="text"
-                          id="subscription-organization" aria-label="Subscription organization ID"
-                          data-testid="organization-id" />
-                  </FormGroup>
-                  <FormGroup isRequired label="Activation key" fieldId="subscription-activation"
-                      helperTextInvalid={ (props.errors['subscription-activation'] && props.errors['subscription-activation'].value) || '' }
-                      validated={ (props.errors['subscription-activation'] && 'error') || 'default' }>
-                      <TextInput value={ props.subscription['activation-key'] || '' } type="password"
-                          data-testid="subscription-activation" isRequired
-                          id="subscription-activation" aria-label="Subscription activation key"
-                          onChange={ value => props.setSubscription(Object.assign(props.subscription, { 'activation-key': value })) } />
-                  </FormGroup>
-              </> }
+                <>
+                    <FormGroup label="Organization ID" fieldId="subscription-organization">
+                        <TextInput isDisabled value={ props.subscription.organization || '' } type="text"
+                            id="subscription-organization" aria-label="Subscription organization ID"
+                            data-testid="organization-id" />
+                    </FormGroup>
+                    <FormGroup isRequired label="Activation key" fieldId="subscription-activation"
+                        helperTextInvalid={ 'A value is required' }
+                        validated={ !props.isValidSubscription && props.subscription['activation-key'] !== null ? 'error' : 'default' }>
+                        <TextInput
+                            value={ props.subscription['activation-key'] || '' }
+                            type="password"
+                            data-testid="subscription-activation"
+                            id="subscription-activation"
+                            aria-label="Subscription activation key"
+                            onChange={ value => props.setSubscription(Object.assign(props.subscription, { 'activation-key': value })) }
+                            validated={ !props.isValidSubscription && props.subscription['activation-key'] !== null ? 'error' : 'default' }
+                            isRequired />
+                    </FormGroup>
+                </> }
         </Form>
     );
 };
@@ -42,7 +47,7 @@ WizardStepRegistration.propTypes = {
     setSubscribeNow: PropTypes.func,
     subscription: PropTypes.object,
     subscribeNow: PropTypes.bool,
-    errors: PropTypes.object,
+    isValidSubscription: PropTypes.bool,
 };
 
 export default WizardStepRegistration;

--- a/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
+++ b/src/PresentationalComponents/CreateImageWizard/WizardStepReview.js
@@ -81,9 +81,9 @@ const WizardStepReview = (props) => {
         subscriptionReview = (<>
             <TextListItem component={ TextListItemVariants.dd }>Register the system on first boot</TextListItem>
             <TextListItem component={ TextListItemVariants.dt }>Activation key</TextListItem>
-            { props.subscriptionErrors['subscription-activation'] ? (
+            { !props.isValidSubscription || !props.subscription['activation-key'] ? (
                 <TextListItem component={ TextListItemVariants.dd }>
-                    <ExclamationCircleIcon className="error" /> { props.subscriptionErrors['subscription-activation'].value }
+                    <ExclamationCircleIcon className="error" /> { 'A value is required' }
                 </TextListItem>
             ) : (
                 <TextListItem component={ TextListItemVariants.dd } type="password">
@@ -96,7 +96,7 @@ const WizardStepReview = (props) => {
     return (
         <>
             { (Object.keys(props.uploadAWSErrors).length > 0 ||
-               Object.keys(props.subscriptionErrors).length > 0) &&
+               !props.isValidSubscription) &&
               <Alert variant="danger" className="pf-u-mb-xl" isInline title="Required information is missing" /> }
             <Title headingLevel="h2" size="xl">Review</Title>
             <TextContent>
@@ -130,7 +130,7 @@ WizardStepReview.propTypes = {
     subscription: PropTypes.object,
     subscribeNow: PropTypes.bool,
     uploadAWSErrors: PropTypes.object,
-    subscriptionErrors: PropTypes.object,
+    isValidSubscription: PropTypes.bool,
 };
 
 export default WizardStepReview;

--- a/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
+++ b/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
@@ -78,7 +78,7 @@ class CreateImageWizard extends Component {
                 'base-url': 'https://cdn.redhat.com/',
                 insights: true
             },
-            subscribeNow: true,
+            subscribeNow: false,
             /* errors take form of $fieldId: error */
             uploadAWSErrors: {},
             uploadAzureErrors: {},

--- a/src/test/SmartComponents/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/SmartComponents/CreateImageWizard/CreateImageWizard.test.js
@@ -509,11 +509,9 @@ describe('Click through all steps', () => {
             .click();
         await screen.findByTestId('subscription-activation');
         userEvent.clear(screen.getByTestId('subscription-activation'));
-        next.click();
-
-        // packages
-        screen.getByText('Optionally add additional packages to your image');
-        next.click();
+        const sidebar = screen.getByRole('navigation');
+        const reviewStep = getByText(sidebar, 'Review');
+        reviewStep.click();
 
         await screen.
             findByText('Review the information and click Create image to create the image using the following criteria.');
@@ -546,11 +544,9 @@ describe('Click through all steps', () => {
             .click();
         await screen.findByTestId('subscription-activation');
         userEvent.clear(screen.getByTestId('subscription-activation'));
-        next.click();
-
-        // packages
-        screen.getByText('Optionally add additional packages to your image');
-        next.click();
+        const sidebar = screen.getByRole('navigation');
+        const reviewStep = getByText(sidebar, 'Review');
+        reviewStep.click();
 
         await screen.
             findByText('Review the information and click Create image to create the image using the following criteria.');


### PR DESCRIPTION
If register now is selected, an activation key is required. If no activation key is entered the Next and Create buttons are disabled.
Also, if the activation key is empty an error message will appear to prompt the user to enter an activation key.

The subscription errors variable is removed in favor of declaring the error message directly in the registration step component. The validateSubscription function is removed in favor of validating the activation key field on change.

This fixes #114 and is dependent on #112 

![invalidActivationKey](https://user-images.githubusercontent.com/11712857/110807313-30717280-8283-11eb-8260-eec9a49ef06f.png)
