### PR TITLE
V2Wizard: Clean up OSCAP info (HMS-2781)

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Oscap/OscapProfileInformation.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/OscapProfileInformation.tsx
@@ -61,7 +61,6 @@ export const OscapProfileInformation = (): JSX.Element => {
               <TextListItem component={TextListItemVariants.dd}>
                 {oscapProfileInfo.openscap?.profile_description}
               </TextListItem>
-              component={TextListVariants.dl}
               <TextListItem
                 component={TextListItemVariants.dt}
                 className="pf-u-min-width"
@@ -71,7 +70,6 @@ export const OscapProfileInformation = (): JSX.Element => {
               <TextListItem component={TextListItemVariants.dd}>
                 {RELEASES.get(release)}
               </TextListItem>
-              component={TextListVariants.dl}
               <TextListItem
                 component={TextListItemVariants.dt}
                 className="pf-u-min-width"


### PR DESCRIPTION
This removes "component=dl" from the OSCAP information.

Before:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/6705696f-d6e1-4444-9474-735fdcc67752)

After:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/ed1da7c1-6403-434b-b379-7f268032e626)
