### PR TITLE
Handle all valid image_status.status values

### DIFF
--- a/src/PresentationalComponents/ImagesTable/ImageBuildStatus.js
+++ b/src/PresentationalComponents/ImagesTable/ImageBuildStatus.js
@@ -26,6 +26,7 @@ const ImageBuildStatus = (props) => {
                 text: 'Image build, Upload, Cloud registration pending'
             }
         ],
+        // Keep "running" for backward compatibility
         running: [
             {
                 icon: <Spinner size="md" />,
@@ -34,6 +35,44 @@ const ImageBuildStatus = (props) => {
             {
                 icon: <PendingIcon />,
                 text: 'Upload, Cloud registration pending'
+            }
+        ],
+        building: [
+            {
+                icon: <Spinner size="md" />,
+                text: 'Image build in progress'
+            },
+            {
+                icon: <PendingIcon />,
+                text: 'Upload, Cloud registration pending'
+            }
+        ],
+        uploading: [
+            {
+                icon: <CheckCircleIcon />,
+                text: 'Image build finished'
+            },
+            {
+                icon: <Spinner size="md" />,
+                text: 'Image upload in progress'
+            },
+            {
+                icon: <PendingIcon />,
+                text: 'Cloud registration pending'
+            }
+        ],
+        registering: [
+            {
+                icon: <CheckCircleIcon />,
+                text: 'Image build finished'
+            },
+            {
+                icon: <CheckCircleIcon />,
+                text: 'Image upload finished'
+            },
+            {
+                icon: <Spinner size="md" />,
+                text: 'Cloud registration in progress'
             }
         ]
     };

--- a/src/test/SmartComponents/ImagesTable/ImagesTable.test.js
+++ b/src/test/SmartComponents/ImagesTable/ImagesTable.test.js
@@ -8,12 +8,62 @@ import '@testing-library/jest-dom';
 
 const store = {
     composes: {
+        // kept "running" for backward compatibility
         'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa': {
             image_status: {
                 status: 'running',
+            },
+            distribution: 'fedora-31',
+            architecture: 'x86_64',
+            image_type: 'ami',
+            upload_type: 'aws',
+        },
+        'edbae1c2-62bc-42c1-ae0c-3110ab718f58': {
+            image_status: {
+                status: 'pending',
+            },
+            distribution: 'fedora-31',
+            architecture: 'x86_64',
+            image_type: 'ami',
+            upload_type: 'aws',
+        },
+        '42ad0826-30b5-4f64-a24e-957df26fd564': {
+            image_status: {
+                status: 'building',
+            },
+            distribution: 'fedora-31',
+            architecture: 'x86_64',
+            image_type: 'ami',
+            upload_type: 'aws',
+        },
+        '955944a2-e149-4058-8ac1-35b514cb5a16': {
+            image_status: {
+                status: 'uploading',
+            },
+            distribution: 'fedora-31',
+            architecture: 'x86_64',
+            image_type: 'ami',
+            upload_type: 'aws',
+        },
+        'f7a60094-b376-4b58-a102-5c8c82dfd18b': {
+            image_status: {
+                status: 'registering',
+            },
+            distribution: 'fedora-31',
+            architecture: 'x86_64',
+            image_type: 'ami',
+            upload_type: 'aws',
+        },
+        '1579d95b-8f1d-4982-8c53-8c2afa4ab04c': {
+            image_status: {
+                status: 'success',
                 upload_status: {
-                    type: 'aws',
-                    status: 'success'
+                    options: {
+                        ami: 'ami-0217b81d9be50e44b',
+                        region: 'us-east-1'
+                    },
+                    status: 'success',
+                    type: 'aws'
                 }
             },
             distribution: 'fedora-31',
@@ -24,9 +74,22 @@ const store = {
         '61b0effa-c901-4ee5-86b9-2010b47f1b22': {
             image_status: {
                 status: 'failure',
+            },
+            distribution: 'fedora-31',
+            architecture: 'x86_64',
+            image_type: 'vhd',
+            upload_type: 'gcp',
+        },
+        'ca03f120-9840-4959-871e-94a5cb49d1f2': {
+            image_status: {
+                status: 'success',
                 upload_status: {
-                    type: 'gcp',
-                    status: 'failure'
+                    options: {
+                        image_name: 'composer-api-d446d8cb-7c16-4756-bf7d-706293785b05',
+                        project_id: 'red-hat-image-builder'
+                    },
+                    status: 'success',
+                    type: 'gcp'
                 }
             },
             distribution: 'fedora-31',
@@ -36,10 +99,22 @@ const store = {
         },
         '551de6f6-1533-4b46-a69f-7924051f9bc6': {
             image_status: {
-                status: 'running',
+                status: 'building',
+            },
+            distribution: 'fedora-31',
+            architecture: 'x86_64',
+            image_type: 'vhd',
+            upload_type: 'azure',
+        },
+        '77fa8b03-7efb-4120-9a20-da66d68c4494': {
+            image_status: {
+                status: 'success',
                 upload_status: {
-                    type: 'aws',
-                    status: ''
+                    options: {
+                        image_name: 'composer-api-cc5920c3-5451-4282-aab3-725d3df7f1cb'
+                    },
+                    status: 'success',
+                    type: 'azure'
                 }
             },
             distribution: 'fedora-31',
@@ -65,7 +140,7 @@ describe('Images Table', () => {
 
         // check table
         const table = screen.getByTestId('images-table');
-        expect(table.rows).toHaveLength(4);
+        expect(table.rows).toHaveLength(11);
         for (const row of table.rows) {
             const col1 = row.cells[0].textContent;
             if (col1 === 'Image') // skip header


### PR DESCRIPTION
This is related to:
- https://github.com/osbuild/image-builder/pull/163
- https://github.com/osbuild/osbuild-composer/pull/1319

osbuild-composer and as a result also Image Builder are returning an invalid `image_status.status` value "running" for composes which are in progress.

Extend the front-end to handle all valid `image_status.status` values, specifically also "building", "uploading" and "registering". Also keep support for the invalid value "running" for some time to ensure backward compatibility with older osbuild-composer versions.

Modify test cases in `ImagesTable.test.js` to verify all possible `image_status.status` values. Also modify the `image_status` values used for testing to what is actually returned by osbuild-composer Cloud API and as a result also by Image Builder's API.

@andreasn can you please review this change from the UX point of view?

Reason: as part of handling "uploading" and "registering" `image_status.status` values, I changed what and how many icons are shown as the compose status. The reality is that "uploading" and "registering" statuses are currently never returned by Image Builder or osbuild-composer.

Example:
- When the build completed and the upload is in progress, there are 3 icons (1. Build completed; 2. Upload in progress; 3. Registering pending).
- When the build and upload completed and the registering is in progress, there are 3 icons (1. Build completed; 2. Upload completed; 3. Registering in progress).

Screenshot of how it looks:
![Screenshot from 2021-03-25 12-08-21](https://user-images.githubusercontent.com/3659736/112482931-da1f2c00-8d78-11eb-8966-83441ad5d730.png)


