### PR TITLE
CreateImageWizard: remove nested p tag

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -4,7 +4,7 @@ import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
 import { actions } from '../../store/actions';
 
-import { Button, Text, Wizard } from '@patternfly/react-core';
+import { Button, Wizard } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 
@@ -294,7 +294,7 @@ class CreateImageWizard extends Component {
             <React.Fragment>
                 <Wizard
                     title={ 'Create image' }
-                    description={ <Text>
+                    description={ <>
                         Create a RHEL image and push it to cloud providers.
                         {' '}
                         <Button
@@ -307,7 +307,7 @@ class CreateImageWizard extends Component {
                             href="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8-beta/">
                                 Documentation
                         </Button>
-                    </Text> }
+                    </> }
                     onNext={ this.onStep }
                     onGoToStep={ this.onStep }
                     steps={ steps }


### PR DESCRIPTION
The patternfly Wizard component's description is wrapped in a p tag. The patternfly Text component also uses a p tag. A p tag should not be nested inside another p tag.