### PR TITLE
Blueprints: Add guest-image and vsphere-ova to requestMapper

### DIFF
--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -75,9 +75,13 @@ const uploadTypeByTargetEnv = (imageType: ImageTypes): UploadTypes => {
       return 'oci.objectstorage';
     case 'wsl':
       return 'aws.s3';
+    case 'guest-image':
+      return 'aws.s3';
     case 'image-installer':
       return 'aws.s3';
     case 'vsphere':
+      return 'aws.s3';
+    case 'vsphere-ova':
       return 'aws.s3';
     case 'ami':
       return 'aws';


### PR DESCRIPTION
This adds guest-image and vsphere-ova as possible target environments to the requestMapper.