### PR TITLE
README: split frontend and backend instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,50 @@
 # image-builder-frontend
 
-## Development
+## Frontend Development
 
-You can skip step 3 and 4 if you don't need the full stack locally. However
-while it's possible to click around the page and use mock data, it won't be able
-to build images.
+To develop the frontend you can use a proxy to run image-builder-frontend locally
+against the chrome and backend at cloud.redhat.com.
 
-1. Clone the following repositories:
-    * https://github.com/osbuild/image-builder-frontend
-    * https://github.com/osbuild/image-builder
-    * https://github.com/RedHatInsights/insights-proxy
+1. Clone the insights proxy: https://github.com/RedHatInsights/insights-proxy
 
 2. Setting up the proxy
 
     Choose a runner (podman or docker), and point the SPANDX_CONFIG variable to
-    profile/local-frontend-and-api-with-identity.js included in
+    `profile/local-frontend.js` included in image-builder-frontend.
+
+    ```
+        sudo insights-proxy/scripts/patch-etc-hosts.sh
+        export RUNNER="podman"
+        export SPANDX_CONFIG=$PATH_TO/image-builder-frontend/profiles/local-frontend.js
+        sudo -E insights-proxy/scripts/run.sh
+    ```
+
+3. Starting up image-builder-frontend
+
+    In the image-builder-frontend checkout directory
+
+    ```
+        npm install
+        npm start
+    ```
+
+The UI should be running on
+https://prod.foo.redhat.com:1337/apps/image-builder/landing.
+
+
+
+## Backend Development
+
+To develop both the frontend and the backend you can again use the proxy to run both the
+frontend and backend locally against the chrome at cloud.redhat.com. In addition to the
+above:
+
+1. Clone the image-builder (backend) repository: https://github.com/osbuild/image-builder
+
+2. Setting up the proxy
+
+    As before, choose a runner (podman or docker), and point the SPANDX_CONFIG variable to
+    `profile/local-frontend-and-api-with-identity.js` included in
     image-builder-frontend.
 
     ```


### PR DESCRIPTION
Spinning up the frontend is a lot simpler than the backend, so have dedicated
instructions to just do that.