### PR TITLE
Blueprints: Add blueprint editing

### DIFF
--- a/api/config/imageBuilder.ts
+++ b/api/config/imageBuilder.ts
@@ -24,6 +24,7 @@ const config: ConfigFile = {
     'getBlueprints',
     'getBlueprintComposes',
     'deleteBlueprint',
+    'getBlueprint',
   ],
 };
 

--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -16,7 +16,7 @@ import PackagesStep from './steps/Packages';
 import RegistrationStep from './steps/Registration';
 import RepositoriesStep from './steps/Repositories';
 import ReviewStep from './steps/Review';
-import ReviewWizardFooter from './steps/Review/Footer';
+import ReviewWizardFooter from './steps/Review/Footer/Footer';
 import Aws from './steps/TargetEnvironment/Aws';
 import Azure from './steps/TargetEnvironment/Azure';
 import Gcp from './steps/TargetEnvironment/Gcp';
@@ -85,7 +85,11 @@ export const CustomWizardFooter = ({
   );
 };
 
-const CreateImageWizard = () => {
+type CreateImageWizardProps = {
+  startStepIndex?: number;
+};
+
+const CreateImageWizard = ({ startStepIndex = 1 }: CreateImageWizardProps) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
 
@@ -136,7 +140,11 @@ const CreateImageWizard = () => {
     <>
       <ImageBuilderHeader />
       <section className="pf-l-page__main-section pf-c-page__main-section">
-        <Wizard onClose={() => navigate(resolveRelPath(''))} isVisitRequired>
+        <Wizard
+          startIndex={startStepIndex}
+          onClose={() => navigate(resolveRelPath(''))}
+          isVisitRequired
+        >
           <WizardStep
             name="Image output"
             id="step-image-output"

--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -37,7 +37,7 @@ import {
   selectActivationKey,
   selectAwsAccountId,
   selectAwsShareMethod,
-  selectAwsSource,
+  selectAwsSourceId,
   selectAzureResourceGroup,
   selectAzureShareMethod,
   selectAzureSource,
@@ -110,7 +110,7 @@ const CreateImageWizard = ({ startStepIndex = 1 }: CreateImageWizardProps) => {
   // AWS
   const awsShareMethod = useAppSelector((state) => selectAwsShareMethod(state));
   const awsAccountId = useAppSelector((state) => selectAwsAccountId(state));
-  const awsSourceId = useAppSelector((state) => selectAwsSource(state));
+  const awsSourceId = useAppSelector((state) => selectAwsSourceId(state));
   // GCP
   const gcpShareMethod = useAppSelector((state) => selectGcpShareMethod(state));
   const gcpEmail = useAppSelector((state) => selectGcpEmail(state));

--- a/src/Components/CreateImageWizardV2/EditImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/EditImageWizard.tsx
@@ -1,0 +1,42 @@
+import React, { useEffect } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import CreateImageWizard from './CreateImageWizard';
+import { mapRequestToState } from './utilities/requestMapper';
+
+import { useAppDispatch } from '../../store/hooks';
+import { useGetBlueprintQuery } from '../../store/imageBuilderApi';
+import { loadWizardState, initializeWizard } from '../../store/wizardSlice';
+import { resolveRelPath } from '../../Utilities/path';
+
+type EditImageWizardProps = {
+  blueprintId: string;
+};
+
+const EditImageWizard = ({ blueprintId }: EditImageWizardProps) => {
+  const dispatch = useAppDispatch();
+  const navigate = useNavigate();
+
+  const { data: blueprintDetails, error } = useGetBlueprintQuery({
+    id: blueprintId,
+  });
+  useEffect(() => {
+    if (blueprintId && blueprintDetails) {
+      const editBlueprintState = mapRequestToState(blueprintDetails);
+      dispatch(loadWizardState(editBlueprintState));
+    } else {
+      dispatch(initializeWizard());
+    }
+  }, [blueprintId, blueprintDetails, dispatch]);
+  useEffect(() => {
+    // redirect to the main page if the composeId is invalid
+
+    if (error) {
+      navigate(resolveRelPath(''));
+    }
+  }, [error, navigate]);
+  return <CreateImageWizard startStepIndex={12} />;
+};
+
+export default EditImageWizard;

--- a/src/Components/CreateImageWizardV2/index.js
+++ b/src/Components/CreateImageWizardV2/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { useParams } from 'react-router-dom';
+
+import CreateImageWizard from './CreateImageWizard';
+import EditImageWizard from './EditImageWizard';
+
+const ImageWizard = () => {
+  const { composeId } = useParams();
+  return composeId ? (
+    <EditImageWizard blueprintId={composeId} />
+  ) : (
+    <CreateImageWizard />
+  );
+};
+export default ImageWizard;

--- a/src/Components/CreateImageWizardV2/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/Footer/CreateDropdown.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+
+import { DropdownList, DropdownItem } from '@patternfly/react-core';
+
+import {
+  CreateBlueprintRequest,
+  useComposeBlueprintMutation,
+  useCreateBlueprintMutation,
+} from '../../../../../store/imageBuilderApi';
+
+type CreateDropdownProps = {
+  getBlueprintPayload: () => Promise<'' | CreateBlueprintRequest | undefined>;
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+const CreateDropdown = ({
+  getBlueprintPayload,
+  setIsOpen,
+}: CreateDropdownProps) => {
+  const [buildBlueprint] = useComposeBlueprintMutation();
+  const [createBlueprint] = useCreateBlueprintMutation({
+    fixedCacheKey: 'createBlueprintKey',
+  });
+
+  const onSave = async () => {
+    const requestBody = await getBlueprintPayload();
+    setIsOpen(false);
+    requestBody && createBlueprint({ createBlueprintRequest: requestBody });
+  };
+
+  const onSaveAndBuild = async () => {
+    const requestBody = await getBlueprintPayload();
+    setIsOpen(false);
+    const blueprint =
+      requestBody &&
+      (await createBlueprint({
+        createBlueprintRequest: requestBody,
+      }).unwrap()); // unwrap - access the success payload immediately after a mutation
+    blueprint && buildBlueprint({ id: blueprint.id });
+  };
+
+  return (
+    <DropdownList>
+      <DropdownItem onClick={onSave} ouiaId="wizard-create-save-btn">
+        Save changes
+      </DropdownItem>
+      <DropdownItem onClick={onSaveAndBuild} ouiaId="wizard-create-build-btn">
+        Save and build images
+      </DropdownItem>
+    </DropdownList>
+  );
+};
+
+export default CreateDropdown;

--- a/src/Components/CreateImageWizardV2/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/Footer/EditDropdown.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { DropdownList, DropdownItem } from '@patternfly/react-core';
+
+import {
+  CreateBlueprintRequest,
+  useComposeBlueprintMutation,
+  useUpdateBlueprintMutation,
+} from '../../../../../store/imageBuilderApi';
+
+type CreateDropdownProps = {
+  getBlueprintPayload: () => Promise<'' | CreateBlueprintRequest | undefined>;
+  setIsOpen: (isOpen: boolean) => void;
+  blueprintId: string;
+};
+
+const EditDropdown = ({
+  getBlueprintPayload,
+  setIsOpen,
+  blueprintId,
+}: CreateDropdownProps) => {
+  const [buildBlueprint] = useComposeBlueprintMutation();
+  const [updateBlueprint] = useUpdateBlueprintMutation({
+    fixedCacheKey: 'updateBlueprintKey',
+  });
+
+  const onSave = async () => {
+    const requestBody = await getBlueprintPayload();
+    setIsOpen(false);
+    requestBody &&
+      updateBlueprint({ id: blueprintId, createBlueprintRequest: requestBody });
+  };
+
+  const onSaveAndBuild = async () => {
+    const requestBody = await getBlueprintPayload();
+    setIsOpen(false);
+    requestBody &&
+      (await updateBlueprint({
+        id: blueprintId,
+        createBlueprintRequest: requestBody,
+      }));
+    buildBlueprint({ id: blueprintId });
+  };
+
+  return (
+    <DropdownList>
+      <DropdownItem onClick={onSave} ouiaId="wizard-edit-save-btn">
+        Save changes
+      </DropdownItem>
+      <DropdownItem onClick={onSaveAndBuild} ouiaId="wizard-edit-build-btn">
+        Save and build images
+      </DropdownItem>
+    </DropdownList>
+  );
+};
+
+export default EditDropdown;

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
@@ -195,9 +195,9 @@ export const TargetEnvGCPList = () => {
               <TextListItem component={TextListItemVariants.dd}>
                 {accountType === 'group'
                   ? 'Google group'
-                  : accountType === 'service'
+                  : accountType === 'serviceAccount'
                   ? 'Service account'
-                  : accountType === 'google'
+                  : accountType === 'user'
                   ? 'Google account'
                   : 'Domain'}
               </TextListItem>

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
@@ -35,12 +35,12 @@ import {
   selectArchitecture,
   selectAwsAccountId,
   selectAwsShareMethod,
-  selectAwsSource,
   selectAzureShareMethod,
   selectAzureSource,
   selectAzureResourceGroup,
   selectAzureSubscriptionId,
   selectAzureTenantId,
+  selectAwsSourceId,
   selectBlueprintDescription,
   selectBlueprintName,
   selectCustomRepositories,
@@ -116,7 +116,17 @@ export const TargetEnvAWSList = () => {
   });
   const awsAccountId = useAppSelector((state) => selectAwsAccountId(state));
   const awsShareMethod = useAppSelector((state) => selectAwsShareMethod(state));
-  const source = useAppSelector((state) => selectAwsSource(state));
+  const sourceId = useAppSelector((state) => selectAwsSourceId(state));
+  const { source } = useGetSourceListQuery(
+    {
+      provider: 'aws',
+    },
+    {
+      selectFromResult: ({ data }) => ({
+        source: data?.data?.find((source) => source.id === sourceId),
+      }),
+    }
+  );
 
   return (
     <TextContent>

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsAccountId.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsAccountId.tsx
@@ -12,18 +12,18 @@ import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import { useGetSourceUploadInfoQuery } from '../../../../../store/provisioningApi';
 import {
   changeAwsAccountId,
-  selectAwsSource,
+  selectAwsSourceId,
 } from '../../../../../store/wizardSlice';
 
 export const AwsAccountId = () => {
   const dispatch = useAppDispatch();
-  const source = useAppSelector((state) => selectAwsSource(state));
+  const sourceId = useAppSelector((state) => selectAwsSourceId(state));
 
   const { data, isError } = useGetSourceUploadInfoQuery(
     {
-      id: parseInt(source?.id as string),
+      id: parseInt(sourceId as string),
     },
-    { skip: source === undefined }
+    { skip: sourceId === undefined || sourceId === '' }
   );
 
   useEffect(() => {
@@ -37,7 +37,7 @@ export const AwsAccountId = () => {
           readOnlyVariant="default"
           isRequired
           id="aws-account-id"
-          value={source && data ? data.aws?.account_id : ''}
+          value={sourceId && data ? data.aws?.account_id : ''}
           aria-label="aws account id"
         />
       </FormGroup>

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsSourcesSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsSourcesSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 
 import { Alert, Spinner } from '@patternfly/react-core';
 import { FormGroup } from '@patternfly/react-core';
@@ -26,6 +26,14 @@ export const AwsSourcesSelect = () => {
     });
 
   const sources = data?.data;
+
+  useEffect(() => {
+    // when the source is already initialized by id (i.e editing / import)
+    if (sources && sources.length > 0) {
+      if (source?.id && !!source?.name)
+        dispatch(changeAwsSource(sources.find((s) => s.id === source.id)));
+    }
+  }, [sources, source, dispatch]);
 
   const handleSelect = (
     _event: React.MouseEvent<Element, MouseEvent>,

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsSourcesSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsSourcesSelect.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState } from 'react';
 
 import { Alert, Spinner } from '@patternfly/react-core';
 import { FormGroup } from '@patternfly/react-core';
@@ -11,14 +11,14 @@ import {
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import { useGetSourceListQuery } from '../../../../../store/provisioningApi';
 import {
-  changeAwsSource,
-  selectAwsSource,
+  changeAwsSourceId,
+  selectAwsSourceId,
 } from '../../../../../store/wizardSlice';
 
 export const AwsSourcesSelect = () => {
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
-  const source = useAppSelector((state) => selectAwsSource(state));
+  const sourceId = useAppSelector((state) => selectAwsSourceId(state));
 
   const { data, isFetching, isLoading, isSuccess, isError, refetch } =
     useGetSourceListQuery({
@@ -26,26 +26,19 @@ export const AwsSourcesSelect = () => {
     });
 
   const sources = data?.data;
-
-  useEffect(() => {
-    // when the source is already initialized by id (i.e editing / import)
-    if (sources && sources.length > 0) {
-      if (source?.id && !!source?.name)
-        dispatch(changeAwsSource(sources.find((s) => s.id === source.id)));
-    }
-  }, [sources, source, dispatch]);
+  const chosenSource = sources?.find((source) => source.id === sourceId);
 
   const handleSelect = (
     _event: React.MouseEvent<Element, MouseEvent>,
     value: string
   ) => {
     const source = sources?.find((source) => source.name === value);
-    dispatch(changeAwsSource(source));
+    dispatch(changeAwsSourceId(source?.id));
     setIsOpen(false);
   };
 
   const handleClear = () => {
-    dispatch(changeAwsSource(undefined));
+    dispatch(changeAwsSourceId(undefined));
   };
 
   const handleToggle = () => {
@@ -80,7 +73,7 @@ export const AwsSourcesSelect = () => {
           onToggle={handleToggle}
           onSelect={handleSelect}
           onClear={handleClear}
-          selections={source?.name}
+          selections={chosenSource?.name}
           isOpen={isOpen}
           placeholderText="Select source"
           typeAheadAriaLabel="Select source"

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/index.tsx
@@ -22,7 +22,7 @@ import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   changeAwsAccountId,
   changeAwsShareMethod,
-  changeAwsSource,
+  changeAwsSourceId,
   selectAwsAccountId,
   selectAwsShareMethod,
 } from '../../../../../store/wizardSlice';
@@ -73,7 +73,7 @@ const Aws = () => {
           description="Use a configured sources to launch environments directly from the console."
           isChecked={shareMethod === 'sources'}
           onChange={() => {
-            dispatch(changeAwsSource(undefined));
+            dispatch(changeAwsSourceId(undefined));
             dispatch(changeAwsAccountId(''));
             dispatch(changeAwsShareMethod('sources'));
           }}
@@ -85,7 +85,7 @@ const Aws = () => {
           name="radio-8"
           isChecked={shareMethod === 'manual'}
           onChange={() => {
-            dispatch(changeAwsSource(undefined));
+            dispatch(changeAwsSourceId(undefined));
             dispatch(changeAwsAccountId(''));
             dispatch(changeAwsShareMethod('manual'));
           }}

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Gcp/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Gcp/index.tsx
@@ -16,8 +16,8 @@ import { isGcpEmailValid } from '../../../validators';
 
 export type GcpShareMethod = 'withGoogle' | 'withInsights';
 export type GcpAccountType =
-  | 'google'
-  | 'service'
+  | 'user'
+  | 'serviceAccount'
   | 'group'
   | 'domain'
   | undefined;
@@ -85,9 +85,9 @@ const Gcp = () => {
               data-testid="google-account"
               label="Google account"
               name="radio-3"
-              isChecked={accountType === 'google'}
+              isChecked={accountType === 'user'}
               onChange={() => {
-                dispatch(changeGcpAccountType('google'));
+                dispatch(changeGcpAccountType('user'));
               }}
             />
             <Radio
@@ -95,9 +95,9 @@ const Gcp = () => {
               data-testid="service-account"
               label="Service account"
               name="radio-4"
-              isChecked={accountType === 'service'}
+              isChecked={accountType === 'serviceAccount'}
               onChange={() => {
-                dispatch(changeGcpAccountType('service'));
+                dispatch(changeGcpAccountType('serviceAccount'));
               }}
             />
             <Radio

--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -4,6 +4,7 @@ import { RootState } from '../../../store';
 import {
   AwsUploadRequestOptions,
   AzureUploadRequestOptions,
+  BlueprintResponse,
   CreateBlueprintRequest,
   Customizations,
   GcpUploadRequestOptions,
@@ -36,7 +37,9 @@ import {
   selectPayloadRepositories,
   selectRegistrationType,
   selectServerUrl,
+  wizardState,
 } from '../../../store/wizardSlice';
+import { GcpAccountType } from '../steps/TargetEnvironment/Gcp';
 
 /**
  * This function maps the wizard state to a valid CreateBlueprint request object
@@ -57,6 +60,93 @@ export const mapRequestFromState = (
     distribution: selectDistribution(state),
     image_requests: imageRequests,
     customizations,
+  };
+};
+
+/**
+ * This function maps the blueprint response to the wizard state, used to populate the wizard with the blueprint details
+ * @param request BlueprintResponse
+ * @param source  V1ListSourceResponseItem
+ * @returns wizardState
+ */
+export const mapRequestToState = (request: BlueprintResponse): wizardState => {
+  const gcp = request.image_requests.find(
+    (image) => image.image_type === 'gcp'
+  );
+  const aws = request.image_requests.find(
+    (image) => image.image_type === 'aws'
+  );
+
+  const azure = request.image_requests.find(
+    (image) => image.image_type === 'azure'
+  );
+
+  const awsUploadOptions = aws?.upload_request
+    .options as AwsUploadRequestOptions;
+  const gcpUploadOptions = gcp?.upload_request
+    .options as GcpUploadRequestOptions;
+  const azureUploadOptions = azure?.upload_request
+    .options as AzureUploadRequestOptions;
+
+  return {
+    details: {
+      blueprintName: request.name,
+      blueprintDescription: request.description,
+    },
+    env: {
+      serverUrl: request.customizations.subscription?.['server-url'] || '',
+      baseUrl: request.customizations.subscription?.['base-url'] || '',
+    },
+    // TODO: add openscap support
+    openScap: {
+      profile: undefined,
+      kernel: {
+        kernelAppend: '',
+      },
+      services: {
+        disabled: [],
+        enabled: [],
+      },
+    },
+    architecture: request.image_requests[0].architecture,
+    distribution: request.distribution,
+    imageTypes: request.image_requests.map((image) => image.image_type),
+    azure: {
+      shareMethod: azureUploadOptions?.source_id ? 'sources' : 'manual',
+      source: azureUploadOptions?.source_id || '',
+      tenantId: azureUploadOptions?.tenant_id || '',
+      subscriptionId: azureUploadOptions?.subscription_id || '',
+      resourceGroup: azureUploadOptions?.resource_group,
+    },
+    gcp: {
+      shareMethod: gcpUploadOptions?.share_with_accounts
+        ? 'withGoogle'
+        : 'withInsights',
+      accountType: gcpUploadOptions?.share_with_accounts?.[0].split(
+        ':'
+      )[0] as GcpAccountType,
+      email: gcpUploadOptions?.share_with_accounts?.[0].split(':')[1] || '',
+    },
+    aws: {
+      accountId: awsUploadOptions?.share_with_accounts?.[0] || '',
+      shareMethod: awsUploadOptions?.share_with_sources ? 'sources' : 'manual',
+      source: { id: awsUploadOptions?.share_with_sources?.[0] },
+    },
+    repositories: {
+      customRepositories: request.customizations.custom_repositories || [],
+    },
+    registration: {
+      registrationType: request.customizations?.subscription?.rhc
+        ? 'register-now-rhc'
+        : 'register-now-insights',
+      activationKey: request.customizations.subscription?.['activation-key'],
+    },
+    packages:
+      request.customizations.packages?.map((pkg) => ({
+        name: pkg,
+        summary: '',
+        repository: '',
+      })) || [],
   };
 };
 
@@ -129,10 +219,10 @@ const getImageOptions = (
       if (selectGcpShareMethod(state) === 'withGoogle') {
         const gcpEmail = selectGcpEmail(state);
         switch (selectGcpAccountType(state)) {
-          case 'google':
+          case 'user':
             googleAccount = `user:${gcpEmail}`;
             break;
-          case 'service':
+          case 'serviceAccount':
             googleAccount = `serviceAccount:${gcpEmail}`;
             break;
           case 'group':

--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -18,7 +18,7 @@ import {
   selectArchitecture,
   selectAwsAccountId,
   selectAwsShareMethod,
-  selectAwsSource,
+  selectAwsSourceId,
   selectAzureResourceGroup,
   selectAzureShareMethod,
   selectAzureSource,
@@ -131,9 +131,11 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
       accountId: awsUploadOptions?.share_with_accounts?.[0] || '',
       shareMethod: awsUploadOptions?.share_with_sources ? 'sources' : 'manual',
       source: { id: awsUploadOptions?.share_with_sources?.[0] },
+      sourceId: awsUploadOptions?.share_with_sources?.[0],
     },
     repositories: {
       customRepositories: request.customizations.custom_repositories || [],
+      payloadRepositories: request.customizations.payload_repositories || [],
     },
     registration: {
       registrationType: request.customizations?.subscription?.rhc
@@ -200,7 +202,7 @@ const getImageOptions = (
   switch (imageType) {
     case 'aws':
       if (selectAwsShareMethod(state) === 'sources')
-        return { share_with_sources: [selectAwsSource(state)?.id || ''] };
+        return { share_with_sources: [selectAwsSourceId(state) || ''] };
       else return { share_with_accounts: [selectAwsAccountId(state)] };
     case 'azure':
       if (selectAzureShareMethod(state) === 'sources')

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -20,7 +20,7 @@ import {
   PageHeader,
   PageHeaderTitle,
 } from '@redhat-cloud-services/frontend-components';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 
 import {
   useComposeBlueprintMutation,
@@ -41,6 +41,7 @@ export const ImageBuilderHeader = ({
 }: ImageBuilderHeaderPropTypes) => {
   const [buildBlueprint, { isLoading: imageBuildLoading }] =
     useComposeBlueprintMutation();
+  const navigate = useNavigate();
 
   const onBuildHandler = async () => {
     selectedBlueprint && (await buildBlueprint({ id: selectedBlueprint }));
@@ -167,7 +168,7 @@ export const ImageBuilderHeader = ({
                       isExpanded={isOpen}
                       onClick={() => setIsOpen(!isOpen)}
                       variant="secondary"
-                      aria-label="blueprint menu toggle"
+                      aria-label={`blueprint ${selectedBlueprint} menu toggle`}
                       isDisabled={selectedBlueprint === undefined}
                     >
                       Blueprint actions
@@ -175,7 +176,15 @@ export const ImageBuilderHeader = ({
                   )}
                 >
                   <DropdownList>
-                    <DropdownItem>Edit details</DropdownItem>
+                    <DropdownItem
+                      onClick={() =>
+                        navigate(
+                          resolveRelPath(`imagewizard/${selectedBlueprint}`)
+                        )
+                      }
+                    >
+                      Edit details
+                    </DropdownItem>
                     <DropdownItem onClick={() => setShowDeleteModal(true)}>
                       Delete blueprint
                     </DropdownItem>

--- a/src/Router.js
+++ b/src/Router.js
@@ -12,7 +12,7 @@ const CreateImageWizard = lazy(() =>
   import('./Components/CreateImageWizard/CreateImageWizard')
 );
 const CreateImageWizardV2 = lazy(() =>
-  import('./Components/CreateImageWizardV2/CreateImageWizard')
+  import('./Components/CreateImageWizardV2')
 );
 
 export const Router = () => {

--- a/src/store/imageBuilderApi.ts
+++ b/src/store/imageBuilderApi.ts
@@ -110,6 +110,9 @@ const injectedRtkApi = api.injectEndpoints({
         body: queryArg.createBlueprintRequest,
       }),
     }),
+    getBlueprint: build.query<GetBlueprintApiResponse, GetBlueprintApiArg>({
+      query: (queryArg) => ({ url: `/experimental/blueprints/${queryArg.id}` }),
+    }),
     deleteBlueprint: build.mutation<
       DeleteBlueprintApiResponse,
       DeleteBlueprintApiArg
@@ -250,6 +253,12 @@ export type UpdateBlueprintApiArg = {
   id: string;
   /** details of blueprint */
   createBlueprintRequest: CreateBlueprintRequest;
+};
+export type GetBlueprintApiResponse =
+  /** status 200 detail of a blueprint */ BlueprintResponse;
+export type GetBlueprintApiArg = {
+  /** UUID of a blueprint */
+  id: string;
 };
 export type DeleteBlueprintApiResponse =
   /** status 204 Successfully deleted */ void;
@@ -783,6 +792,16 @@ export type CreateBlueprintRequest = {
   image_requests: ImageRequest[];
   customizations: Customizations;
 };
+export type BlueprintResponse = {
+  id: string;
+  name: string;
+  description: string;
+  distribution: Distributions;
+  /** Array of image requests. Having more image requests in a single blueprint is currently not supported.
+   */
+  image_requests: ImageRequest[];
+  customizations: Customizations;
+};
 export const {
   useGetArchitecturesQuery,
   useGetComposesQuery,
@@ -797,6 +816,7 @@ export const {
   useGetBlueprintsQuery,
   useCreateBlueprintMutation,
   useUpdateBlueprintMutation,
+  useGetBlueprintQuery,
   useDeleteBlueprintMutation,
   useComposeBlueprintMutation,
   useGetBlueprintComposesQuery,

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -40,6 +40,7 @@ export type wizardState = {
     accountId: string;
     shareMethod: AwsShareMethod;
     source: V1ListSourceResponseItem | undefined;
+    sourceId?: string;
   };
   azure: {
     shareMethod: AzureShareMethod;
@@ -153,10 +154,8 @@ export const selectAwsAccountId = (state: RootState): string => {
   return state.wizard.aws.accountId;
 };
 
-export const selectAwsSource = (
-  state: RootState
-): V1ListSourceResponseItem | undefined => {
-  return state.wizard.aws.source;
+export const selectAwsSourceId = (state: RootState): string | undefined => {
+  return state.wizard.aws.sourceId;
 };
 
 export const selectAwsShareMethod = (state: RootState) => {
@@ -282,11 +281,8 @@ export const wizardSlice = createSlice({
     changeAwsShareMethod: (state, action: PayloadAction<AwsShareMethod>) => {
       state.aws.shareMethod = action.payload;
     },
-    changeAwsSource: (
-      state,
-      action: PayloadAction<V1ListSourceResponseItem | undefined>
-    ) => {
-      state.aws.source = action.payload;
+    changeAwsSourceId: (state, action: PayloadAction<string | undefined>) => {
+      state.aws.sourceId = action.payload;
     },
     changeAzureTenantId: (state, action: PayloadAction<string>) => {
       state.azure.tenantId = action.payload;
@@ -398,7 +394,7 @@ export const {
   changeImageTypes,
   changeAwsAccountId,
   changeAwsShareMethod,
-  changeAwsSource,
+  changeAwsSourceId,
   changeAzureTenantId,
   changeAzureShareMethod,
   changeAzureSubscriptionId,

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -28,7 +28,7 @@ export type RegistrationType =
   | 'register-now-insights'
   | 'register-now-rhc';
 
-type wizardState = {
+export type wizardState = {
   env: {
     serverUrl: string;
     baseUrl: string;
@@ -101,7 +101,7 @@ const initialState: wizardState = {
   },
   gcp: {
     shareMethod: 'withGoogle',
-    accountType: 'google',
+    accountType: 'user',
     email: '',
   },
   registration: {
@@ -244,6 +244,8 @@ export const wizardSlice = createSlice({
   initialState,
   reducers: {
     initializeWizard: () => initialState,
+    loadWizardState: (state, action: PayloadAction<wizardState>) =>
+      action.payload,
     changeServerUrl: (state, action: PayloadAction<string>) => {
       state.env.serverUrl = action.payload;
     },
@@ -311,7 +313,7 @@ export const wizardSlice = createSlice({
           state.gcp.email = '';
           break;
         case 'withGoogle':
-          state.gcp.accountType = 'google';
+          state.gcp.accountType = 'user';
       }
       state.gcp.shareMethod = action.payload;
     },
@@ -417,5 +419,6 @@ export const {
   removePackage,
   changeBlueprintName,
   changeBlueprintDescription,
+  loadWizardState,
 } = wizardSlice.actions;
 export default wizardSlice.reducer;

--- a/src/test/fixtures/blueprints.ts
+++ b/src/test/fixtures/blueprints.ts
@@ -3,6 +3,7 @@ import {
   GetBlueprintsApiResponse,
   CreateBlueprintResponse,
   GetBlueprintComposesApiResponse,
+  GetBlueprintApiResponse,
 } from '../../store/imageBuilderApi';
 
 export const mockBlueprintsCreation: CreateBlueprintResponse[] = [
@@ -90,4 +91,31 @@ export const mockEmptyBlueprintsComposes: GetBlueprintComposesApiResponse = {
   meta: { count: 0 },
   data: [],
   links: { first: 'first', last: 'last' },
+};
+
+export const updatedBlueprints: GetBlueprintsApiResponse = {
+  ...mockGetBlueprints,
+  data: mockGetBlueprints.data.map((item) => ({
+    ...item,
+    // Update version to 2 for all items
+    version: 2,
+    // If the item name is 'Dark Chocolate', rename it to 'Extra Dark Chocolate'
+    name: item.name === 'Dark Chocolate' ? 'Extra Dark Chocolate' : item.name,
+  })),
+};
+
+export const mockBlueprintDetail: GetBlueprintApiResponse = {
+  ...mockGetBlueprints.data[0],
+  image_requests: mockBlueprintComposes.data[0].request.image_requests,
+  distribution: mockBlueprintComposes.data[0].request.distribution,
+  customizations: {
+    subscription: {
+      organization: 1234,
+      'activation-key': '',
+      'server-url': '',
+      'base-url': '',
+      insights: true,
+      rhc: true,
+    },
+  },
 };

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -14,6 +14,7 @@ import {
 import { mockArchitecturesByDistro } from '../fixtures/architectures';
 import {
   mockBlueprintComposes,
+  mockBlueprintDetail,
   mockEmptyBlueprintsComposes,
   mockGetBlueprints,
 } from '../fixtures/blueprints';
@@ -152,6 +153,12 @@ export const handlers = [
         return res(ctx.status(200), ctx.json(mockEmptyBlueprintsComposes));
       }
       return res(ctx.status(200), ctx.json(mockBlueprintComposes));
+    }
+  ),
+  rest.get(
+    `${IMAGE_BUILDER_API}/experimental/blueprints/:id`,
+    (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(mockBlueprintDetail));
     }
   ),
 ];


### PR DESCRIPTION
This PR adds editing blueprints capabilities.
When a user clicks on `Edit details` or navigate to `/imagewizard/<BLUEPRINT_ID>`  the wizard opens  in the review step with preloaded blueprint's data, by mapping the blueprint's request to the state. 