### PR TITLE
test: Up timeout for 'image name invalid for more than 63 chars'

### DIFF
--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -908,7 +908,7 @@ describe('Step Upload to AWS', () => {
 
       expect(await getNextButton()).not.toHaveClass('pf-m-disabled');
       expect(await getNextButton()).toBeEnabled();
-    });
+    }, 20000);
   });
 
   describe('Step Review', () => {


### PR DESCRIPTION
This increases the timeout of 'image name invalid for more than 63 chars' to 20000.