### PR TITLE
Blueprints: add blueprints slice for client global state 

### DIFF
--- a/src/Components/Blueprints/BlueprintActionsMenu.tsx
+++ b/src/Components/Blueprints/BlueprintActionsMenu.tsx
@@ -8,20 +8,26 @@ import {
   MenuToggleElement,
 } from '@patternfly/react-core';
 import { EllipsisVIcon } from '@patternfly/react-icons';
+import { useNavigate } from 'react-router-dom';
+
+import { selectSelectedBlueprintId } from '../../store/BlueprintSlice';
+import { useAppSelector } from '../../store/hooks';
+import { resolveRelPath } from '../../Utilities/path';
 
 interface BlueprintActionsMenuProps {
-  selectedBlueprint: string | undefined;
   setShowDeleteModal: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export const BlueprintActionsMenu: React.FunctionComponent<
   BlueprintActionsMenuProps
-> = ({ selectedBlueprint, setShowDeleteModal }: BlueprintActionsMenuProps) => {
+> = ({ setShowDeleteModal }: BlueprintActionsMenuProps) => {
   const [showBlueprintActionsMenu, setShowBlueprintActionsMenu] =
     useState(false);
   const onSelect = () => {
     setShowBlueprintActionsMenu(!showBlueprintActionsMenu);
   };
+  const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
+  const navigate = useNavigate();
 
   return (
     <Dropdown
@@ -39,14 +45,20 @@ export const BlueprintActionsMenu: React.FunctionComponent<
           onClick={() => setShowBlueprintActionsMenu(!showBlueprintActionsMenu)}
           variant="plain"
           aria-label="blueprint menu toggle"
-          isDisabled={selectedBlueprint === undefined}
+          isDisabled={selectedBlueprintId === undefined}
         >
           <EllipsisVIcon aria-hidden="true" />
         </MenuToggle>
       )}
     >
       <DropdownList>
-        <DropdownItem>Edit details</DropdownItem>
+        <DropdownItem
+          onClick={() =>
+            navigate(resolveRelPath(`imagewizard/${selectedBlueprintId}`))
+          }
+        >
+          Edit details
+        </DropdownItem>
         <DropdownItem>Download blueprint (.json)</DropdownItem>
         <DropdownItem onClick={() => setShowDeleteModal(true)}>
           Delete blueprint

--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -11,23 +11,23 @@ import {
 } from '@patternfly/react-core';
 
 import {
+  selectSelectedBlueprintId,
+  setBlueprintId,
+} from '../../store/BlueprintSlice';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import {
   BlueprintItem,
   useDeleteBlueprintMutation,
 } from '../../store/imageBuilderApi';
 
 type blueprintProps = {
   blueprint: BlueprintItem;
-  selectedBlueprint: string | undefined;
-  setSelectedBlueprint: React.Dispatch<
-    React.SetStateAction<string | undefined>
-  >;
 };
 
-const BlueprintCard = ({
-  blueprint,
-  selectedBlueprint,
-  setSelectedBlueprint,
-}: blueprintProps) => {
+const BlueprintCard = ({ blueprint }: blueprintProps) => {
+  const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
+  const dispatch = useAppDispatch();
+
   const [, { isLoading }] = useDeleteBlueprintMutation({
     fixedCacheKey: 'delete-blueprint',
   });
@@ -39,11 +39,11 @@ const BlueprintCard = ({
           selectableActions={{
             selectableActionId: blueprint.id,
             name: 'blueprints',
-            onClickAction: () => setSelectedBlueprint(blueprint.id),
+            onClickAction: () => dispatch(setBlueprintId(blueprint.id)),
           }}
         >
           <CardTitle>
-            {isLoading && blueprint.id === selectedBlueprint && (
+            {isLoading && blueprint.id === selectedBlueprintId && (
               <Spinner size="md" />
             )}
             &nbsp;&nbsp;

--- a/src/Components/Blueprints/DeleteBlueprintModal.tsx
+++ b/src/Components/Blueprints/DeleteBlueprintModal.tsx
@@ -8,34 +8,34 @@ import {
 } from '@patternfly/react-core';
 
 import {
+  selectBlueprintSearchInput,
+  selectSelectedBlueprintId,
+  setBlueprintId,
+} from '../../store/BlueprintSlice';
+import { useAppDispatch, useAppSelector } from '../../store/hooks';
+import {
   useDeleteBlueprintMutation,
   useGetBlueprintsQuery,
 } from '../../store/imageBuilderApi';
 
 interface DeleteBlueprintModalProps {
-  selectedBlueprint: string | undefined;
-  setSelectedBlueprint: React.Dispatch<
-    React.SetStateAction<string | undefined>
-  >;
   setShowDeleteModal: React.Dispatch<React.SetStateAction<boolean>>;
   isOpen: boolean;
 }
 
 export const DeleteBlueprintModal: React.FunctionComponent<
   DeleteBlueprintModalProps
-> = ({
-  selectedBlueprint,
-  setSelectedBlueprint,
-  setShowDeleteModal,
-  isOpen,
-}: DeleteBlueprintModalProps) => {
+> = ({ setShowDeleteModal, isOpen }: DeleteBlueprintModalProps) => {
+  const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
+  const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
+  const dispatch = useAppDispatch();
   const { blueprintName } = useGetBlueprintsQuery(
-    { search: undefined },
+    { search: blueprintSearchInput },
     {
       selectFromResult: ({ data }) => ({
         blueprintName: data?.data?.find(
           (blueprint: { id: string | undefined }) =>
-            blueprint.id === selectedBlueprint
+            blueprint.id === selectedBlueprintId
         )?.name,
       }),
     }
@@ -44,10 +44,10 @@ export const DeleteBlueprintModal: React.FunctionComponent<
     fixedCacheKey: 'delete-blueprint',
   });
   const handleDelete = async () => {
-    if (selectedBlueprint) {
+    if (selectedBlueprintId) {
       setShowDeleteModal(false);
-      await deleteBlueprint({ id: selectedBlueprint });
-      setSelectedBlueprint(undefined);
+      await deleteBlueprint({ id: selectedBlueprintId });
+      dispatch(setBlueprintId(undefined));
     }
   };
   const onDeleteClose = () => {

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -45,6 +45,11 @@ import {
   STATUS_POLLING_INTERVAL,
 } from '../../constants';
 import {
+  selectBlueprintSearchInput,
+  selectSelectedBlueprintId,
+} from '../../store/BlueprintSlice';
+import { useAppSelector } from '../../store/hooks';
+import {
   BlueprintItem,
   ComposesResponseItem,
   ComposeStatus,
@@ -63,25 +68,18 @@ import { BlueprintActionsMenu } from '../Blueprints/BlueprintActionsMenu';
 import { BuildImagesButton } from '../Blueprints/BuildImagesButton';
 import { DeleteBlueprintModal } from '../Blueprints/DeleteBlueprintModal';
 
-type ImageTableProps = {
-  selectedBlueprint?: string | undefined;
-  setSelectedBlueprint: React.Dispatch<
-    React.SetStateAction<string | undefined>
-  >;
-};
-
-const ImagesTable = ({
-  selectedBlueprint,
-  setSelectedBlueprint,
-}: ImageTableProps) => {
+const ImagesTable = () => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
+  const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
+  const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
+
   const { selectedBlueprintVersion } = useGetBlueprintsQuery(
-    {},
+    { search: blueprintSearchInput },
     {
       selectFromResult: ({ data }) => ({
         selectedBlueprintVersion: data?.data?.find(
-          (blueprint: BlueprintItem) => blueprint.id === selectedBlueprint
+          (blueprint: BlueprintItem) => blueprint.id === selectedBlueprintId
         )?.version,
       }),
     }
@@ -103,11 +101,11 @@ const ImagesTable = ({
     isError: isBlueprintsError,
   } = useGetBlueprintComposesQuery(
     {
-      id: selectedBlueprint as string,
+      id: selectedBlueprintId as string,
       limit: perPage,
       offset: perPage * (page - 1),
     },
-    { skip: !selectedBlueprint }
+    { skip: !selectedBlueprintId }
   );
 
   const {
@@ -126,18 +124,20 @@ const ImagesTable = ({
         'edge-installer',
       ],
     },
-    { skip: !!selectedBlueprint }
+    { skip: !!selectedBlueprintId }
   );
 
-  const data = selectedBlueprint ? blueprintsComposes : composesData;
-  const isSuccess = selectedBlueprint ? isBlueprintsSuccess : isComposesSuccess;
-  const isError = selectedBlueprint ? isBlueprintsError : isComposesError;
-  const isLoading = selectedBlueprint
+  const data = selectedBlueprintId ? blueprintsComposes : composesData;
+  const isSuccess = selectedBlueprintId
+    ? isBlueprintsSuccess
+    : isComposesSuccess;
+  const isError = selectedBlueprintId ? isBlueprintsError : isComposesError;
+  const isLoading = selectedBlueprintId
     ? isLoadingBlueprintsCompose
     : isLoadingComposes;
 
   const isBlueprintOutSync =
-    selectedBlueprint &&
+    selectedBlueprintId &&
     !isFetchingBlueprintsCompose &&
     blueprintsComposes?.data[0]?.blueprint_version !== selectedBlueprintVersion;
 
@@ -174,8 +174,6 @@ const ImagesTable = ({
     <>
       <>
         <DeleteBlueprintModal
-          selectedBlueprint={selectedBlueprint}
-          setSelectedBlueprint={setSelectedBlueprint}
           setShowDeleteModal={setShowDeleteModal}
           isOpen={showDeleteModal}
         />
@@ -198,11 +196,10 @@ const ImagesTable = ({
             {experimentalFlag && (
               <>
                 <ToolbarItem>
-                  <BuildImagesButton selectedBlueprint={selectedBlueprint} />
+                  <BuildImagesButton selectedBlueprint={selectedBlueprintId} />
                 </ToolbarItem>
                 <ToolbarItem>
                   <BlueprintActionsMenu
-                    selectedBlueprint={selectedBlueprint}
                     setShowDeleteModal={setShowDeleteModal}
                   />
                 </ToolbarItem>
@@ -240,7 +237,7 @@ const ImagesTable = ({
             <Tbody>
               <Tr>
                 <Td colSpan={12}>
-                  <ImagesEmptyState selectedBlueprint={selectedBlueprint} />
+                  <ImagesEmptyState selectedBlueprint={selectedBlueprintId} />
                 </Td>
               </Tr>
             </Tbody>

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -51,9 +51,6 @@ export const LandingPage = () => {
     }
     setActiveTabKey(tabIndex);
   };
-  const [selectedBlueprint, setSelectedBlueprint] = useState<
-    string | undefined
-  >();
 
   const edgeParityFlag = useFlag('edgeParity.image-list');
   const experimentalFlag = useExperimentalFlag();
@@ -64,7 +61,7 @@ export const LandingPage = () => {
         <Quickstarts />
       </PageSection>
       <PageSection>
-        <ImagesTable setSelectedBlueprint={setSelectedBlueprint} />
+        <ImagesTable />
       </PageSection>
     </>
   );
@@ -74,16 +71,10 @@ export const LandingPage = () => {
       <PageSection>
         <Sidebar hasBorder className="pf-v5-u-background-color-100">
           <SidebarPanel hasPadding width={{ default: 'width_25' }}>
-            <BlueprintsSidebar
-              selectedBlueprint={selectedBlueprint}
-              setSelectedBlueprint={setSelectedBlueprint}
-            />
+            <BlueprintsSidebar />
           </SidebarPanel>
           <SidebarContent>
-            <ImagesTable
-              selectedBlueprint={selectedBlueprint}
-              setSelectedBlueprint={setSelectedBlueprint}
-            />
+            <ImagesTable />
           </SidebarContent>
         </Sidebar>
       </PageSection>

--- a/src/store/BlueprintSlice.ts
+++ b/src/store/BlueprintSlice.ts
@@ -1,0 +1,53 @@
+import { PayloadAction, createSlice } from '@reduxjs/toolkit';
+
+import { RootState } from '.';
+
+type blueprintsState = {
+  selectedBlueprintId: string | undefined;
+  searchInput?: string;
+  offset?: number;
+  limit?: number;
+};
+
+const initialState: blueprintsState = {
+  selectedBlueprintId: undefined,
+  searchInput: undefined,
+  offset: 0,
+  limit: 10,
+};
+
+export const selectSelectedBlueprintId = (state: RootState) =>
+  state.blueprints.selectedBlueprintId;
+export const selectBlueprintSearchInput = (state: RootState) =>
+  state.blueprints.searchInput;
+export const selectOffset = (state: RootState) => state.blueprints.offset;
+export const selectLimit = (state: RootState) => state.blueprints.limit;
+
+export const blueprintsSlice = createSlice({
+  name: 'blueprints',
+  initialState,
+  reducers: {
+    setBlueprintId: (state, action: PayloadAction<string | undefined>) => {
+      state.selectedBlueprintId = action.payload;
+    },
+    setBlueprintSearchInput: (
+      state,
+      action: PayloadAction<string | undefined>
+    ) => {
+      state.searchInput = action.payload;
+    },
+    setBlueprintsOffset: (state, action: PayloadAction<number>) => {
+      state.offset = action.payload;
+    },
+    setBlueprintLimit: (state, action: PayloadAction<number>) => {
+      state.limit = action.payload;
+    },
+  },
+});
+
+export const {
+  setBlueprintId,
+  setBlueprintSearchInput,
+  setBlueprintsOffset,
+  setBlueprintLimit,
+} = blueprintsSlice.actions;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -2,6 +2,7 @@ import { notificationsReducer } from '@redhat-cloud-services/frontend-components
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import promiseMiddleware from 'redux-promise-middleware';
 
+import { blueprintsSlice } from './BlueprintSlice';
 import { contentSourcesApi } from './contentSourcesApi';
 import { edgeApi } from './edgeApi';
 import { imageBuilderApi } from './enhancedImageBuilderApi';
@@ -25,6 +26,7 @@ export const reducer = combineReducers({
   [provisioningApi.reducerPath]: provisioningApi.reducer,
   notifications: notificationsReducer,
   wizard: wizardSlice,
+  blueprints: blueprintsSlice.reducer,
 });
 
 startAppListening({


### PR DESCRIPTION
Made on top of  #1654, first two commits unrelated. 

This PR adds blueprints slice for managing blueprints client state globally. Multiple components use these data as props and args, and for keeping it consistent when a change occurs,  redux slice gives a clean solution.