### PR TITLE
V2 Wizard: Add search parameter for release selection (HMS-3684)

### DIFF
--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -7,7 +7,7 @@ import {
   WizardStep,
   useWizardContext,
 } from '@patternfly/react-core';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import DetailsStep from './steps/Details';
 import ImageOutputStep from './steps/ImageOutput';
@@ -30,9 +30,11 @@ import {
   isGcpEmailValid,
 } from './validators';
 
+import { RHEL_8 } from '../../constants';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import './CreateImageWizard.scss';
 import {
+  changeDistribution,
   initializeWizard,
   selectActivationKey,
   selectAwsAccountId,
@@ -92,10 +94,13 @@ type CreateImageWizardProps = {
 const CreateImageWizard = ({ startStepIndex = 1 }: CreateImageWizardProps) => {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const [searchParams] = useSearchParams();
 
   // IMPORTANT: Ensure the wizard starts with a fresh initial state
   useEffect(() => {
     dispatch(initializeWizard());
+    searchParams.get('release') === 'rhel8' &&
+      dispatch(changeDistribution(RHEL_8));
     // This useEffect hook should run *only* on mount and therefore has an empty
     // dependency array. eslint's exhaustive-deps rule does not support this use.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -9,6 +9,7 @@ import { AARCH64, RHEL_8, RHEL_9, X86_64 } from '../../../../../constants';
 import { mockArchitecturesByDistro } from '../../../../fixtures/architectures';
 import { server } from '../../../../mocks/server';
 import { renderCustomRoutesWithReduxRouter } from '../../../../testUtils';
+import { render } from '../../wizardTestUtils';
 
 const routes = [
   {
@@ -256,5 +257,22 @@ describe('Check step consistency', () => {
     await user.click(archMenu);
     await user.click(await screen.findByRole('option', { name: 'x86_64' }));
     await waitFor(() => expect(next).toBeEnabled());
+  });
+});
+
+describe('set release using query parameter', () => {
+  test('rhel 9 by default (no query parameter)', async () => {
+    await render();
+    await screen.findByText('Red Hat Enterprise Linux (RHEL) 9');
+  });
+
+  test('rhel 9 by default (invalid query parameter)', async () => {
+    await render({ release: 'rhel9001' });
+    await screen.findByText('Red Hat Enterprise Linux (RHEL) 9');
+  });
+
+  test('rhel 8 (query parameter provided)', async () => {
+    await render({ release: 'rhel8' });
+    await screen.findByText('Red Hat Enterprise Linux (RHEL) 8');
   });
 });

--- a/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
@@ -55,7 +55,15 @@ export const blueprintRequest: CreateBlueprintRequest = {
   customizations: {},
 };
 
-const preparePathname = (searchParams: {}) => {
+/**
+ * @example
+ * // returns 'imageWizard?release=rhel8&architecture=aarch64'
+ * preparePathname({ release: 'rhel8', architecture: 'aarch64' });
+ * @example
+ * // returns 'imageWizard'
+ * preparePathname({});
+ */
+function preparePathname(searchParams: { [key: string]: string } = {}): string {
   let pathName = 'imageWizard';
   const params = Object.entries(searchParams).map(
     ([param, value]) => `${param}=${value}`
@@ -64,7 +72,7 @@ const preparePathname = (searchParams: {}) => {
     pathName += `?${params.join('&')}`;
   }
   return pathName;
-};
+}
 
 export const render = async (searchParams = {}) => {
   const pathName = preparePathname(searchParams);

--- a/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
@@ -55,8 +55,20 @@ export const blueprintRequest: CreateBlueprintRequest = {
   customizations: {},
 };
 
-export const render = async () => {
-  await renderCustomRoutesWithReduxRouter('imagewizard', {}, routes);
+const preparePathname = (searchParams: {}) => {
+  let pathName = 'imageWizard';
+  const params = Object.entries(searchParams).map(
+    ([param, value]) => `${param}=${value}`
+  );
+  if (params.length > 0) {
+    pathName += `?${params.join('&')}`;
+  }
+  return pathName;
+};
+
+export const render = async (searchParams = {}) => {
+  const pathName = preparePathname(searchParams);
+  await renderCustomRoutesWithReduxRouter(pathName, {}, routes);
 };
 
 export const goToRegistrationStep = async () => {


### PR DESCRIPTION
Adding an optional search parameter to the V2 wizard like so:

/insights/image-builder/imagewizard?release=rhel8

results in the wizard being opened and RHEL 8 being pre-selected as the release.

The Insights assistant chat bot will make use of this feature.

The render() test utility function had to be updated to accept an
optional searchParams argument. 