### PR TITLE
Wizard: Remove aspect ratio for chart

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ReleaseLifecycle.tsx
+++ b/src/Components/CreateImageWizard/formComponents/ReleaseLifecycle.tsx
@@ -82,8 +82,7 @@ export const chartMajorVersionCfg = {
       },
     },
     responsive: true,
-    maintainAspectRatio: true,
-    aspectRatio: 1 | 5,
+    maintainAspectRatio: false,
     plugins: {
       tooltip: {
         enabled: false,


### PR DESCRIPTION
This removes the aspect ratio for chart and sets `maintainAspectRatio` to false.

The aspect ratio was causing problems with the annotation plugin, rendering the currentDate annotation line in a wrong place for some windows sizes.