### PR TITLE
V2Wizard: Remove bulk select and refresh button from the Packages step

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 
 import {
   Bullseye,
-  Button,
   EmptyState,
   EmptyStateBody,
   EmptyStateHeader,
@@ -17,12 +16,6 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import {
-  Dropdown,
-  DropdownItem,
-  DropdownToggle,
-  DropdownToggleCheckbox,
-} from '@patternfly/react-core/deprecated';
 import { CogIcon, SearchIcon, UserIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useDispatch } from 'react-redux';
@@ -46,81 +39,6 @@ export type IBPackageWithRepositoryInfo = {
   name: Package['name'];
   summary: Package['summary'];
   repository: string;
-};
-
-type BulkSelectProps = {
-  selected: Package[];
-  count: number | undefined;
-  perPage: number;
-  packagesCount: number | undefined;
-  handleSelectAll: Function;
-  handleSelectPage: Function;
-  handleDeselectAll: Function;
-};
-
-const BulkSelect = ({
-  selected,
-  count,
-  perPage,
-  packagesCount,
-  handleSelectAll,
-  handleSelectPage,
-  handleDeselectAll,
-}: BulkSelectProps) => {
-  const [dropdownIsOpen, setDropdownIsOpen] = useState(false);
-
-  const numSelected = selected.length;
-  const allSelected = count !== 0 ? numSelected === count : undefined;
-  const anySelected = numSelected > 0;
-  const someChecked = anySelected ? null : false;
-  const isChecked = allSelected ? true : someChecked;
-
-  const items = [
-    <DropdownItem
-      key="none"
-      onClick={() => handleDeselectAll()}
-    >{`Select none (0 items)`}</DropdownItem>,
-    <DropdownItem
-      key="page"
-      onClick={() => handleSelectPage()}
-    >{`Select page (${
-      perPage > packagesCount! ? packagesCount : perPage
-    } items)`}</DropdownItem>,
-    <DropdownItem key="all" onClick={() => handleSelectAll()}>{`Select all (${
-      packagesCount || 0
-    } items)`}</DropdownItem>,
-  ];
-
-  const handleDropdownSelect = () => toggleDropdown();
-
-  const toggleDropdown = () => setDropdownIsOpen(!dropdownIsOpen);
-
-  return (
-    <Dropdown
-      onSelect={handleDropdownSelect}
-      toggle={
-        <DropdownToggle
-          id="stacked-example-toggle"
-          splitButtonItems={[
-            <DropdownToggleCheckbox
-              id="example-checkbox-1"
-              key="split-checkbox"
-              aria-label="Select all"
-              isChecked={isChecked}
-              onClick={() => {
-                anySelected ? handleDeselectAll() : handleSelectAll();
-              }}
-            />,
-          ]}
-          onToggle={toggleDropdown}
-        >
-          {numSelected !== 0 ? `${numSelected} selected` : null}
-        </DropdownToggle>
-      }
-      isOpen={dropdownIsOpen}
-      dropdownItems={items}
-    />
-  );
 };
 
 const EmptySearch = () => {
@@ -312,30 +230,6 @@ const Packages = () => {
     }
   };
 
-  const handleSelectAll = () => {
-    for (const pkgIndex in transformedPackages) {
-      dispatch(addPackage(transformedPackages[pkgIndex]));
-    }
-  };
-
-  const handleSelectPage = () => {
-    const packagesSlice = transformedPackages.slice(
-      computeStart(),
-      computeEnd()
-    );
-    for (const pkgIndex in packagesSlice) {
-      if (!packages.some((p) => p.name === packagesSlice[pkgIndex].name)) {
-        dispatch(addPackage(packagesSlice[pkgIndex]));
-      }
-    }
-  };
-
-  const handleDeselectAll = () => {
-    for (const pkgIndex in packages) {
-      dispatch(removePackage(packages[pkgIndex]));
-    }
-  };
-
   const handleFilterToggleClick = (event: React.MouseEvent) => {
     const id = event.currentTarget.id;
     setPage(1);
@@ -419,28 +313,12 @@ const Packages = () => {
     <>
       <Toolbar>
         <ToolbarContent>
-          <ToolbarItem variant="bulk-select">
-            <BulkSelect
-              selected={packages}
-              count={packages.length}
-              perPage={perPage}
-              packagesCount={transformedPackages.length}
-              handleSelectAll={handleSelectAll}
-              handleSelectPage={handleSelectPage}
-              handleDeselectAll={handleDeselectAll}
-            />
-          </ToolbarItem>
           <ToolbarItem variant="search-filter">
             <SearchInput
               aria-label="Search packages"
               value={searchTerm}
               onChange={handleSearch}
             />
-          </ToolbarItem>
-          <ToolbarItem>
-            <Button variant="primary" isInline>
-              Refresh
-            </Button>
           </ToolbarItem>
           <ToolbarItem>
             <ToggleGroup>

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.content.test.tsx
@@ -103,12 +103,6 @@ const toggleSelected = async () => {
   );
 };
 
-const clickRefresh = async () => {
-  await userEvent.click(
-    await screen.findByRole('button', { name: /refresh/i })
-  );
-};
-
 describe('Step Packages', () => {
   const setUp = async () => {
     mockContentSourcesEnabled = false;
@@ -179,13 +173,16 @@ describe('Step Packages', () => {
     await verifyCancelButton(router);
   });
 
-  test('should display search bar and button', async () => {
+  test('should display search bar and toggle buttons', async () => {
     await setUp();
 
     await typeIntoSearchBox('test');
 
     await screen.findByRole('button', {
-      name: /refresh/i,
+      name: /available/i,
+    });
+    await screen.findByRole('button', {
+      name: /selected/i,
     });
   });
 
@@ -201,7 +198,6 @@ describe('Step Packages', () => {
     await setUp();
 
     await typeIntoSearchBox('testPkg-123');
-    await clickRefresh();
 
     await screen.findByTestId('exact-match-row');
 
@@ -284,23 +280,6 @@ describe('Step Packages', () => {
     expect(firstPkgCheckbox.checked).toEqual(true);
   });
 
-  test('removing a single package updates the state correctly', async () => {
-    await setUp();
-
-    await typeIntoSearchBox('test');
-
-    const checkboxes = await getAllCheckboxes();
-
-    await userEvent.click(checkboxes[0]);
-    expect(await screen.findByText('1 selected'));
-
-    await userEvent.click(checkboxes[2]);
-    expect(await screen.findByText('2 selected'));
-
-    await userEvent.click(checkboxes[0]);
-    expect(await screen.findAllByText('1 selected'));
-  });
-
   test('should display empty available state on failed search', async () => {
     await setUp();
 
@@ -329,7 +308,6 @@ describe('Step Packages', () => {
 
     await clearSearchBox();
     await typeIntoSearchBox('mock');
-    await clickRefresh();
 
     await userEvent.click(checkboxes[0]);
     await userEvent.click(checkboxes[1]);
@@ -338,7 +316,6 @@ describe('Step Packages', () => {
 
     await clearSearchBox();
     await typeIntoSearchBox('test');
-    await clickRefresh();
 
     const packagesTable = await screen.findByTestId('packages-table');
 
@@ -348,34 +325,6 @@ describe('Step Packages', () => {
 
     expect(availablePackages[0]).toHaveTextContent('test');
     expect(availablePackages[1]).toHaveTextContent('test-sources');
-  });
-
-  test('bulk select works', async () => {
-    await setUp();
-
-    await typeIntoSearchBox('test');
-
-    await userEvent.click(
-      await screen.findByRole('checkbox', { name: /select all/i })
-    );
-
-    let checkboxes = await getAllCheckboxes();
-
-    for (const checkbox in checkboxes) {
-      const pkgCheckbox = checkboxes[checkbox] as HTMLInputElement;
-      expect(pkgCheckbox.checked).toEqual(true);
-    }
-
-    await userEvent.click(
-      await screen.findByRole('checkbox', { name: /select all/i })
-    );
-
-    checkboxes = await getAllCheckboxes();
-
-    for (const checkbox in checkboxes) {
-      const pkgCheckbox = checkboxes[checkbox] as HTMLInputElement;
-      expect(pkgCheckbox.checked).toEqual(false);
-    }
   });
 });
 


### PR DESCRIPTION
This removes bulk select and a refresh button from the Packages step and updates tests accordingly.