### PR TITLE
ImagesTable: add link to launch uploaded aws image

### DIFF
--- a/src/Components/ImagesTable/ImageLink.js
+++ b/src/Components/ImagesTable/ImageLink.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { Button } from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+const ImageLink = (props) => {
+    const uploadStatus = props.imageStatus ? props.imageStatus.upload_status : undefined;
+    if (uploadStatus && uploadStatus.type === 'aws') {
+        const url = 'https://console.aws.amazon.com/ec2/v2/home?region=' +
+                uploadStatus.options.region +
+                '#LaunchInstanceWizard:ami=' +
+                uploadStatus.options.ami;
+
+        return (
+            <Button
+                component="a"
+                target="_blank"
+                variant="link"
+                icon={ <ExternalLinkAltIcon /> }
+                iconPosition="right"
+                isInline
+                href={ url }>
+                    Launch instance
+            </Button>
+        );
+    }
+
+    return null;
+};
+
+ImageLink.propTypes = {
+    imageStatus: PropTypes.object,
+};
+
+export default ImageLink;

--- a/src/Components/ImagesTable/ImagesTable.js
+++ b/src/Components/ImagesTable/ImagesTable.js
@@ -14,6 +14,7 @@ import { ExternalLinkAltIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import ImageBuildStatus from './ImageBuildStatus';
 import Release from './Release';
 import Upload from './Upload';
+import ImageLink from './ImageLink';
 class ImagesTable extends Component {
     constructor(props) {
         super(props);
@@ -95,6 +96,7 @@ class ImagesTable extends Component {
             'Release',
             'Target',
             'Status',
+            ''
         ];
 
         // the state.page is not an index so must be reduced by 1 get the starting index
@@ -110,6 +112,7 @@ class ImagesTable extends Component {
                     { title: <Release release={ compose.request.distribution } /> },
                     { title: <Upload uploadType={ compose.request.image_requests[0].upload_request.type } /> },
                     { title: <ImageBuildStatus status={ compose.image_status ? compose.image_status.status : '' } /> },
+                    { title: <ImageLink imageStatus={ compose.image_status } /> },
                 ]
             };
         });

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -3,6 +3,7 @@ import { screen, render } from '@testing-library/react';
 import { renderWithReduxRouter } from '../../testUtils';
 import ImagesTable from '../../../Components/ImagesTable/ImagesTable';
 import ImageBuildStatus from '../../../Components/ImagesTable/ImageBuildStatus';
+import ImageLink from '../../../Components/ImagesTable/ImageLink';
 import Upload from '../../../Components/ImagesTable/Upload';
 import '@testing-library/jest-dom';
 
@@ -22,6 +23,34 @@ const store = {
             '77fa8b03-7efb-4120-9a20-da66d68c4494',
         ],
         byId: {
+            '1579d95b-8f1d-4982-8c53-8c2afa4ab04c': {
+                id: '1579d95b-8f1d-4982-8c53-8c2afa4ab04c',
+                created_at: '2021-04-27 12:31:12.794809 +0000 UTC',
+                request: {
+                    distribution: 'rhel-8',
+                    image_requests: [
+                        {
+                            architecture: 'x86_64',
+                            image_type: 'ami',
+                            upload_request: {
+                                type: 'aws',
+                                options: {}
+                            }
+                        }
+                    ],
+                },
+                image_status: {
+                    status: 'success',
+                    upload_status: {
+                        options: {
+                            ami: 'ami-0217b81d9be50e44b',
+                            region: 'us-east-1'
+                        },
+                        status: 'success',
+                        type: 'aws'
+                    }
+                },
+            },
             // kept "running" for backward compatibility
             'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa': {
                 id: 'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa',
@@ -121,34 +150,6 @@ const store = {
                 },
                 image_status: {
                     status: 'registering',
-                },
-            },
-            '1579d95b-8f1d-4982-8c53-8c2afa4ab04c': {
-                id: '1579d95b-8f1d-4982-8c53-8c2afa4ab04c',
-                created_at: '2021-04-27 12:31:12.794809 +0000 UTC',
-                request: {
-                    distribution: 'rhel-8',
-                    image_requests: [
-                        {
-                            architecture: 'x86_64',
-                            image_type: 'ami',
-                            upload_request: {
-                                type: 'aws',
-                                options: {}
-                            }
-                        }
-                    ],
-                },
-                image_status: {
-                    status: 'success',
-                    upload_status: {
-                        options: {
-                            ami: 'ami-0217b81d9be50e44b',
-                            region: 'us-east-1'
-                        },
-                        status: 'success',
-                        type: 'aws'
-                    }
                 },
             },
             '61b0effa-c901-4ee5-86b9-2010b47f1b22': {
@@ -282,6 +283,10 @@ describe('Images Table', () => {
             // render the expected <ImageBuildStatus /> and compare the text content
             render(<ImageBuildStatus status={ compose.image_status.status } />, { container: testElement });
             expect(row.cells[4]).toHaveTextContent(testElement.textContent);
+
+            // render the expected <ImageLink /> and compare the text content for an aws link
+            render(<ImageLink imageStatus={ compose.image_status } />, { container: testElement });
+            expect(row.cells[5]).toHaveTextContent(testElement.textContent);
         }
     });
 });


### PR DESCRIPTION
The images list now contains a link to the ec2 launch wizard for a successfully uploaded aws image.

![launchAWSInstance](https://user-images.githubusercontent.com/11712857/118502810-56573f80-b72a-11eb-95d8-53b7db561c3b.png)
