### PR TITLE
V1/V2Wizard: Capitalise ID on Azure step

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/AzureSourcesSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/AzureSourcesSelect.js
@@ -146,7 +146,7 @@ const AzureSourcesSelect = ({ label, isRequired, className, ...props }) => {
             isInline
             title={'Azure details unavailable'}
           >
-            Could not fetch Tenant id and Subscription id from Azure for given
+            Could not fetch Tenant ID and Subscription ID from Azure for given
             Source. Check Sources page for the source availability or select a
             different Source.
           </Alert>

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureSourcesSelect.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureSourcesSelect.tsx
@@ -144,7 +144,7 @@ export const AzureSourcesSelect = () => {
           isInline
           title={'Azure details unavailable'}
         >
-          Could not fetch Tenant id and Subscription id from Azure for given
+          Could not fetch Tenant ID and Subscription ID from Azure for given
           Source. Check Sources page for the source availability or select a
           different Source.
         </Alert>


### PR DESCRIPTION
This capitalises id -> ID in the test of an alert on Azure step to keep consistent with the capitalisation throughout the step.