### PR TITLE
V2Wizard/test: Fix bug on registration step and enable tests (HMS-2781)

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
@@ -459,13 +459,13 @@ export const RegisterNowList = () => {
                   <br />
                 </TextListItem>
               )}
-              {registrationType === 'register-now-insights' ||
-                (registrationType === 'register-now-rhc' && (
-                  <TextListItem>
-                    Connect to Red Hat Insights
-                    <br />
-                  </TextListItem>
-                ))}
+              {(registrationType === 'register-now-insights' ||
+                registrationType === 'register-now-rhc') && (
+                <TextListItem>
+                  Connect to Red Hat Insights
+                  <br />
+                </TextListItem>
+              )}
               {registrationType === 'register-now-rhc' && (
                 <TextListItem>
                   Use remote host configuration (rhc) utility

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -615,20 +615,21 @@ describe('Step Registration', () => {
     await user.click(activationKey);
     await screen.findByDisplayValue('name0');
 
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     const review = await screen.findByTestId('review-registration');
-    //     expect(review).toHaveTextContent(
-    //       'Register with Red Hat Subscription Manager (RHSM)'
-    //     );
-    //     expect(review).toHaveTextContent('Connect to Red Hat Insights');
-    //     expect(review).toHaveTextContent(
-    //       'Use remote host configuration (rhc) utility'
-    //     );
-    //     screen.getAllByText('012345678901');
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await enterBlueprintName();
+    await clickNext();
+    const review = await screen.findByTestId('review-registration');
+    expect(review).toHaveTextContent(
+      'Register with Red Hat Subscription Manager (RHSM)'
+    );
+    expect(review).toHaveTextContent('Connect to Red Hat Insights');
+    expect(review).toHaveTextContent(
+      'Use remote host configuration (rhc) utility'
+    );
+    screen.getAllByText('012345678901');
   });
 
   test('should allow registering without rhc', async () => {
@@ -658,20 +659,21 @@ describe('Step Registration', () => {
     await user.click(activationKey);
     await screen.findByDisplayValue('name0');
 
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     const review = await screen.findByTestId('review-registration');
-    //     expect(review).toHaveTextContent(
-    //       'Register with Red Hat Subscription Manager (RHSM)'
-    //     );
-    //     expect(review).toHaveTextContent('Connect to Red Hat Insights');
-    //     screen.getAllByText('012345678901');
-    //     expect(review).not.toHaveTextContent(
-    //       'Use remote host configuration (rhc) utility'
-    //     );
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await enterBlueprintName();
+    await clickNext();
+    const review = await screen.findByTestId('review-registration');
+    expect(review).toHaveTextContent(
+      'Register with Red Hat Subscription Manager (RHSM)'
+    );
+    expect(review).toHaveTextContent('Connect to Red Hat Insights');
+    screen.getAllByText('012345678901');
+    expect(review).not.toHaveTextContent(
+      'Use remote host configuration (rhc) utility'
+    );
   });
 
   test('should allow registering without insights or rhc', async () => {
@@ -703,20 +705,21 @@ describe('Step Registration', () => {
     await user.click(activationKey);
     await screen.findByDisplayValue('name0');
 
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     const review = await screen.findByTestId('review-registration');
-    //     expect(review).toHaveTextContent(
-    //       'Register with Red Hat Subscription Manager (RHSM)'
-    //     );
-    //     screen.getAllByText('012345678901');
-    //     expect(review).not.toHaveTextContent('Connect to Red Hat Insights');
-    //     expect(review).not.toHaveTextContent(
-    //       'Use remote host configuration (rhc) utility'
-    //     );
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await enterBlueprintName();
+    await clickNext();
+    const review = await screen.findByTestId('review-registration');
+    expect(review).toHaveTextContent(
+      'Register with Red Hat Subscription Manager (RHSM)'
+    );
+    screen.getAllByText('012345678901');
+    expect(review).not.toHaveTextContent('Connect to Red Hat Insights');
+    expect(review).not.toHaveTextContent(
+      'Use remote host configuration (rhc) utility'
+    );
   });
 
   test('should hide input fields when clicking Register the system later', async () => {
@@ -730,12 +733,13 @@ describe('Step Registration', () => {
 
     await removeKeyInformation;
 
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     await clickNext();
-    //     await screen.findByText('Register the system later');
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await clickNext();
+    await enterBlueprintName();
+    await clickNext();
+    await screen.findByText('Register the system later');
   });
 
   test('registering with rhc implies registering with insights', async () => {


### PR DESCRIPTION
This fixes a bug on the registration step which made the text "Connect to Red Hat Insights" not to get rendered when registering with rhc.

All registration tests were also enabled in CreateImageWizard.test.tsx