### PR TITLE
Add documentation links

### DIFF
--- a/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
+++ b/src/SmartComponents/CreateImageWizard/CreateImageWizard.js
@@ -4,7 +4,8 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { actions } from '../../store/actions';
 
-import { Wizard } from '@patternfly/react-core';
+import { Button, Text, Wizard } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 
 import WizardStepImageOutput from './WizardStepImageOutput';
@@ -293,6 +294,20 @@ class CreateImageWizard extends Component {
             <React.Fragment>
                 <Wizard
                     title={ 'Create image' }
+                    description={ <Text>
+                        Create a RHEL image and push it to cloud providers.
+                        {' '}
+                        <Button
+                            component="a"
+                            target="_blank"
+                            variant="link"
+                            icon={ <ExternalLinkAltIcon /> }
+                            iconPosition="right"
+                            isInline
+                            href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8-beta/">
+                                Documentation
+                        </Button>
+                    </Text> }
                     onNext={ this.onStep }
                     onGoToStep={ this.onStep }
                     steps={ steps }

--- a/src/SmartComponents/ImagesTable/ImagesTable.js
+++ b/src/SmartComponents/ImagesTable/ImagesTable.js
@@ -5,8 +5,11 @@ import { actions } from '../../store/actions';
 import { Link } from 'react-router-dom';
 import { Table, TableHeader, TableBody, classNames, Visibility } from '@patternfly/react-table';
 import { TableToolbar } from '@redhat-cloud-services/frontend-components';
-import { ToolbarGroup, ToolbarItem, EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateBody, Title } from '@patternfly/react-core';
-import { PlusCircleIcon } from '@patternfly/react-icons';
+import { Button,
+    ToolbarGroup, ToolbarItem,
+    EmptyState, EmptyStateVariant, EmptyStateIcon, EmptyStateBody, EmptyStateSecondaryActions,
+    Title } from '@patternfly/react-core';
+import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
 import ImageBuildStatus from '../../PresentationalComponents/ImagesTable/ImageBuildStatus';
 import Release from '../../PresentationalComponents/ImagesTable/Release';
@@ -95,6 +98,18 @@ class ImagesTable extends Component {
                         <Link to="/imagewizard" className="pf-c-button pf-m-primary" data-testid="create-image-action">
                         Create image
                         </Link>
+                        <EmptyStateSecondaryActions>
+                            <Button
+                                component="a"
+                                target="_blank"
+                                variant="link"
+                                icon={ <ExternalLinkAltIcon /> }
+                                iconPosition="right"
+                                isInline
+                                href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8-beta/">
+                                    Documentation
+                            </Button>
+                        </EmptyStateSecondaryActions>
                     </EmptyState>
                 ) || (
                     <React.Fragment>

--- a/src/SmartComponents/LandingPage/LandingPage.js
+++ b/src/SmartComponents/LandingPage/LandingPage.js
@@ -3,7 +3,11 @@ import { withRouter } from 'react-router-dom';
 
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components';
 
+import { Button, Popover, TextContent, Text } from '@patternfly/react-core';
+import { ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons';
+
 import ImagesTable from '../ImagesTable/ImagesTable';
+import './LandingPage.scss';
 
 class LandingPage extends Component {
     constructor(props) {
@@ -14,7 +18,32 @@ class LandingPage extends Component {
         return (
             <React.Fragment>
                 <PageHeader>
-                    <PageHeaderTitle title='Images' />
+                    <PageHeaderTitle className="title" title="Image Builder" />
+                    <Popover
+                        headerContent={ 'About Image Builder' }
+                        bodyContent={ <TextContent>
+                            <Text>
+                                        Image Builder is a service that allows you to create RHEL images
+                                        and push them to cloud environments.
+                            </Text>
+                            <Button
+                                component="a"
+                                target="_blank"
+                                variant="link"
+                                icon={ <ExternalLinkAltIcon /> }
+                                iconPosition="right"
+                                isInline
+                                href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8-beta/">
+                                    Documentation
+                            </Button>
+                        </TextContent> }>
+                        <button
+                            type="button"
+                            aria-label="About image builder"
+                            className="pf-c-form__group-label-help">
+                            <HelpIcon />
+                        </button>
+                    </Popover>
                 </PageHeader>
                 <section className="pf-l-page__main-section pf-c-page__main-section">
                     <ImagesTable />

--- a/src/SmartComponents/LandingPage/LandingPage.scss
+++ b/src/SmartComponents/LandingPage/LandingPage.scss
@@ -1,0 +1,11 @@
+.title {
+    display: inline;
+}
+
+.pf-c-form__group-label-help {
+    color: var(--pf-global--icon--Color--light);
+}
+
+.pf-c-form__group-label-help:active {
+    color: var(--pf-global--icon--Color--dark);
+}

--- a/src/test/SmartComponents/LandingPage/LandingPage.test.js
+++ b/src/test/SmartComponents/LandingPage/LandingPage.test.js
@@ -12,7 +12,7 @@ describe('Landing Page', () => {
         const composeImage = jest.spyOn(api, 'getVersion');
         composeImage.mockResolvedValue({ version: '1.0' });
         // check heading
-        screen.getByRole('heading', { name: /images/i });
+        screen.getByRole('heading', { name: /Image Builder/i });
     });
     test('renders EmptyState child component', async () => {
         // check action loads


### PR DESCRIPTION
Links to documentation are added. Some of the styling does not exactly match the mockups but is the default styling for the patternfly components. @katierik any thoughts?
![wizardDocumentation](https://user-images.githubusercontent.com/11712857/115407148-174bd200-a1f0-11eb-8d40-f39309f0762f.png)
![documentationLanding](https://user-images.githubusercontent.com/11712857/115407155-187cff00-a1f0-11eb-9c10-6564600c7778.png)

