### PR TITLE
V2Wizard: Move OSCAP alert outside of OscapProfileInformation (HMS-2781)

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
@@ -285,10 +285,24 @@ const OScapSelectOption = ({
 };
 
 export const Oscap = () => {
+  const oscapProfile = useAppSelector((state) => selectProfile(state));
+
   return (
     <>
       <ProfileSelector />
       <OscapProfileInformation />
+      {oscapProfile && (
+        <Alert
+          variant="info"
+          isInline
+          isPlain
+          title="Additional customizations"
+        >
+          Selecting an OpenSCAP profile will cause the appropriate packages,
+          file system configuration, kernel arguments, and services to be added
+          to your image.
+        </Alert>
+      )}
     </>
   );
 };

--- a/src/Components/CreateImageWizardV2/steps/Oscap/OscapProfileInformation.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/OscapProfileInformation.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {
-  Alert,
   CodeBlock,
   CodeBlockCode,
   Spinner,
@@ -116,17 +115,6 @@ export const OscapProfileInformation = (): JSX.Element => {
               </TextListItem>
             </TextList>
           </TextContent>
-
-          <Alert
-            variant="info"
-            isInline
-            isPlain
-            title="Additional customizations"
-          >
-            Selecting an OpenSCAP profile will cause the appropriate packages,
-            file system configuration, kernel arguments, and services to be
-            added to your image.
-          </Alert>
         </>
       )}
     </>


### PR DESCRIPTION
This moves the "Additional customizations" alert outside of OscapProfileInformation which ensures it is not shown in the Oscap expandable on the Review step.

User can see the added customisations in the individual expandables, making the alert non-actionable extra information.