### PR TITLE
README: Link to osbuild-getting-started

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ we're planning on using.
 
 To develop both the frontend and the backend you can again use the proxy to run both the
 frontend and backend locally against the chrome at cloud.redhat.com. For instructions
-see [devel/README.md](devel/README.md).
+see the [osbuild-getting-started project](https://github.com/osbuild/osbuild-getting-started).
 
 ## File Structure
 


### PR DESCRIPTION
Let's save our contributors a hop and not link to the (deprecated) devel/README.md anymore, which is only a placeholder pointing to osubild-getting-started. Let's instead direct folks there in the first place.

This will also unblock periodically pulling the frontend docs into the developer guide: https://github.com/osbuild/osbuild.github.io/pull/40
I'd rather not fix the broken link there by pulling in an empty page.