### PR TITLE
feat(HMS-3341): pass module_hotfixes flag to compose request

### DIFF
--- a/api/schema/contentSources.json
+++ b/api/schema/contentSources.json
@@ -1,6 +1,33 @@
 {
     "components": {
         "schemas": {
+            "api.ContentUnitSearchRequest": {
+                "properties": {
+                    "limit": {
+                        "description": "Maximum number of records to return for the search",
+                        "type": "integer"
+                    },
+                    "search": {
+                        "description": "Search string to search content unit names",
+                        "type": "string"
+                    },
+                    "urls": {
+                        "description": "URLs of repositories to search",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "uuids": {
+                        "description": "List of RepositoryConfig UUIDs to search",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
             "api.Feature": {
                 "properties": {
                     "accessible": {
@@ -62,6 +89,38 @@
                     },
                     "prev": {
                         "description": "Path to previous page of results",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.ListSnapshotByDateRequest": {
+                "properties": {
+                    "date": {
+                        "description": "Exact date to search by.",
+                        "type": "string"
+                    },
+                    "repository_uuids": {
+                        "description": "Repository uuids to find snapshots for",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    }
+                },
+                "type": "object"
+            },
+            "api.ListSnapshotByDateResponse": {
+                "properties": {
+                    "is_after": {
+                        "description": "Is the snapshot after the specified date",
+                        "type": "boolean"
+                    },
+                    "match": {
+                        "$ref": "#/components/schemas/api.SnapshotResponse"
+                    },
+                    "repository_uuid": {
+                        "description": "Repository uuid for associated snapshot",
                         "type": "string"
                     }
                 },
@@ -201,11 +260,96 @@
                 },
                 "type": "object"
             },
+            "api.RepositoryEnvironment": {
+                "properties": {
+                    "description": {
+                        "description": "The environment description",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "The environment ID",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "The environment name",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "description": "Identifier of the environment",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.RepositoryEnvironmentCollectionResponse": {
+                "properties": {
+                    "data": {
+                        "description": "List of environments",
+                        "items": {
+                            "$ref": "#/components/schemas/api.RepositoryEnvironment"
+                        },
+                        "type": "array"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/api.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/api.ResponseMetadata"
+                    }
+                },
+                "type": "object"
+            },
             "api.RepositoryIntrospectRequest": {
                 "properties": {
                     "reset_count": {
                         "description": "Reset the failed introspections count",
                         "type": "boolean"
+                    }
+                },
+                "type": "object"
+            },
+            "api.RepositoryPackageGroup": {
+                "properties": {
+                    "description": {
+                        "description": "The package group description",
+                        "type": "string"
+                    },
+                    "id": {
+                        "description": "The package group ID",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "The package group name",
+                        "type": "string"
+                    },
+                    "packagelist": {
+                        "description": "The list of packages in the package group",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "uuid": {
+                        "description": "Identifier of the package group",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.RepositoryPackageGroupCollectionResponse": {
+                "properties": {
+                    "data": {
+                        "description": "List of package groups",
+                        "items": {
+                            "$ref": "#/components/schemas/api.RepositoryPackageGroup"
+                        },
+                        "type": "array"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/api.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/api.ResponseMetadata"
                     }
                 },
                 "type": "object"
@@ -253,6 +397,10 @@
                     },
                     "metadata_verification": {
                         "description": "Verify packages",
+                        "type": "boolean"
+                    },
+                    "module_hotfixes": {
+                        "description": "Disable modularity filtering on this repository",
                         "type": "boolean"
                     },
                     "name": {
@@ -334,6 +482,10 @@
                     },
                     "metadata_verification": {
                         "description": "Verify packages",
+                        "type": "boolean"
+                    },
+                    "module_hotfixes": {
+                        "description": "Disable modularity filtering on this repository",
                         "type": "boolean"
                     },
                     "name": {
@@ -484,25 +636,31 @@
                 },
                 "type": "object"
             },
-            "api.SearchRpmRequest": {
+            "api.SearchEnvironmentResponse": {
                 "properties": {
-                    "limit": {
-                        "description": "Maximum number of records to return for the search",
-                        "type": "integer"
-                    },
-                    "search": {
-                        "description": "Search string to search rpm names",
+                    "description": {
+                        "description": "Description of the environment found",
                         "type": "string"
                     },
-                    "urls": {
-                        "description": "URLs of repositories to search",
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
+                    "environment_name": {
+                        "description": "Environment found",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.SearchPackageGroupResponse": {
+                "properties": {
+                    "description": {
+                        "description": "Description of the package group found",
+                        "type": "string"
                     },
-                    "uuids": {
-                        "description": "List of RepositoryConfig UUIDs to search",
+                    "package_group_name": {
+                        "description": "Package group found",
+                        "type": "string"
+                    },
+                    "package_list": {
+                        "description": "Package list of the package group found",
                         "items": {
                             "type": "string"
                         },
@@ -572,6 +730,33 @@
                     "repository_path": {
                         "description": "Path to repository snapshot contents",
                         "type": "string"
+                    },
+                    "url": {
+                        "description": "URL to the snapshot's content",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.SnapshotSearchRpmRequest": {
+                "properties": {
+                    "limit": {
+                        "description": "Maximum number of records to return for the search",
+                        "type": "integer"
+                    },
+                    "search": {
+                        "description": "Search string to search rpm names",
+                        "type": "string"
+                    },
+                    "uuids": {
+                        "description": "List of Snapshot UUIDs to search",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "type": "object"
@@ -630,6 +815,89 @@
                     },
                     "uuid": {
                         "description": "UUID of the object",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.TemplateCollectionResponse": {
+                "properties": {
+                    "data": {
+                        "description": "Requested Data",
+                        "items": {
+                            "$ref": "#/components/schemas/api.TemplateResponse"
+                        },
+                        "type": "array"
+                    },
+                    "links": {
+                        "$ref": "#/components/schemas/api.Links"
+                    },
+                    "meta": {
+                        "$ref": "#/components/schemas/api.ResponseMetadata"
+                    }
+                },
+                "type": "object"
+            },
+            "api.TemplateRequest": {
+                "properties": {
+                    "arch": {
+                        "description": "Architecture of the template",
+                        "type": "string"
+                    },
+                    "date": {
+                        "description": "Latest date to include snapshots for",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Description of the template",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name of the template",
+                        "type": "string"
+                    },
+                    "repository_uuids": {
+                        "description": "Repositories to add to the template",
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "version": {
+                        "description": "Version of the template",
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "api.TemplateResponse": {
+                "properties": {
+                    "arch": {
+                        "description": "Architecture of the template",
+                        "type": "string"
+                    },
+                    "date": {
+                        "description": "Latest date to include snapshots for",
+                        "type": "string"
+                    },
+                    "description": {
+                        "description": "Description of the template",
+                        "type": "string"
+                    },
+                    "name": {
+                        "description": "Name of the template",
+                        "type": "string"
+                    },
+                    "org_id": {
+                        "description": "Organization ID of the owner",
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "readOnly": true,
+                        "type": "string"
+                    },
+                    "version": {
+                        "description": "Version of the template",
                         "type": "string"
                     }
                 },
@@ -740,7 +1008,7 @@
     },
     "info": {
         "contact": {},
-        "description": "API of the Content Sources application on [console.redhat.com](https://console.redhat.com)\n",
+        "description": "The API for the repositories of the content sources that you can use to create and manage repositories between third-party applications and the [Red Hat Hybrid Cloud Console](https://console.redhat.com). With these repositories, you can build and deploy images using Image Builder for Cloud, on-Premise, and Edge. You can handle tasks, search for required RPMs, fetch a GPGKey from the URL, and list the features within applications.\n",
         "license": {
             "name": "Apache 2.0",
             "url": "https://www.apache.org/licenses/LICENSE-2.0"
@@ -750,9 +1018,97 @@
     },
     "openapi": "3.0.3",
     "paths": {
+        "/environments/names": {
+            "post": {
+                "description": "This enables users to search for environments in a given list of repositories.",
+                "operationId": "searchEnvironments",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.ContentUnitSearchRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/api.SearchEnvironmentResponse"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Search environments",
+                "tags": [
+                    "repositories",
+                    "environments"
+                ]
+            }
+        },
         "/features/": {
             "get": {
-                "description": "Get features available for the user within their Organization",
+                "description": "Get features enables retrieving information about the features within an application, regardless of their current status (enabled or disabled) and the user's access to them.",
                 "operationId": "listFeatures",
                 "responses": {
                     "200": {
@@ -772,13 +1128,101 @@
                 ]
             }
         },
+        "/package_groups/names": {
+            "post": {
+                "description": "This enables users to search for package groups in a given list of repositories.",
+                "operationId": "searchPackageGroup",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.ContentUnitSearchRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/api.SearchPackageGroupResponse"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Search package groups",
+                "tags": [
+                    "repositories",
+                    "packagegroups"
+                ]
+            }
+        },
         "/popular_repositories/": {
             "get": {
-                "description": "Get popular repositories",
+                "description": "This operation enables retrieving a paginated list of repository suggestions that are commonly used.",
                 "operationId": "listPopularRepositories",
                 "parameters": [
                     {
-                        "description": "Offset into the list of results to return in the response",
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
                         "in": "query",
                         "name": "offset",
                         "schema": {
@@ -786,7 +1230,7 @@
                         }
                     },
                     {
-                        "description": "Limit the number of items returned",
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
@@ -794,7 +1238,7 @@
                         }
                     },
                     {
-                        "description": "Search term for name and url.",
+                        "description": "Term to filter and retrieve items that match the specified search criteria. Search term can include name or URL.",
                         "in": "query",
                         "name": "search",
                         "schema": {
@@ -862,11 +1306,11 @@
         },
         "/public_repositories/": {
             "get": {
-                "description": "Get public repositories.\nA public repository is a defined repository that is available to all accounts for the purposes of searching for rpm names by URL.\nIt does not show up via the normal repositories API.",
+                "description": "Get public repositories.\nThis enables listing a set of pre-created entries that represent a base set of RPMs needed for image building. These repositories are defined and made available to all user accounts, enabling them to perform RPM name searches using URLs as search criteria. These public repositories are not listed by the normal repositories API.\nIt does not show up via the normal repositories API.",
                 "operationId": "listPublicRepositories",
                 "parameters": [
                     {
-                        "description": "Offset into the list of results to return in the response",
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
                         "in": "query",
                         "name": "offset",
                         "schema": {
@@ -874,7 +1318,7 @@
                         }
                     },
                     {
-                        "description": "Limit the number of items returned",
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
@@ -942,11 +1386,11 @@
         },
         "/repositories/": {
             "get": {
-                "description": "list repositories",
+                "description": "This operation enables users to retrieve a list of repositories.",
                 "operationId": "listRepositories",
                 "parameters": [
                     {
-                        "description": "Offset into the list of results to return in the response",
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
                         "in": "query",
                         "name": "offset",
                         "schema": {
@@ -954,7 +1398,7 @@
                         }
                     },
                     {
-                        "description": "Limit the number of items returned",
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
@@ -962,7 +1406,7 @@
                         }
                     },
                     {
-                        "description": "Comma separated list of architecture to optionally filter-on (e.g. 'x86_64,s390x' would return Repositories with x86_64 or s390x only)",
+                        "description": "A comma separated list of release versions to filter on. For example, `1,2` would return repositories with versions 1 or 2 only.",
                         "in": "query",
                         "name": "version",
                         "schema": {
@@ -970,7 +1414,7 @@
                         }
                     },
                     {
-                        "description": "Comma separated list of versions to optionally filter-on  (e.g. '7,8' would return Repositories with versions 7 or 8 only)",
+                        "description": "A comma separated list of architectures or platforms for that you want to retrieve repositories. It controls responses where repositories support multiple architectures or platforms. For example, ‘x86_64,s390x' returns repositories with `x86_64` or `s390x` only.",
                         "in": "query",
                         "name": "arch",
                         "schema": {
@@ -978,7 +1422,7 @@
                         }
                     },
                     {
-                        "description": "Filter by compatible arch (e.g. 'x86_64' would return Repositories with the 'x86_64' arch and Repositories where arch is not set)",
+                        "description": "Filter repositories by supported release version. For example, `1` returns repositories with the version `1` or where version is not set.",
                         "in": "query",
                         "name": "available_for_version",
                         "schema": {
@@ -986,7 +1430,7 @@
                         }
                     },
                     {
-                        "description": "Filter by compatible version (e.g. 7 would return Repositories with the version 7 or where version is not set)",
+                        "description": "Filter repositories by architecture. For example, `x86_64` returns repositories with the version `x86_64` or where architecture is not set.",
                         "in": "query",
                         "name": "available_for_arch",
                         "schema": {
@@ -994,7 +1438,7 @@
                         }
                     },
                     {
-                        "description": "Search term for name and url.",
+                        "description": "Term to filter and retrieve items that match the specified search criteria. Search term can include name or URL.",
                         "in": "query",
                         "name": "search",
                         "schema": {
@@ -1002,7 +1446,7 @@
                         }
                     },
                     {
-                        "description": "Filter repositories by name using an exact match",
+                        "description": "Filter repositories by name.",
                         "in": "query",
                         "name": "name",
                         "schema": {
@@ -1010,7 +1454,7 @@
                         }
                     },
                     {
-                        "description": "Filter repositories by name using an exact match",
+                        "description": "A comma separated list of URLs to control api response.",
                         "in": "query",
                         "name": "url",
                         "schema": {
@@ -1018,7 +1462,15 @@
                         }
                     },
                     {
-                        "description": "Sets the sort order of the results",
+                        "description": "A comma separated list of uuids to control api response.",
+                        "in": "query",
+                        "name": "uuid",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sort the response data based on specific repository parameters. Sort criteria can include `name`, `url`, `status`, and `package_count`.",
                         "in": "query",
                         "name": "sort_by",
                         "schema": {
@@ -1026,7 +1478,7 @@
                         }
                     },
                     {
-                        "description": "Comma separated list of statuses to optionally filter on",
+                        "description": "A comma separated list of statuses to control api response. Statuses can include `pending`, `valid`, `invalid`.",
                         "in": "query",
                         "name": "status",
                         "schema": {
@@ -1034,7 +1486,7 @@
                         }
                     },
                     {
-                        "description": "Comma separated list of origins to filter (red_hat,external)",
+                        "description": "A comma separated list of origins to filter api response. Origins can include `red_hat` and `external`.",
                         "in": "query",
                         "name": "origin",
                         "schema": {
@@ -1108,7 +1560,7 @@
                 ]
             },
             "post": {
-                "description": "create a repository",
+                "description": "This operation enables creating custom repositories based on user preferences.",
                 "operationId": "createRepository",
                 "requestBody": {
                     "content": {
@@ -1200,7 +1652,7 @@
         },
         "/repositories/bulk_create/": {
             "post": {
-                "description": "bulk create repositories",
+                "description": "This enables creating multiple repositories in a single API. If a user encounters any error, none of the repositories will be created. The applicable error message will be returned.",
                 "operationId": "bulkCreateRepositories",
                 "requestBody": {
                     "content": {
@@ -1298,7 +1750,7 @@
         },
         "/repositories/bulk_delete/": {
             "post": {
-                "description": "bulk delete repositories",
+                "description": "This enables deleting multiple repositories.",
                 "operationId": "bulkDeleteRepositories",
                 "requestBody": {
                     "content": {
@@ -1373,12 +1825,90 @@
                 ]
             }
         },
+        "/repositories/snapshots/for_date/": {
+            "post": {
+                "description": "Get nearest snapshot by date for a list of repositories.",
+                "operationId": "listSnapshotsByDate",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.ListSnapshotByDateRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/api.ListSnapshotByDateResponse"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get nearest snapshot by date for a list of repositories.",
+                "tags": [
+                    "snapshots"
+                ]
+            }
+        },
         "/repositories/{uuid}": {
             "delete": {
+                "description": "This enables deleting a specific repository.",
                 "operationId": "deleteRepository",
                 "parameters": [
                     {
-                        "description": "Identifier of the Repository",
+                        "description": "Repository ID.",
                         "in": "path",
                         "name": "uuid",
                         "required": true,
@@ -1438,11 +1968,11 @@
                 ]
             },
             "get": {
-                "description": "Get information about a Repository",
+                "description": "Get repository information.",
                 "operationId": "getRepository",
                 "parameters": [
                     {
-                        "description": "Identifier of the Repository",
+                        "description": "Repository ID.",
                         "in": "path",
                         "name": "uuid",
                         "required": true,
@@ -1509,11 +2039,11 @@
                 ]
             },
             "patch": {
-                "description": "Partially Update a repository",
+                "description": "Partially update a repository.",
                 "operationId": "partialUpdateRepository",
                 "parameters": [
                     {
-                        "description": "Identifier of the Repository",
+                        "description": "Repository ID.",
                         "in": "path",
                         "name": "uuid",
                         "required": true,
@@ -1602,11 +2132,11 @@
                 ]
             },
             "put": {
-                "description": "Fully update a repository",
+                "description": "Update a repository.",
                 "operationId": "fullUpdateRepository",
                 "parameters": [
                     {
-                        "description": "Identifier of the Repository",
+                        "description": "Repository ID.",
                         "in": "path",
                         "name": "uuid",
                         "required": true,
@@ -1695,12 +2225,119 @@
                 ]
             }
         },
+        "/repositories/{uuid}/environments": {
+            "get": {
+                "description": "List environments in a repository.",
+                "operationId": "listRepositoriesEnvironments",
+                "parameters": [
+                    {
+                        "description": "Repository ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Term to filter and retrieve items that match the specified search criteria. Search term can include name.",
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sort the response based on specific repository parameters. Sort criteria can include `id`, `name`, and `description`.",
+                        "in": "query",
+                        "name": "sort_by",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.RepositoryEnvironmentCollectionResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "List Repositories Environments",
+                "tags": [
+                    "repositories",
+                    "environments"
+                ]
+            }
+        },
         "/repositories/{uuid}/introspect/": {
             "post": {
+                "description": "Check for repository updates.",
                 "operationId": "introspect",
                 "parameters": [
                     {
-                        "description": "Identifier of the Repository",
+                        "description": "Repository ID.",
                         "in": "path",
                         "name": "uuid",
                         "required": true,
@@ -1761,13 +2398,13 @@
                 ]
             }
         },
-        "/repositories/{uuid}/rpms": {
+        "/repositories/{uuid}/package_groups": {
             "get": {
-                "description": "list repositories RPMs",
-                "operationId": "listRepositoriesRpms",
+                "description": "List package groups in a repository.",
+                "operationId": "listRepositoriesPackageGroups",
                 "parameters": [
                     {
-                        "description": "Identifier of the Repository",
+                        "description": "Repository ID.",
                         "in": "path",
                         "name": "uuid",
                         "required": true,
@@ -1776,7 +2413,7 @@
                         }
                     },
                     {
-                        "description": "Limit the number of items returned",
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
@@ -1784,7 +2421,7 @@
                         }
                     },
                     {
-                        "description": "Offset into the list of results to return in the response",
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
                         "in": "query",
                         "name": "offset",
                         "schema": {
@@ -1792,7 +2429,7 @@
                         }
                     },
                     {
-                        "description": "Search term for name.",
+                        "description": "Term to filter and retrieve items that match the specified search criteria. Search term can include name.",
                         "in": "query",
                         "name": "search",
                         "schema": {
@@ -1800,7 +2437,113 @@
                         }
                     },
                     {
-                        "description": "Sets the sort order of the results.",
+                        "description": "Sort the response based on specific repository parameters. Sort criteria can include `id`, `name`, `description`, and `package_list`.",
+                        "in": "query",
+                        "name": "sort_by",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.RepositoryPackageGroupCollectionResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "List Repositories Package Groups",
+                "tags": [
+                    "repositories",
+                    "packagegroups"
+                ]
+            }
+        },
+        "/repositories/{uuid}/rpms": {
+            "get": {
+                "description": "List RPMs in a repository.",
+                "operationId": "listRepositoriesRpms",
+                "parameters": [
+                    {
+                        "description": "Repository ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Term to filter and retrieve items that match the specified search criteria. Search term can include name.",
+                        "in": "query",
+                        "name": "search",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sort the response based on specific repository parameters. Sort criteria can include `name`, `url`, `status`, and `package_count`.",
                         "in": "query",
                         "name": "sort_by",
                         "schema": {
@@ -1867,12 +2610,69 @@
                 ]
             }
         },
+        "/repositories/{uuid}/snapshot/": {
+            "post": {
+                "description": "Snapshot a repository if not already snapshotting",
+                "operationId": "createSnapshot",
+                "parameters": [
+                    {
+                        "description": "Repository ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Snapshot was successfully queued"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "snapshot a repository",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
         "/repositories/{uuid}/snapshots/": {
             "get": {
+                "description": "List snapshots of a repository.",
                 "operationId": "listSnapshots",
                 "parameters": [
                     {
-                        "description": "Identifier of the Repository",
+                        "description": "Repository ID.",
                         "in": "path",
                         "name": "uuid",
                         "required": true,
@@ -1939,9 +2739,173 @@
                 ]
             }
         },
+        "/repositories/{uuid}/snapshots/{snapshot_uuid}/config.repo": {
+            "get": {
+                "operationId": "getRepoConfigurationFile",
+                "parameters": [
+                    {
+                        "description": "Identifier of the repository",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Identifier of the snapshot",
+                        "in": "path",
+                        "name": "snapshot_uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get configuration file of a repository",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
+        "/repository_gpg_key/{uuid}": {
+            "get": {
+                "description": "Get the GPG key file for a repository.",
+                "operationId": "getGpgKeyFile",
+                "parameters": [
+                    {
+                        "description": "Repository ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
+                    "500": {
+                        "content": {
+                            "text/plain": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get the GPG key file for a repository",
+                "tags": [
+                    "repositories"
+                ]
+            }
+        },
         "/repository_parameters/": {
             "get": {
-                "description": "get repository parameters (Versions and Architectures)",
+                "description": "List repository parameters.",
                 "operationId": "listRepositoryParameters",
                 "responses": {
                     "200": {
@@ -1983,7 +2947,7 @@
         },
         "/repository_parameters/external_gpg_key": {
             "post": {
-                "description": "Fetch gpgkey from URL",
+                "description": "Fetch a gpgkey from a remote repo.",
                 "operationId": "fetchGpgKey",
                 "responses": {
                     "200": {
@@ -2055,7 +3019,7 @@
         },
         "/repository_parameters/validate/": {
             "post": {
-                "description": "Validate parameters prior to creating a repository, including checking if remote yum metadata is present",
+                "description": "This validates the parameters before creating a repository. It provides a way to ensure the accuracy and validity of the provided parameters, including a check for the presence of remote yum metadata. Users can perform necessary checks before proceeding with the creation of a repository.",
                 "operationId": "validateRepositoryParameters",
                 "requestBody": {
                     "content": {
@@ -2145,13 +3109,13 @@
         },
         "/rpms/names": {
             "post": {
-                "description": "Search RPMs for a given list of repositories as URLs or UUIDs",
+                "description": "This enables users to search for RPMs (Red Hat Package Manager) in a given list of repositories.",
                 "operationId": "searchRpm",
                 "requestBody": {
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/api.SearchRpmRequest"
+                                "$ref": "#/components/schemas/api.ContentUnitSearchRequest"
                             }
                         }
                     },
@@ -2231,13 +3195,101 @@
                 ]
             }
         },
+        "/snapshots/rpms/names": {
+            "post": {
+                "description": "This enables users to search for RPMs (Red Hat Package Manager) in a given list of snapshots.",
+                "operationId": "searchSnapshotRpms",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.SnapshotSearchRpmRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "items": {
+                                        "$ref": "#/components/schemas/api.SearchRpmResponse"
+                                    },
+                                    "type": "array"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Search RPMs within snapshots",
+                "tags": [
+                    "snapshots",
+                    "rpms"
+                ]
+            }
+        },
         "/tasks/": {
             "get": {
-                "description": "list tasks",
+                "description": "Get the list of tasks.",
                 "operationId": "listTasks",
                 "parameters": [
                     {
-                        "description": "Offset into the list of results to return in the response",
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
                         "in": "query",
                         "name": "offset",
                         "schema": {
@@ -2245,7 +3297,7 @@
                         }
                     },
                     {
-                        "description": "Limit the number of items returned",
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
                         "in": "query",
                         "name": "limit",
                         "schema": {
@@ -2253,7 +3305,7 @@
                         }
                     },
                     {
-                        "description": "Filter tasks by status using an exact match",
+                        "description": "A comma separated list of statuses to control response. Statuses can include `running`, `completed`, `failed`.",
                         "in": "query",
                         "name": "status",
                         "schema": {
@@ -2261,7 +3313,7 @@
                         }
                     },
                     {
-                        "description": "Filter tasks by type using an exact match",
+                        "description": "Filter results based on a specific task types. Helps to narrow down the results to a specific type. Task types can be `snapshot` or `introspect`. ",
                         "in": "query",
                         "name": "type",
                         "schema": {
@@ -2269,7 +3321,7 @@
                         }
                     },
                     {
-                        "description": "Filter tasks by associated repository UUID using an exact match",
+                        "description": "A unique identifier of a repository to filter the results.",
                         "in": "query",
                         "name": "repository_uuid",
                         "schema": {
@@ -2337,11 +3389,11 @@
         },
         "/tasks/{uuid}": {
             "get": {
-                "description": "Get information about a Task",
+                "description": "Get information about a specific task.",
                 "operationId": "getTask",
                 "parameters": [
                     {
-                        "description": "Identifier of the Task",
+                        "description": "Task ID.",
                         "in": "path",
                         "name": "uuid",
                         "required": true,
@@ -2405,6 +3457,281 @@
                 "summary": "Get Task",
                 "tags": [
                     "tasks"
+                ]
+            }
+        },
+        "/templates/": {
+            "get": {
+                "description": "This operation enables users to retrieve a list of templates.",
+                "operationId": "listTemplates",
+                "parameters": [
+                    {
+                        "description": "Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`.",
+                        "in": "query",
+                        "name": "offset",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`.",
+                        "in": "query",
+                        "name": "limit",
+                        "schema": {
+                            "type": "integer"
+                        }
+                    },
+                    {
+                        "description": "Filter templates by version.",
+                        "in": "query",
+                        "name": "version",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter templates by architecture.",
+                        "in": "query",
+                        "name": "arch",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Filter templates by name.",
+                        "in": "query",
+                        "name": "name",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Sort the response data based on specific parameters. Sort criteria can include `name`, `arch`, and `version`.",
+                        "in": "query",
+                        "name": "sort_by",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.TemplateCollectionResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "List Templates",
+                "tags": [
+                    "templates"
+                ]
+            },
+            "post": {
+                "description": "This operation enables creating templates based on user preferences.",
+                "operationId": "createTemplate",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/api.TemplateRequest"
+                            }
+                        }
+                    },
+                    "description": "request body",
+                    "required": true,
+                    "x-originalParamName": "body"
+                },
+                "responses": {
+                    "201": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.TemplateResponse"
+                                }
+                            }
+                        },
+                        "description": "Created",
+                        "headers": {
+                            "Location": {
+                                "description": "resource URL",
+                                "schema": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "415": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unsupported Media Type"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Create Template",
+                "tags": [
+                    "templates"
+                ]
+            }
+        },
+        "/templates/{uuid}": {
+            "get": {
+                "description": "Get template information.",
+                "operationId": "getTemplate",
+                "parameters": [
+                    {
+                        "description": "Template ID.",
+                        "in": "path",
+                        "name": "uuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/api.TemplateResponse"
+                                }
+                            }
+                        },
+                        "description": "OK"
+                    },
+                    "400": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Bad Request"
+                    },
+                    "401": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Unauthorized"
+                    },
+                    "404": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/errors.ErrorResponse"
+                                }
+                            }
+                        },
+                        "description": "Internal Server Error"
+                    }
+                },
+                "summary": "Get Template",
+                "tags": [
+                    "templates"
                 ]
             }
         }

--- a/src/Components/CreateImageWizard/formComponents/Repositories.js
+++ b/src/Components/CreateImageWizard/formComponents/Repositories.js
@@ -114,6 +114,10 @@ const convertSchemaToIBPayloadRepo = (repo) => {
     rhsm: false,
     check_gpg: false,
   };
+  // only include the flag if enabled
+  if (repo.module_hotfixes) {
+    imageBuilderRepo.module_hotfixes = repo.module_hotfixes;
+  }
   if (repo.gpg_key) {
     imageBuilderRepo.gpgkey = repo.gpg_key;
     imageBuilderRepo.check_gpg = true;
@@ -131,6 +135,10 @@ const convertSchemaToIBCustomRepo = (repo) => {
     baseurl: [repo.url],
     check_gpg: false,
   };
+  // only include the flag if enabled
+  if (repo.module_hotfixes) {
+    imageBuilderRepo.module_hotfixes = repo.module_hotfixes;
+  }
   if (repo.gpg_key) {
     imageBuilderRepo.gpgkey = [repo.gpg_key];
     imageBuilderRepo.check_gpg = true;

--- a/src/store/contentSourcesApi.ts
+++ b/src/store/contentSourcesApi.ts
@@ -17,6 +17,7 @@ const injectedRtkApi = api.injectEndpoints({
           search: queryArg.search,
           name: queryArg.name,
           url: queryArg.url,
+          uuid: queryArg.uuid,
           sort_by: queryArg.sortBy,
           status: queryArg.status,
           origin: queryArg.origin,
@@ -45,29 +46,31 @@ export { injectedRtkApi as contentSourcesApi };
 export type ListRepositoriesApiResponse =
   /** status 200 OK */ ApiRepositoryCollectionResponseRead;
 export type ListRepositoriesApiArg = {
-  /** Offset into the list of results to return in the response */
+  /** Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`. */
   offset?: number;
-  /** Limit the number of items returned */
+  /** Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`. */
   limit?: number;
-  /** Comma separated list of architecture to optionally filter-on (e.g. 'x86_64,s390x' would return Repositories with x86_64 or s390x only) */
+  /** A comma separated list of release versions to filter on. For example, `1,2` would return repositories with versions 1 or 2 only. */
   version?: string;
-  /** Comma separated list of versions to optionally filter-on  (e.g. '7,8' would return Repositories with versions 7 or 8 only) */
+  /** A comma separated list of architectures or platforms for that you want to retrieve repositories. It controls responses where repositories support multiple architectures or platforms. For example, ‘x86_64,s390x' returns repositories with `x86_64` or `s390x` only. */
   arch?: string;
-  /** Filter by compatible arch (e.g. 'x86_64' would return Repositories with the 'x86_64' arch and Repositories where arch is not set) */
+  /** Filter repositories by supported release version. For example, `1` returns repositories with the version `1` or where version is not set. */
   availableForVersion?: string;
-  /** Filter by compatible version (e.g. 7 would return Repositories with the version 7 or where version is not set) */
+  /** Filter repositories by architecture. For example, `x86_64` returns repositories with the version `x86_64` or where architecture is not set. */
   availableForArch?: string;
-  /** Search term for name and url. */
+  /** Term to filter and retrieve items that match the specified search criteria. Search term can include name or URL. */
   search?: string;
-  /** Filter repositories by name using an exact match */
+  /** Filter repositories by name. */
   name?: string;
-  /** Filter repositories by name using an exact match */
+  /** A comma separated list of URLs to control api response. */
   url?: string;
-  /** Sets the sort order of the results */
+  /** A comma separated list of uuids to control api response. */
+  uuid?: string;
+  /** Sort the response data based on specific repository parameters. Sort criteria can include `name`, `url`, `status`, and `package_count`. */
   sortBy?: string;
-  /** Comma separated list of statuses to optionally filter on */
+  /** A comma separated list of statuses to control api response. Statuses can include `pending`, `valid`, `invalid`. */
   status?: string;
-  /** Comma separated list of origins to filter (red_hat,external) */
+  /** A comma separated list of origins to filter api response. Origins can include `red_hat` and `external`. */
   origin?: string;
   /** content type of a repository to filter on (rpm) */
   contentType?: string;
@@ -75,15 +78,15 @@ export type ListRepositoriesApiArg = {
 export type ListRepositoriesRpmsApiResponse =
   /** status 200 OK */ ApiRepositoryRpmCollectionResponse;
 export type ListRepositoriesRpmsApiArg = {
-  /** Identifier of the Repository */
+  /** Repository ID. */
   uuid: string;
-  /** Limit the number of items returned */
+  /** Number of items to include in response. Use it to control the number of items, particularly when dealing with large datasets. Default value: `100`. */
   limit?: number;
-  /** Offset into the list of results to return in the response */
+  /** Starting point for retrieving a subset of results. Determines how many items to skip from the beginning of the result set. Default value:`0`. */
   offset?: number;
-  /** Search term for name. */
+  /** Term to filter and retrieve items that match the specified search criteria. Search term can include name. */
   search?: string;
-  /** Sets the sort order of the results. */
+  /** Sort the response based on specific repository parameters. Sort criteria can include `name`, `url`, `status`, and `package_count`. */
   sortBy?: string;
 };
 export type ApiSnapshotResponse = {
@@ -103,6 +106,9 @@ export type ApiSnapshotResponse = {
   };
   /** Path to repository snapshot contents */
   repository_path?: string;
+  /** URL to the snapshot's content */
+  url?: string;
+  uuid?: string;
 };
 export type ApiRepositoryResponse = {
   /** Content Type (rpm) of the repository */
@@ -130,6 +136,8 @@ export type ApiRepositoryResponse = {
   last_update_introspection_time?: string;
   /** Verify packages */
   metadata_verification?: boolean;
+  /** Disable modularity filtering on this repository */
+  module_hotfixes?: boolean;
   /** Name of the remote yum repository */
   name?: string;
   /** Origin of the repository */
@@ -171,6 +179,8 @@ export type ApiRepositoryResponseRead = {
   last_update_introspection_time?: string;
   /** Verify packages */
   metadata_verification?: boolean;
+  /** Disable modularity filtering on this repository */
+  module_hotfixes?: boolean;
   /** Name of the remote yum repository */
   name?: string;
   /** Organization ID of the owner */

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1311,6 +1311,7 @@ describe('Click through all steps', () => {
           'http://mirror.stream.centos.org/SIGs/8/kmods/x86_64/packages-main/',
         check_gpg: false,
         rhsm: false,
+        module_hotfixes: true,
       },
     ];
 
@@ -1332,6 +1333,7 @@ describe('Click through all steps', () => {
         check_gpg: false,
         id: '9cf1d45d-aa06-46fe-87ea-121845cc6bbb',
         name: '2lmdtj',
+        module_hotfixes: true,
       },
     ];
 

--- a/src/test/fixtures/composes.ts
+++ b/src/test/fixtures/composes.ts
@@ -1309,6 +1309,17 @@ export const mockComposesRecreateImage = {
               id: '9cf1d45d-aa06-46fe-87ea-121845cc6bbb',
               name: '2lmdtj',
             },
+            {
+              id: 'f087f9ad-dfe6-4627-9d53-447d1a997de5',
+              name: 'nginx stable repo',
+              baseurl: ['http://nginx.org/packages/centos/8/x86_64/'],
+              check_gpg: true,
+              check_repo_gpg: false,
+              gpg_key: [
+                '-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQENBE5OMmIBCAD+FPYKGriGGf7NqwKfWC83cBV01gabgVWQmZbMcFzeW+hMsgxH\nW6iimD0RsfZ9oEbfJCPG0CRSZ7ppq5pKamYs2+EJ8Q2ysOFHHwpGrA2C8zyNAs4I\nQxnZZIbETgcSwFtDun0XiqPwPZgyuXVm9PAbLZRbfBzm8wR/3SWygqZBBLdQk5TE\nfDR+Eny/M1RVR4xClECONF9UBB2ejFdI1LD45APbP2hsN/piFByU1t7yK2gpFyRt\n97WzGHn9MV5/TL7AmRPM4pcr3JacmtCnxXeCZ8nLqedoSuHFuhwyDnlAbu8I16O5\nXRrfzhrHRJFM1JnIiGmzZi6zBvH0ItfyX6ttABEBAAG0KW5naW54IHNpZ25pbmcg\na2V5IDxzaWduaW5nLWtleUBuZ2lueC5jb20+iQE+BBMBAgAoAhsDBgsJCAcDAgYV\nCAIJCgsEFgIDAQIeAQIXgAUCV2K1+AUJGB4fQQAKCRCr9b2Ce9m/YloaB/9XGrol\nkocm7l/tsVjaBQCteXKuwsm4XhCuAQ6YAwA1L1UheGOG/aa2xJvrXE8X32tgcTjr\nKoYoXWcdxaFjlXGTt6jV85qRguUzvMOxxSEM2Dn115etN9piPl0Zz+4rkx8+2vJG\nF+eMlruPXg/zd88NvyLq5gGHEsFRBMVufYmHtNfcp4okC1klWiRIRSdp4QY1wdrN\n1O+/oCTl8Bzy6hcHjLIq3aoumcLxMjtBoclc/5OTioLDwSDfVx7rWyfRhcBzVbwD\noe/PD08AoAA6fxXvWjSxy+dGhEaXoTHjkCbz/l6NxrK3JFyauDgU4K4MytsZ1HDi\nMgMW8hZXxszoICTTiQEcBBABAgAGBQJOTkelAAoJEKZP1bF62zmo79oH/1XDb29S\nYtWp+MTJTPFEwlWRiyRuDXy3wBd/BpwBRIWfWzMs1gnCjNjk0EVBVGa2grvy9Jtx\nJKMd6l/PWXVucSt+U/+GO8rBkw14SdhqxaS2l14v6gyMeUrSbY3XfToGfwHC4sa/\nThn8X4jFaQ2XN5dAIzJGU1s5JA0tjEzUwCnmrKmyMlXZaoQVrmORGjCuH0I0aAFk\nRS0UtnB9HPpxhGVbs24xXZQnZDNbUQeulFxS4uP3OLDBAeCHl+v4t/uotIad8v6J\nSO93vc1evIje6lguE81HHmJn9noxPItvOvSMb2yPsE8mH4cJHRTFNSEhPW6ghmlf\nWa9ZwiVX5igxcvaIRgQQEQIABgUCTk5b0gAKCRDs8OkLLBcgg1G+AKCnacLb/+W6\ncflirUIExgZdUJqoogCeNPVwXiHEIVqithAM1pdY/gcaQZmIRgQQEQIABgUCTk5f\nYQAKCRCpN2E5pSTFPnNWAJ9gUozyiS+9jf2rJvqmJSeWuCgVRwCcCUFhXRCpQO2Y\nVa3l3WuB+rgKjsQ=\n=EWWI\n-----END PGP PUBLIC KEY BLOCK-----',
+              ],
+              module_hotfixes: true,
+            },
           ],
           payload_repositories: [
             {
@@ -1326,6 +1337,17 @@ export const mockComposesRecreateImage = {
               check_repo_gpg: false,
               gpgkey: '',
               rhsm: false,
+            },
+
+            {
+              baseurl: 'http://nginx.org/packages/centos/8/x86_64/',
+              check_gpg: true,
+              check_repo_gpg: false,
+              gpg_key: [
+                '-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQENBE5OMmIBCAD+FPYKGriGGf7NqwKfWC83cBV01gabgVWQmZbMcFzeW+hMsgxH\nW6iimD0RsfZ9oEbfJCPG0CRSZ7ppq5pKamYs2+EJ8Q2ysOFHHwpGrA2C8zyNAs4I\nQxnZZIbETgcSwFtDun0XiqPwPZgyuXVm9PAbLZRbfBzm8wR/3SWygqZBBLdQk5TE\nfDR+Eny/M1RVR4xClECONF9UBB2ejFdI1LD45APbP2hsN/piFByU1t7yK2gpFyRt\n97WzGHn9MV5/TL7AmRPM4pcr3JacmtCnxXeCZ8nLqedoSuHFuhwyDnlAbu8I16O5\nXRrfzhrHRJFM1JnIiGmzZi6zBvH0ItfyX6ttABEBAAG0KW5naW54IHNpZ25pbmcg\na2V5IDxzaWduaW5nLWtleUBuZ2lueC5jb20+iQE+BBMBAgAoAhsDBgsJCAcDAgYV\nCAIJCgsEFgIDAQIeAQIXgAUCV2K1+AUJGB4fQQAKCRCr9b2Ce9m/YloaB/9XGrol\nkocm7l/tsVjaBQCteXKuwsm4XhCuAQ6YAwA1L1UheGOG/aa2xJvrXE8X32tgcTjr\nKoYoXWcdxaFjlXGTt6jV85qRguUzvMOxxSEM2Dn115etN9piPl0Zz+4rkx8+2vJG\nF+eMlruPXg/zd88NvyLq5gGHEsFRBMVufYmHtNfcp4okC1klWiRIRSdp4QY1wdrN\n1O+/oCTl8Bzy6hcHjLIq3aoumcLxMjtBoclc/5OTioLDwSDfVx7rWyfRhcBzVbwD\noe/PD08AoAA6fxXvWjSxy+dGhEaXoTHjkCbz/l6NxrK3JFyauDgU4K4MytsZ1HDi\nMgMW8hZXxszoICTTiQEcBBABAgAGBQJOTkelAAoJEKZP1bF62zmo79oH/1XDb29S\nYtWp+MTJTPFEwlWRiyRuDXy3wBd/BpwBRIWfWzMs1gnCjNjk0EVBVGa2grvy9Jtx\nJKMd6l/PWXVucSt+U/+GO8rBkw14SdhqxaS2l14v6gyMeUrSbY3XfToGfwHC4sa/\nThn8X4jFaQ2XN5dAIzJGU1s5JA0tjEzUwCnmrKmyMlXZaoQVrmORGjCuH0I0aAFk\nRS0UtnB9HPpxhGVbs24xXZQnZDNbUQeulFxS4uP3OLDBAeCHl+v4t/uotIad8v6J\nSO93vc1evIje6lguE81HHmJn9noxPItvOvSMb2yPsE8mH4cJHRTFNSEhPW6ghmlf\nWa9ZwiVX5igxcvaIRgQQEQIABgUCTk5b0gAKCRDs8OkLLBcgg1G+AKCnacLb/+W6\ncflirUIExgZdUJqoogCeNPVwXiHEIVqithAM1pdY/gcaQZmIRgQQEQIABgUCTk5f\nYQAKCRCpN2E5pSTFPnNWAJ9gUozyiS+9jf2rJvqmJSeWuCgVRwCcCUFhXRCpQO2Y\nVa3l3WuB+rgKjsQ=\n=EWWI\n-----END PGP PUBLIC KEY BLOCK-----',
+              ],
+              rhsm: false,
+              module_hotfixes: true,
             },
           ],
         },

--- a/src/test/fixtures/repositories.ts
+++ b/src/test/fixtures/repositories.ts
@@ -74,6 +74,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     gpg_key:
       '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGN9300BEAC1FLODu0cL6saMMHa7yJY1JZUc+jQUI/HdECQrrsTaPXlcc7nM\nykYMMv6amPqbnhH/R5BW2Ano+OMse+PXtUr0NXU4OcvxbnnXkrVBVUf8mXI9DzLZ\njw8KoD+4/s0BuzO78zAJF5uhuyHMAK0ll9v0r92kK45Fas9iZTfRFcqFAzvgjScf\n5jeBnbRs5U3UTz9mtDy802mk357o1A8BD0qlu3kANDpjLbORGWdAj21A6sMJDYXy\nHS9FBNV54daNcr+weky2L9gaF2yFjeu2rSEHCSfkbWfpSiVUx/bDTj7XS6XDOuJT\nJqvGS8jHqjHAIFBirhCA4cY/jLKxWyMr5N6IbXpPAYgt8/YYz2aOYVvdyB8tZ1u1\nkVsMYSGcvTBexZCn1cDkbO6I+waIlsc0uxGqUGBKF83AVYCQqOkBjF1uNnu9qefE\nkEc9obr4JZsAgnisboU25ss5ZJddKlmFMKSi66g4S5ChLEPFq7MB06PhLFioaD3L\nEXza7XitoW5VBwr0BSVKAHMC0T2xbm70zY06a6gQRlvr9a10lPmv4Tptc7xgQReg\nu1TlFPbrkGJ0d8O6vHQRAd3zdsNaVr4gX0Tg7UYiqT9ZUkP7hOc8PYXQ28hHrHTB\nA63MTq0aiPlJ/ivTuX8M6+Bi25dIV6N6IOUi/NQKIYxgovJCDSdCAAM0fQARAQAB\ntCFMdWNhcyBHYXJmaWVsZCA8bHVjYXNAcmVkaGF0LmNvbT6JAlcEEwEIAEEWIQTO\nQZeiHnXqdjmfUURc6PeuecS2PAUCY33fTQIbAwUJA8JnAAULCQgHAgIiAgYVCgkI\nCwIEFgIDAQIeBwIXgAAKCRBc6PeuecS2PCk3D/9jW7xrBB/2MQFKd5l+mNMFyKwc\nL9M/M5RFI9GaQRo55CwnPb0nnxOJR1V5GzZ/YGii53H2ose65CfBOE2L/F/RvKF0\nH9S9MInixlahzzKtV3TpDoZGk5oZIHEMuPmPS4XaHggolrzExY0ib0mQuBBE/uEV\n/HlyHEunBKPhTkAe+6Q+2dl22SUuVfWr4Uzlp65+DkdN3M37WI1a3Suhnef3rOSM\nV6puUzWRR7qcYs5C2In87AcYPn92P5ur1y/C32r8Ftg3fRWnEzI9QfRG52ojNOLK\nyGQ8ZC9PGe0q7VFcF7ridT/uzRU+NVKldbJg+rvBnszb1MjNuR7rUQHyvGmbsUVQ\nRCsgdovkee3lP4gfZHzk2SSLVSo0+NJRNaM90EmPk14Pgi/yfRSDGBVvLBbEanYI\nv1ZtdIPRyKi+/IaMOu/l7nayM/8RzghdU+0f1FAif5qf9nXuI13P8fqcqfu67gNd\nkh0UUF1XyR5UHHEZQQDqCuKEkZJ/+27jYlsG1ZiLb1odlIWoR44RP6k5OJl0raZb\nyLXbAfpITsXiJJBpCam9P9+XR5VSfgkqp5hIa7J8piN3DoMpoExg4PPQr6PbLAJy\nOUCOnuB7yYVbj0wYuMXTuyrcBHh/UymQnS8AMpQoEkCLWS/A/Hze/pD23LgiBoLY\nXIn5A2EOAf7t2IMSlA==\n=OanT\n-----END PGP PUBLIC KEY BLOCK-----',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'ae39f556-6986-478a-95d1-f9c7e33d066c',
@@ -92,6 +93,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     gpg_key:
       '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGN9300BEAC1FLODu0cL6saMMHa7yJY1JZUc+jQUI/HdECQrrsTaPXlcc7nM\nykYMMv6amPqbnhH/R5BW2Ano+OMse+PXtUr0NXU4OcvxbnnXkrVBVUf8mXI9DzLZ\njw8KoD+4/s0BuzO78zAJF5uhuyHMAK0ll9v0r92kK45Fas9iZTfRFcqFAzvgjScf\n5jeBnbRs5U3UTz9mtDy802mk357o1A8BD0qlu3kANDpjLbORGWdAj21A6sMJDYXy\nHS9FBNV54daNcr+weky2L9gaF2yFjeu2rSEHCSfkbWfpSiVUx/bDTj7XS6XDOuJT\nJqvGS8jHqjHAIFBirhCA4cY/jLKxWyMr5N6IbXpPAYgt8/YYz2aOYVvdyB8tZ1u1\nkVsMYSGcvTBexZCn1cDkbO6I+waIlsc0uxGqUGBKF83AVYCQqOkBjF1uNnu9qefE\nkEc9obr4JZsAgnisboU25ss5ZJddKlmFMKSi66g4S5ChLEPFq7MB06PhLFioaD3L\nEXza7XitoW5VBwr0BSVKAHMC0T2xbm70zY06a6gQRlvr9a10lPmv4Tptc7xgQReg\nu1TlFPbrkGJ0d8O6vHQRAd3zdsNaVr4gX0Tg7UYiqT9ZUkP7hOc8PYXQ28hHrHTB\nA63MTq0aiPlJ/ivTuX8M6+Bi25dIV6N6IOUi/NQKIYxgovJCDSdCAAM0fQARAQAB\ntCFMdWNhcyBHYXJmaWVsZCA8bHVjYXNAcmVkaGF0LmNvbT6JAlcEEwEIAEEWIQTO\nQZeiHnXqdjmfUURc6PeuecS2PAUCY33fTQIbAwUJA8JnAAULCQgHAgIiAgYVCgkI\nCwIEFgIDAQIeBwIXgAAKCRBc6PeuecS2PCk3D/9jW7xrBB/2MQFKd5l+mNMFyKwc\nL9M/M5RFI9GaQRo55CwnPb0nnxOJR1V5GzZ/YGii53H2ose65CfBOE2L/F/RvKF0\nH9S9MInixlahzzKtV3TpDoZGk5oZIHEMuPmPS4XaHggolrzExY0ib0mQuBBE/uEV\n/HlyHEunBKPhTkAe+6Q+2dl22SUuVfWr4Uzlp65+DkdN3M37WI1a3Suhnef3rOSM\nV6puUzWRR7qcYs5C2In87AcYPn92P5ur1y/C32r8Ftg3fRWnEzI9QfRG52ojNOLK\nyGQ8ZC9PGe0q7VFcF7ridT/uzRU+NVKldbJg+rvBnszb1MjNuR7rUQHyvGmbsUVQ\nRCsgdovkee3lP4gfZHzk2SSLVSo0+NJRNaM90EmPk14Pgi/yfRSDGBVvLBbEanYI\nv1ZtdIPRyKi+/IaMOu/l7nayM/8RzghdU+0f1FAif5qf9nXuI13P8fqcqfu67gNd\nkh0UUF1XyR5UHHEZQQDqCuKEkZJ/+27jYlsG1ZiLb1odlIWoR44RP6k5OJl0raZb\nyLXbAfpITsXiJJBpCam9P9+XR5VSfgkqp5hIa7J8piN3DoMpoExg4PPQr6PbLAJy\nOUCOnuB7yYVbj0wYuMXTuyrcBHh/UymQnS8AMpQoEkCLWS/A/Hze/pD23LgiBoLY\nXIn5A2EOAf7t2IMSlA==\n=OanT\n-----END PGP PUBLIC KEY BLOCK-----',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'ae39f556-6986-478a-95d1-f9c7e33d066c',
@@ -110,6 +112,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     gpg_key:
       '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGN9300BEAC1FLODu0cL6saMMHa7yJY1JZUc+jQUI/HdECQrrsTaPXlcc7nM\nykYMMv6amPqbnhH/R5BW2Ano+OMse+PXtUr0NXU4OcvxbnnXkrVBVUf8mXI9DzLZ\njw8KoD+4/s0BuzO78zAJF5uhuyHMAK0ll9v0r92kK45Fas9iZTfRFcqFAzvgjScf\n5jeBnbRs5U3UTz9mtDy802mk357o1A8BD0qlu3kANDpjLbORGWdAj21A6sMJDYXy\nHS9FBNV54daNcr+weky2L9gaF2yFjeu2rSEHCSfkbWfpSiVUx/bDTj7XS6XDOuJT\nJqvGS8jHqjHAIFBirhCA4cY/jLKxWyMr5N6IbXpPAYgt8/YYz2aOYVvdyB8tZ1u1\nkVsMYSGcvTBexZCn1cDkbO6I+waIlsc0uxGqUGBKF83AVYCQqOkBjF1uNnu9qefE\nkEc9obr4JZsAgnisboU25ss5ZJddKlmFMKSi66g4S5ChLEPFq7MB06PhLFioaD3L\nEXza7XitoW5VBwr0BSVKAHMC0T2xbm70zY06a6gQRlvr9a10lPmv4Tptc7xgQReg\nu1TlFPbrkGJ0d8O6vHQRAd3zdsNaVr4gX0Tg7UYiqT9ZUkP7hOc8PYXQ28hHrHTB\nA63MTq0aiPlJ/ivTuX8M6+Bi25dIV6N6IOUi/NQKIYxgovJCDSdCAAM0fQARAQAB\ntCFMdWNhcyBHYXJmaWVsZCA8bHVjYXNAcmVkaGF0LmNvbT6JAlcEEwEIAEEWIQTO\nQZeiHnXqdjmfUURc6PeuecS2PAUCY33fTQIbAwUJA8JnAAULCQgHAgIiAgYVCgkI\nCwIEFgIDAQIeBwIXgAAKCRBc6PeuecS2PCk3D/9jW7xrBB/2MQFKd5l+mNMFyKwc\nL9M/M5RFI9GaQRo55CwnPb0nnxOJR1V5GzZ/YGii53H2ose65CfBOE2L/F/RvKF0\nH9S9MInixlahzzKtV3TpDoZGk5oZIHEMuPmPS4XaHggolrzExY0ib0mQuBBE/uEV\n/HlyHEunBKPhTkAe+6Q+2dl22SUuVfWr4Uzlp65+DkdN3M37WI1a3Suhnef3rOSM\nV6puUzWRR7qcYs5C2In87AcYPn92P5ur1y/C32r8Ftg3fRWnEzI9QfRG52ojNOLK\nyGQ8ZC9PGe0q7VFcF7ridT/uzRU+NVKldbJg+rvBnszb1MjNuR7rUQHyvGmbsUVQ\nRCsgdovkee3lP4gfZHzk2SSLVSo0+NJRNaM90EmPk14Pgi/yfRSDGBVvLBbEanYI\nv1ZtdIPRyKi+/IaMOu/l7nayM/8RzghdU+0f1FAif5qf9nXuI13P8fqcqfu67gNd\nkh0UUF1XyR5UHHEZQQDqCuKEkZJ/+27jYlsG1ZiLb1odlIWoR44RP6k5OJl0raZb\nyLXbAfpITsXiJJBpCam9P9+XR5VSfgkqp5hIa7J8piN3DoMpoExg4PPQr6PbLAJy\nOUCOnuB7yYVbj0wYuMXTuyrcBHh/UymQnS8AMpQoEkCLWS/A/Hze/pD23LgiBoLY\nXIn5A2EOAf7t2IMSlA==\n=OanT\n-----END PGP PUBLIC KEY BLOCK-----',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'd4b6d3db-bd15-4750-98c0-667f42995566',
@@ -128,6 +131,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     gpg_key:
       '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGN9300BEAC1FLODu0cL6saMMHa7yJY1JZUc+jQUI/HdECQrrsTaPXlcc7nM\nykYMMv6amPqbnhH/R5BW2Ano+OMse+PXtUr0NXU4OcvxbnnXkrVBVUf8mXI9DzLZ\njw8KoD+4/s0BuzO78zAJF5uhuyHMAK0ll9v0r92kK45Fas9iZTfRFcqFAzvgjScf\n5jeBnbRs5U3UTz9mtDy802mk357o1A8BD0qlu3kANDpjLbORGWdAj21A6sMJDYXy\nHS9FBNV54daNcr+weky2L9gaF2yFjeu2rSEHCSfkbWfpSiVUx/bDTj7XS6XDOuJT\nJqvGS8jHqjHAIFBirhCA4cY/jLKxWyMr5N6IbXpPAYgt8/YYz2aOYVvdyB8tZ1u1\nkVsMYSGcvTBexZCn1cDkbO6I+waIlsc0uxGqUGBKF83AVYCQqOkBjF1uNnu9qefE\nkEc9obr4JZsAgnisboU25ss5ZJddKlmFMKSi66g4S5ChLEPFq7MB06PhLFioaD3L\nEXza7XitoW5VBwr0BSVKAHMC0T2xbm70zY06a6gQRlvr9a10lPmv4Tptc7xgQReg\nu1TlFPbrkGJ0d8O6vHQRAd3zdsNaVr4gX0Tg7UYiqT9ZUkP7hOc8PYXQ28hHrHTB\nA63MTq0aiPlJ/ivTuX8M6+Bi25dIV6N6IOUi/NQKIYxgovJCDSdCAAM0fQARAQAB\ntCFMdWNhcyBHYXJmaWVsZCA8bHVjYXNAcmVkaGF0LmNvbT6JAlcEEwEIAEEWIQTO\nQZeiHnXqdjmfUURc6PeuecS2PAUCY33fTQIbAwUJA8JnAAULCQgHAgIiAgYVCgkI\nCwIEFgIDAQIeBwIXgAAKCRBc6PeuecS2PCk3D/9jW7xrBB/2MQFKd5l+mNMFyKwc\nL9M/M5RFI9GaQRo55CwnPb0nnxOJR1V5GzZ/YGii53H2ose65CfBOE2L/F/RvKF0\nH9S9MInixlahzzKtV3TpDoZGk5oZIHEMuPmPS4XaHggolrzExY0ib0mQuBBE/uEV\n/HlyHEunBKPhTkAe+6Q+2dl22SUuVfWr4Uzlp65+DkdN3M37WI1a3Suhnef3rOSM\nV6puUzWRR7qcYs5C2In87AcYPn92P5ur1y/C32r8Ftg3fRWnEzI9QfRG52ojNOLK\nyGQ8ZC9PGe0q7VFcF7ridT/uzRU+NVKldbJg+rvBnszb1MjNuR7rUQHyvGmbsUVQ\nRCsgdovkee3lP4gfZHzk2SSLVSo0+NJRNaM90EmPk14Pgi/yfRSDGBVvLBbEanYI\nv1ZtdIPRyKi+/IaMOu/l7nayM/8RzghdU+0f1FAif5qf9nXuI13P8fqcqfu67gNd\nkh0UUF1XyR5UHHEZQQDqCuKEkZJ/+27jYlsG1ZiLb1odlIWoR44RP6k5OJl0raZb\nyLXbAfpITsXiJJBpCam9P9+XR5VSfgkqp5hIa7J8piN3DoMpoExg4PPQr6PbLAJy\nOUCOnuB7yYVbj0wYuMXTuyrcBHh/UymQnS8AMpQoEkCLWS/A/Hze/pD23LgiBoLY\nXIn5A2EOAf7t2IMSlA==\n=OanT\n-----END PGP PUBLIC KEY BLOCK-----',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '81091684-4708-11ee-be56-0242ac120002',
@@ -146,6 +150,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     gpg_key:
       '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGN9300BEAC1FLODu0cL6saMMHa7yJY1JZUc+jQUI/HdECQrrsTaPXlcc7nM\nykYMMv6amPqbnhH/R5BW2Ano+OMse+PXtUr0NXU4OcvxbnnXkrVBVUf8mXI9DzLZ\njw8KoD+4/s0BuzO78zAJF5uhuyHMAK0ll9v0r92kK45Fas9iZTfRFcqFAzvgjScf\n5jeBnbRs5U3UTz9mtDy802mk357o1A8BD0qlu3kANDpjLbORGWdAj21A6sMJDYXy\nHS9FBNV54daNcr+weky2L9gaF2yFjeu2rSEHCSfkbWfpSiVUx/bDTj7XS6XDOuJT\nJqvGS8jHqjHAIFBirhCA4cY/jLKxWyMr5N6IbXpPAYgt8/YYz2aOYVvdyB8tZ1u1\nkVsMYSGcvTBexZCn1cDkbO6I+waIlsc0uxGqUGBKF83AVYCQqOkBjF1uNnu9qefE\nkEc9obr4JZsAgnisboU25ss5ZJddKlmFMKSi66g4S5ChLEPFq7MB06PhLFioaD3L\nEXza7XitoW5VBwr0BSVKAHMC0T2xbm70zY06a6gQRlvr9a10lPmv4Tptc7xgQReg\nu1TlFPbrkGJ0d8O6vHQRAd3zdsNaVr4gX0Tg7UYiqT9ZUkP7hOc8PYXQ28hHrHTB\nA63MTq0aiPlJ/ivTuX8M6+Bi25dIV6N6IOUi/NQKIYxgovJCDSdCAAM0fQARAQAB\ntCFMdWNhcyBHYXJmaWVsZCA8bHVjYXNAcmVkaGF0LmNvbT6JAlcEEwEIAEEWIQTO\nQZeiHnXqdjmfUURc6PeuecS2PAUCY33fTQIbAwUJA8JnAAULCQgHAgIiAgYVCgkI\nCwIEFgIDAQIeBwIXgAAKCRBc6PeuecS2PCk3D/9jW7xrBB/2MQFKd5l+mNMFyKwc\nL9M/M5RFI9GaQRo55CwnPb0nnxOJR1V5GzZ/YGii53H2ose65CfBOE2L/F/RvKF0\nH9S9MInixlahzzKtV3TpDoZGk5oZIHEMuPmPS4XaHggolrzExY0ib0mQuBBE/uEV\n/HlyHEunBKPhTkAe+6Q+2dl22SUuVfWr4Uzlp65+DkdN3M37WI1a3Suhnef3rOSM\nV6puUzWRR7qcYs5C2In87AcYPn92P5ur1y/C32r8Ftg3fRWnEzI9QfRG52ojNOLK\nyGQ8ZC9PGe0q7VFcF7ridT/uzRU+NVKldbJg+rvBnszb1MjNuR7rUQHyvGmbsUVQ\nRCsgdovkee3lP4gfZHzk2SSLVSo0+NJRNaM90EmPk14Pgi/yfRSDGBVvLBbEanYI\nv1ZtdIPRyKi+/IaMOu/l7nayM/8RzghdU+0f1FAif5qf9nXuI13P8fqcqfu67gNd\nkh0UUF1XyR5UHHEZQQDqCuKEkZJ/+27jYlsG1ZiLb1odlIWoR44RP6k5OJl0raZb\nyLXbAfpITsXiJJBpCam9P9+XR5VSfgkqp5hIa7J8piN3DoMpoExg4PPQr6PbLAJy\nOUCOnuB7yYVbj0wYuMXTuyrcBHh/UymQnS8AMpQoEkCLWS/A/Hze/pD23LgiBoLY\nXIn5A2EOAf7t2IMSlA==\n=OanT\n-----END PGP PUBLIC KEY BLOCK-----',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '9cf1d45d-aa06-46fe-87ea-121845cc6bbb',
@@ -163,6 +168,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: true,
   },
   {
     uuid: '828e7db8-c0d4-48fc-a887-9070e0e75c45',
@@ -180,6 +186,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'ffe90892-6e6c-43c0-a284-df78977d8e37',
@@ -197,6 +204,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '744000a5-fde5-481d-a1ae-07f27e7f4db9',
@@ -214,6 +222,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '45068247-67b9-4f6d-8f19-1718ab56586e',
@@ -231,6 +240,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '60887c35-ce7a-4abc-8c57-1cb8a596f63d',
@@ -248,6 +258,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'f033a5af-ae00-4c26-8bb9-7329d4f17180',
@@ -265,6 +276,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'be0fd64b-b7d0-48f1-b671-4c74b93a42d2',
@@ -282,6 +294,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'bf5270e6-0559-469b-a4bd-9c881f603813',
@@ -300,6 +313,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Invalid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '31ae1b1c-0a14-46df-a6d4-4170f88abeee',
@@ -317,6 +331,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'ea375230-32f7-490d-82b6-501f0a8c2932',
@@ -334,6 +349,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'aa9506b1-e5dd-42be-b5b0-a674f4db915f',
@@ -351,6 +367,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '3cce24d2-41e2-481d-8f01-2b043c72fd6f',
@@ -368,6 +385,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'c988934a-87e2-482f-b887-d9ba677a037a',
@@ -385,6 +403,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'bbc2bba5-9d7d-4726-b96f-a48408e130b5',
@@ -402,6 +421,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '593a973b-715f-4867-ae9c-fa791b59b92d',
@@ -419,6 +439,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'd08a74ef-589b-486f-aae0-60c6abe25768',
@@ -436,6 +457,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '0a12a77d-c3fa-4cd7-958b-ecbec1fd1494',
@@ -453,6 +475,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: '5288c386-274c-4598-8f09-0e2f65346e0d',
@@ -470,6 +493,7 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
   },
   {
     uuid: 'f087f9ad-dfe6-4627-9d53-336c09886cd4',
@@ -487,6 +511,26 @@ const testingRepos: ApiRepositoryResponseRead[] = [
     status: 'Valid',
     gpg_key: '',
     metadata_verification: false,
+    module_hotfixes: false,
+  },
+  {
+    uuid: 'f087f9ad-dfe6-4627-9d53-447d1a997de5',
+    name: 'nginx stable repo',
+    url: 'http://nginx.org/packages/centos/8/x86_64/',
+    distribution_versions: ['8'],
+    distribution_arch: 'x86_64',
+    account_id: '6416440',
+    org_id: '13476545',
+    last_introspection_time: '2022-11-23T08:00:22Z',
+    last_success_introspection_time: '2022-11-23T08:00:22Z',
+    last_update_introspection_time: '2022-10-10T16:00:18Z',
+    last_introspection_error: '',
+    package_count: 25,
+    status: 'Valid',
+    gpg_key:
+      '-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v2.0.22 (GNU/Linux)\n\nmQENBE5OMmIBCAD+FPYKGriGGf7NqwKfWC83cBV01gabgVWQmZbMcFzeW+hMsgxH\nW6iimD0RsfZ9oEbfJCPG0CRSZ7ppq5pKamYs2+EJ8Q2ysOFHHwpGrA2C8zyNAs4I\nQxnZZIbETgcSwFtDun0XiqPwPZgyuXVm9PAbLZRbfBzm8wR/3SWygqZBBLdQk5TE\nfDR+Eny/M1RVR4xClECONF9UBB2ejFdI1LD45APbP2hsN/piFByU1t7yK2gpFyRt\n97WzGHn9MV5/TL7AmRPM4pcr3JacmtCnxXeCZ8nLqedoSuHFuhwyDnlAbu8I16O5\nXRrfzhrHRJFM1JnIiGmzZi6zBvH0ItfyX6ttABEBAAG0KW5naW54IHNpZ25pbmcg\na2V5IDxzaWduaW5nLWtleUBuZ2lueC5jb20+iQE+BBMBAgAoAhsDBgsJCAcDAgYV\nCAIJCgsEFgIDAQIeAQIXgAUCV2K1+AUJGB4fQQAKCRCr9b2Ce9m/YloaB/9XGrol\nkocm7l/tsVjaBQCteXKuwsm4XhCuAQ6YAwA1L1UheGOG/aa2xJvrXE8X32tgcTjr\nKoYoXWcdxaFjlXGTt6jV85qRguUzvMOxxSEM2Dn115etN9piPl0Zz+4rkx8+2vJG\nF+eMlruPXg/zd88NvyLq5gGHEsFRBMVufYmHtNfcp4okC1klWiRIRSdp4QY1wdrN\n1O+/oCTl8Bzy6hcHjLIq3aoumcLxMjtBoclc/5OTioLDwSDfVx7rWyfRhcBzVbwD\noe/PD08AoAA6fxXvWjSxy+dGhEaXoTHjkCbz/l6NxrK3JFyauDgU4K4MytsZ1HDi\nMgMW8hZXxszoICTTiQEcBBABAgAGBQJOTkelAAoJEKZP1bF62zmo79oH/1XDb29S\nYtWp+MTJTPFEwlWRiyRuDXy3wBd/BpwBRIWfWzMs1gnCjNjk0EVBVGa2grvy9Jtx\nJKMd6l/PWXVucSt+U/+GO8rBkw14SdhqxaS2l14v6gyMeUrSbY3XfToGfwHC4sa/\nThn8X4jFaQ2XN5dAIzJGU1s5JA0tjEzUwCnmrKmyMlXZaoQVrmORGjCuH0I0aAFk\nRS0UtnB9HPpxhGVbs24xXZQnZDNbUQeulFxS4uP3OLDBAeCHl+v4t/uotIad8v6J\nSO93vc1evIje6lguE81HHmJn9noxPItvOvSMb2yPsE8mH4cJHRTFNSEhPW6ghmlf\nWa9ZwiVX5igxcvaIRgQQEQIABgUCTk5b0gAKCRDs8OkLLBcgg1G+AKCnacLb/+W6\ncflirUIExgZdUJqoogCeNPVwXiHEIVqithAM1pdY/gcaQZmIRgQQEQIABgUCTk5f\nYQAKCRCpN2E5pSTFPnNWAJ9gUozyiS+9jf2rJvqmJSeWuCgVRwCcCUFhXRCpQO2Y\nVa3l3WuB+rgKjsQ=\n=EWWI\n-----END PGP PUBLIC KEY BLOCK-----',
+    metadata_verification: false,
+    module_hotfixes: true,
   },
 ];
 
@@ -530,6 +574,7 @@ const generateFillerRepos = (num: number): ApiRepositoryResponse[] => {
       status: 'Valid',
       gpg_key: '',
       metadata_verification: false,
+      module_hotfixes: false,
     };
   });
   return repos;


### PR DESCRIPTION
Content sources now support module_hotfixes flag, which is also supported by image-builder API (https://github.com/osbuild/image-builder/pull/928).
This passes this flag from ContentSources to the Compose request, to adhere to what user had set in Content sources. 

This flag allows for disabling unwanted modularity filtering.