### PR TITLE
V2Wizard: Update repository icons and names on Packages step (HMS-2864)

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -7,7 +7,6 @@ import {
   EmptyStateHeader,
   EmptyStateIcon,
   EmptyStateVariant,
-  Icon,
   Pagination,
   SearchInput,
   ToggleGroup,
@@ -16,10 +15,11 @@ import {
   ToolbarContent,
   ToolbarItem,
 } from '@patternfly/react-core';
-import { CogIcon, SearchIcon, UserIcon } from '@patternfly/react-icons';
+import { SearchIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import { useDispatch } from 'react-redux';
 
+import { RH_ICON_SIZE } from '../../../../constants';
 import { useSearchRpmMutation } from '../../../../store/contentSourcesApi';
 import { useAppSelector } from '../../../../store/hooks';
 import {
@@ -282,21 +282,21 @@ const Packages = () => {
             {exactMatch.repository === 'distro' ? (
               <>
                 <Td>
-                  <Icon status="danger">
-                    <UserIcon />
-                  </Icon>{' '}
+                  <img
+                    src={
+                      '/apps/frontend-assets/red-hat-logos/logo_hat-only.svg'
+                    }
+                    alt="Red Hat logo"
+                    height={RH_ICON_SIZE}
+                    width={RH_ICON_SIZE}
+                  />{' '}
                   Red Hat repository
                 </Td>
                 <Td>Supported</Td>
               </>
             ) : (
               <>
-                <Td>
-                  <Icon>
-                    <CogIcon />
-                  </Icon>{' '}
-                  Custom repository
-                </Td>
+                <Td>Third party repository</Td>
                 <Td>Not supported</Td>
               </>
             )}
@@ -403,21 +403,21 @@ const Packages = () => {
                   {pkg.repository === 'distro' ? (
                     <>
                       <Td>
-                        <Icon status="danger">
-                          <UserIcon />
-                        </Icon>{' '}
+                        <img
+                          src={
+                            '/apps/frontend-assets/red-hat-logos/logo_hat-only.svg'
+                          }
+                          alt="Red Hat logo"
+                          height={RH_ICON_SIZE}
+                          width={RH_ICON_SIZE}
+                        />{' '}
                         Red Hat repository
                       </Td>
                       <Td>Supported</Td>
                     </>
                   ) : (
                     <>
-                      <Td>
-                        <Icon>
-                          <CogIcon />
-                        </Icon>{' '}
-                        Custom repository
-                      </Td>
+                      <Td>Third party repository</Td>
                       <Td>Not supported</Td>
                     </>
                   )}

--- a/src/constants.js
+++ b/src/constants.js
@@ -136,3 +136,5 @@ export const OCI_STORAGE_EXPIRATION_TIME_IN_DAYS = 7;
 export const MODAL_ANCHOR = '.pf-c-page.chr-c-page';
 
 export const STATUS_POLLING_INTERVAL = 8000;
+
+export const RH_ICON_SIZE = 16;


### PR DESCRIPTION
This updates the naming and the icons in the "Packages repository" column to be consistent with current mocks.

Before:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/9fe8d60b-ac33-48f8-adfa-674d068ab8dd)

After:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/95d9fc8f-b8ba-4977-a856-9c9d9c96048e)
