### PR TITLE
V2Wizrd: clean resource group when user change the source name

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureSourcesSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureSourcesSelect.tsx
@@ -68,6 +68,7 @@ export const AzureSourcesSelect = () => {
       (source) => source?.name === sourceName
     )?.id;
     dispatch(changeAzureSource(sourceId || ''));
+    dispatch(changeAzureResourceGroup(''));
     setIsOpen(false);
   };
 


### PR DESCRIPTION
this commit fix https://github.com/osbuild/image-builder-frontend/issues/1691 when user change the source name, resource gruop should clean up