### PR TITLE
CreateImageWizard: Pass organization as a number

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -122,7 +122,7 @@ class CreateImageWizard extends Component {
             customizations.subscription = {
                 'activation-key': this.props.subscription.activationKey,
                 insights: this.props.subscription.insights,
-                organization: this.props.subscription.organization,
+                organization: Number(this.props.subscription.organization),
                 'server-url': 'subscription.rhsm.redhat.com',
                 'base-url': 'https://cdn.redhat.com/',
             };


### PR DESCRIPTION
This should be changed in the api. But will take some more work. For now
just pass it as a number, that is what the api expects at this point in time.