### PR TITLE
Enable masked systemd services in the frontend (HMS-3661)

### DIFF
--- a/api/schema/imageBuilder.yaml
+++ b/api/schema/imageBuilder.yaml
@@ -1653,6 +1653,13 @@ components:
           items:
             type: string
             example: "firewalld"
+        masked:
+          description: List of services to mask by default
+          type: array
+          minItems: 1
+          items:
+            type: string
+            example: "telnet"
     Timezone:
       type: object
       description: Timezone configuration

--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -104,7 +104,9 @@ const onSave = (values) => {
       (Array.isArray(values['enabledServices']) &&
         values['enabledServices'].length > 0) ||
       (Array.isArray(values['disabledServices']) &&
-        values['disabledServices'].length > 0)
+        values['disabledServices'].length > 0) ||
+      (Array.isArray(values['maskedServices']) &&
+        values['maskedServices'].length > 0)
     ) {
       customizations.services = {};
       if (values['enabledServices'].length > 0) {
@@ -112,6 +114,9 @@ const onSave = (values) => {
       }
       if (values['disabledServices'].length > 0) {
         customizations.services.disabled = values['disabledServices'];
+      }
+      if (values['maskedServices'].length > 0) {
+        customizations.services.masked = values['maskedServices'];
       }
     }
   }
@@ -537,6 +542,8 @@ const requestToState = (composeRequest, isProd, enableOscap) => {
         composeRequest?.customizations?.services?.enabled;
       formState['disabledServices'] =
         composeRequest?.customizations?.services?.disabled;
+      formState['maskedServices'] =
+        composeRequest?.customizations?.services?.masked;
     }
 
     return formState;

--- a/src/Components/CreateImageWizard/formComponents/Oscap.tsx
+++ b/src/Components/CreateImageWizard/formComponents/Oscap.tsx
@@ -96,6 +96,9 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
     if (data?.services?.disabled) {
       change('disabledServices', data.services.disabled);
     }
+    if (data?.services?.masked) {
+      change('maskedServices', data.services.masked);
+    }
   }, [data]);
 
   const handleToggle = () => {
@@ -111,6 +114,7 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
     change('kernel', undefined);
     change('disabledServices', undefined);
     change('enabledServices', undefined);
+    change('maskedServices', undefined);
     setProfileName('');
     reinitDependingSteps(change);
   };

--- a/src/Components/CreateImageWizard/formComponents/OscapProfileInformation.tsx
+++ b/src/Components/CreateImageWizard/formComponents/OscapProfileInformation.tsx
@@ -34,8 +34,10 @@ const OscapProfileInformation = (): JSX.Element => {
 
   const enabledServicesDisplayString =
     oscapProfileInfo?.services?.enabled?.join(' ');
-  const disableServicesDisplayString =
+  const disabledServicesDisplayString =
     oscapProfileInfo?.services?.disabled?.join(' ');
+  const maskedServicesDisplayString =
+    oscapProfileInfo?.services?.masked?.join(' ');
 
   return (
     <>
@@ -93,7 +95,7 @@ const OscapProfileInformation = (): JSX.Element => {
               </TextListItem>
               <TextListItem component={TextListItemVariants.dd}>
                 <CodeBlock>
-                  <CodeBlockCode>{disableServicesDisplayString}</CodeBlockCode>
+                  <CodeBlockCode>{disabledServicesDisplayString}</CodeBlockCode>
                 </CodeBlock>
               </TextListItem>
               <TextListItem
@@ -105,6 +107,17 @@ const OscapProfileInformation = (): JSX.Element => {
               <TextListItem component={TextListItemVariants.dd}>
                 <CodeBlock>
                   <CodeBlockCode>{enabledServicesDisplayString}</CodeBlockCode>
+                </CodeBlock>
+              </TextListItem>
+              <TextListItem
+                component={TextListItemVariants.dt}
+                className="pf-u-min-width"
+              >
+                Masked services:
+              </TextListItem>
+              <TextListItem component={TextListItemVariants.dd}>
+                <CodeBlock>
+                  <CodeBlockCode>{maskedServicesDisplayString}</CodeBlockCode>
                 </CodeBlock>
               </TextListItem>
             </TextList>

--- a/src/store/imageBuilderApi.ts
+++ b/src/store/imageBuilderApi.ts
@@ -524,6 +524,8 @@ export type Services = {
   enabled?: string[];
   /** List of services to disable by default */
   disabled?: string[];
+  /** List of services to mask by default */
+  masked?: string[];
 };
 export type Kernel = {
   /** Name of the kernel to use */

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
@@ -155,9 +155,10 @@ describe('Step Compliance', () => {
     );
     await screen.findByText(/kernel arguments:/i);
     await screen.findByText(/audit_backlog_limit=8192 audit=1/i);
-    await screen.findByText(/disabled services:/i);
     await screen.findByText(/nfs-server/i);
+    await screen.findByText(/disabled services:/i);
     await screen.findByText(/enabled services:/i);
+    await screen.findByText(/masked services:/i);
     await screen.findByText(/crond/i);
 
     // check that the FSC contains a /tmp partition


### PR DESCRIPTION
Add masked services as a customization option, since disabling systemd units when the package isn't installed breaks the image build.

This depends on:
https://github.com/osbuild/image-builder/pull/1062 (manually added the API endpoint for the time being)