### PR TITLE
Repositories: fix lint warning react-hooks/exhaustive-deps with adding useCallback hook

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Repositories/Repositories.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/Repositories.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 
 import {
   Alert,
@@ -213,9 +213,10 @@ const Repositories = () => {
     setToggleSelected(id);
   };
 
-  const isRepoSelected = (repoURL: string | undefined) =>
-    selected.includes(repoURL);
-
+  const isRepoSelected = useCallback(
+    (repoURL: string | undefined) => selected.includes(repoURL),
+    [selected]
+  );
   const handlePerPageSelect = (
     _: React.MouseEvent,
     newPerPage: number,
@@ -252,7 +253,7 @@ const Repositories = () => {
         .filter((repo: ApiRepositoryResponseRead) => isRepoSelected(repo.url!))
         .map((repo: ApiRepositoryResponseRead) => repo.url);
     }
-  }, [filterValue, data, toggleSelected]);
+  }, [filterValue, data, toggleSelected, isRepoSelected]);
 
   const handleClearFilter = () => {
     setFilterValue('');


### PR DESCRIPTION
this commit fix the exhaustive-deps by adding the useCallback hook.
after adding the missing dependencies to the useEffect,
I fix this problem that we have  -'The 'initializeRepositories' function makes the
dependencies of useMemo Hook (at line 256) change on every render.'
Move it inside the useMemo callback. Alternatively,
wrap the definition of 'initializeRepositories' in its own useCallback() Hook  react-hooks/exhaustive-deps'
