### PR TITLE
wizard: disable the unbuildable oscap profiles (HMS-2077)

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Oscap.tsx
+++ b/src/Components/CreateImageWizard/formComponents/Oscap.tsx
@@ -22,6 +22,7 @@ import { HelpIcon } from '@patternfly/react-icons';
 
 import OscapProfileInformation from './OscapProfileInformation';
 
+import { RHEL_9 } from '../../../constants';
 import {
   DistributionProfileItem,
   useGetOscapCustomizationsQuery,
@@ -59,6 +60,20 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
   const [profileName, setProfileName] = useState<string>('None');
   const [profile, setProfile] = useState(getState()?.values?.['oscap-profile']);
   const [isOpen, setIsOpen] = useState(false);
+  const unbuildableProfiles =
+    getState()?.values?.['release'] === RHEL_9
+      ? [
+          'xccdf_org.ssgproject.content_profile_cis',
+          'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+          'xccdf_org.ssgproject.content_profile_cis_workstation_l2',
+          'xccdf_org.ssgproject.content_profile_e8',
+          'xccdf_org.ssgproject.content_profile_hipaa',
+          'xccdf_org.ssgproject.content_profile_ism_o',
+          'xccdf_org.ssgproject.content_profile_e8',
+          'xccdf_org.ssgproject.content_profile_stig',
+          'xccdf_org.ssgproject.content_profile_stig_gui',
+        ]
+      : [];
   const {
     data: profiles,
     isFetching,
@@ -129,15 +144,21 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
   ];
   if (isSuccess) {
     options.concat(
-      profiles.map((profile_id) => {
-        return (
-          <OScapSelectOption
-            key={profile_id}
-            profile_id={profile_id}
-            setProfileName={setProfileName}
-          />
-        );
-      })
+      profiles
+        // TODO: until the backend is able to disable the services without
+        // failing, disable the set of unbuildableProfiles
+        .filter((profile_id) => {
+          return !unbuildableProfiles.find((id) => id === profile_id);
+        })
+        .map((profile_id) => {
+          return (
+            <OScapSelectOption
+              key={profile_id}
+              profile_id={profile_id}
+              setProfileName={setProfileName}
+            />
+          );
+        })
     );
   }
 
@@ -198,16 +219,22 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
                 key="oscap-none-option"
               />,
             ].concat(
-              profiles.map((profile_id, index) => {
-                return (
-                  <OScapSelectOption
-                    key={index}
-                    profile_id={profile_id}
-                    setProfileName={setProfileName}
-                    input={value}
-                  />
-                );
-              })
+              profiles
+                // TODO: until the backend is able to disable the services without
+                // failing, disable the set of unbuildableProfiles
+                .filter((profile_id) => {
+                  return !unbuildableProfiles.find((id) => id === profile_id);
+                })
+                .map((profile_id, index) => {
+                  return (
+                    <OScapSelectOption
+                      key={index}
+                      profile_id={profile_id}
+                      setProfileName={setProfileName}
+                      input={value}
+                    />
+                  );
+                })
             );
           }
         }}

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
@@ -148,11 +148,7 @@ describe('Step Compliance', () => {
       })
     );
 
-    await user.click(
-      await screen.findByText(
-        /cis red hat enterprise linux 8 benchmark for level 1 - workstation/i
-      )
-    );
+    await user.click(await screen.findByText(/Sample Test Profile/i));
     await screen.findByText(/kernel arguments:/i);
     await screen.findByText(/audit_backlog_limit=8192 audit=1/i);
     await screen.findByText(/disabled services:/i);

--- a/src/test/fixtures/oscap.ts
+++ b/src/test/fixtures/oscap.ts
@@ -5,6 +5,7 @@ import {
 
 export const distributionOscapProfiles = (): GetOscapProfilesApiResponse => {
   return [
+    'xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced',
     'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
     'xccdf_org.ssgproject.content_profile_cis_workstation_l2',
     'xccdf_org.ssgproject.content_profile_stig_gui',
@@ -14,6 +15,32 @@ export const distributionOscapProfiles = (): GetOscapProfilesApiResponse => {
 export const oscapCustomizations = (
   profile: string
 ): GetOscapCustomizationsApiResponse => {
+  if (profile === 'xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced') {
+    return {
+      filesystem: [{ min_size: 1073741824, mountpoint: '/tmp' }],
+      openscap: {
+        profile_id: 'xccdf_org.ssgproject.content_profile_anssi_bp28_enhanced',
+        profile_name: 'Sample Test Profile',
+        profile_description:
+          'This is a mocked profile description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean posuere velit enim, tincidunt porttitor nisl elementum eu.',
+      },
+      packages: [
+        'aide',
+        'sudo',
+        'rsyslog',
+        'firewalld',
+        'nftables',
+        'libselinux',
+      ],
+      kernel: {
+        append: 'audit_backlog_limit=8192 audit=1',
+      },
+      services: {
+        disabled: ['nfs-server'],
+        enabled: ['crond'],
+      },
+    };
+  }
   if (profile === 'xccdf_org.ssgproject.content_profile_cis_workstation_l1') {
     return {
       filesystem: [{ min_size: 1073741824, mountpoint: '/tmp' }],


### PR DESCRIPTION
Some Oscap profiles can't get built. That is because they require to disable a set of services that aren't installed on the system at this moment.

A workaround is being worked on the backend side. But meanwhile, we decide to disable this set of profiles to insure the user doesn't stumble upon bound-to-fail configurations.