### PR TITLE
V1 Wizard: Add search parameter for release selection (HMS-3684)

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ImageOutputReleaseSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/ImageOutputReleaseSelect.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { FormSpy } from '@data-driven-forms/react-form-renderer';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
@@ -10,6 +10,7 @@ import {
   SelectVariant,
 } from '@patternfly/react-core/deprecated';
 import PropTypes from 'prop-types';
+import { useSearchParams } from 'react-router-dom';
 
 import {
   RELEASES,
@@ -28,6 +29,14 @@ const ImageOutputReleaseSelect = ({ label, isRequired, ...props }) => {
   const { input } = useFieldApi(props);
   const [isOpen, setIsOpen] = useState(false);
   const [showDevelopmentOptions, setShowDevelopmentOptions] = useState(false);
+
+  const [searchParams] = useSearchParams();
+
+  // Used to set release to RHEL 8 via search parameter, used by Insights assistant
+  const preloadRelease = searchParams.get('release');
+  useEffect(() => {
+    preloadRelease === 'rhel8' && change(input.name, RHEL_8);
+  }, [change, input.name, preloadRelease]);
 
   const setRelease = (_, selection) => {
     change(input.name, selection);

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1656,3 +1656,32 @@ describe('Keyboard accessibility', () => {
     testTile(await screen.findByTestId('upload-azure'));
   });
 });
+
+describe('set release using query parameter', () => {
+  test('rhel 9 by default (no query parameter)', async () => {
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
+    await screen.findByText('Red Hat Enterprise Linux (RHEL) 9');
+  });
+
+  test('rhel 9 by default (invalid query parameter)', async () => {
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard?release=rhel9000',
+      {},
+      routes
+    ));
+    await screen.findByText('Red Hat Enterprise Linux (RHEL) 9');
+  });
+
+  test('rhel 8 (query parameter provided)', async () => {
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard?release=rhel8',
+      {},
+      routes
+    ));
+    await screen.findByText('Red Hat Enterprise Linux (RHEL) 8');
+  });
+});

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1642,9 +1642,9 @@ describe('Keyboard accessibility', () => {
     const testTile = async (tile) => {
       tile.focus();
       await user.keyboard('{space}');
-      expect(tile).toHaveClass('pf-m-selected');
+      await waitFor(() => expect(tile).toHaveClass('pf-m-selected'));
       await user.keyboard('{space}');
-      expect(tile).not.toHaveClass('pf-m-selected');
+      await waitFor(() => expect(tile).not.toHaveClass('pf-m-selected'));
     };
 
     await setUp();


### PR DESCRIPTION
Adding an optional search parameter to the wizard like so:

/insights/image-builder/imagewizard?release=rhel8

results in the wizard being opened and RHEL 8 being pre-selected as the release.

The Insights assistant chat bot will make use of this feature.