### PR TITLE
App: experimental features in beta only

### DIFF
--- a/src/Components/ImagesTable/EmptyState.tsx
+++ b/src/Components/ImagesTable/EmptyState.tsx
@@ -89,7 +89,7 @@ const EmptyImagesTable = () => {
           <Link
             to={resolveRelPath('imagewizard')}
             className="pf-c-button pf-m-primary"
-            data-testid="create-image-action"
+            data-testid="create-image-action-empty-state"
           >
             Create image
           </Link>

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -22,7 +22,6 @@ import {
   Thead,
   Tr,
 } from '@patternfly/react-table';
-import { useFlag } from '@unleash/proxy-client-react';
 import { Link, NavigateFunction, useNavigate } from 'react-router-dom';
 
 import './ImagesTable.scss';
@@ -58,7 +57,7 @@ import {
   computeHoursToExpiration,
   timestampToDisplayString,
 } from '../../Utilities/time';
-import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
+import { useExperimentalFlag } from '../../Utilities/useExperimentalFlag';
 import { BlueprintActionsMenu } from '../Blueprints/BlueprintActionsMenu';
 import { BuildImagesButton } from '../Blueprints/BuildImagesButton';
 import { DeleteBlueprintModal } from '../Blueprints/DeleteBlueprintModal';
@@ -86,8 +85,7 @@ const ImagesTable = ({
       }),
     }
   );
-  const experimentalFlag =
-    useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL;
+  const experimentalFlag = useExperimentalFlag();
   const onSetPage: OnSetPage = (_, page) => setPage(page);
 
   const onPerPageSelect: OnSetPage = (_, perPage) => {
@@ -498,10 +496,7 @@ const Row = ({
 }: RowPropTypes) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const handleToggle = () => setIsExpanded(!isExpanded);
-  const { isBeta } = useGetEnvironment();
-  const experimentalFlag =
-    (useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL) &&
-    isBeta();
+  const experimentalFlag = useExperimentalFlag();
   const navigate = useNavigate();
 
   return (

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -58,6 +58,7 @@ import {
   computeHoursToExpiration,
   timestampToDisplayString,
 } from '../../Utilities/time';
+import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
 import { BlueprintActionsMenu } from '../Blueprints/BlueprintActionsMenu';
 import { BuildImagesButton } from '../Blueprints/BuildImagesButton';
 import { DeleteBlueprintModal } from '../Blueprints/DeleteBlueprintModal';
@@ -497,8 +498,10 @@ const Row = ({
 }: RowPropTypes) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const handleToggle = () => setIsExpanded(!isExpanded);
+  const { isBeta } = useGetEnvironment();
   const experimentalFlag =
-    useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL;
+    (useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL) &&
+    isBeta();
   const navigate = useNavigate();
 
   return (

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -25,6 +25,7 @@ import Quickstarts from './Quickstarts';
 
 import { manageEdgeImagesUrlName } from '../../Utilities/edge';
 import { resolveRelPath } from '../../Utilities/path';
+import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
 import BlueprintsSidebar from '../Blueprints/BlueprintsSideBar';
 import EdgeImagesTable from '../edge/ImagesTable';
 import ImagesTable from '../ImagesTable/ImagesTable';
@@ -55,8 +56,10 @@ export const LandingPage = () => {
   >();
 
   const edgeParityFlag = useFlag('edgeParity.image-list');
+  const { isBeta } = useGetEnvironment();
   const experimentalFlag =
-    useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL;
+    (useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL) &&
+    isBeta();
 
   const traditionalImageList = (
     <>

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -25,7 +25,7 @@ import Quickstarts from './Quickstarts';
 
 import { manageEdgeImagesUrlName } from '../../Utilities/edge';
 import { resolveRelPath } from '../../Utilities/path';
-import { useGetEnvironment } from '../../Utilities/useGetEnvironment';
+import { useExperimentalFlag } from '../../Utilities/useExperimentalFlag';
 import BlueprintsSidebar from '../Blueprints/BlueprintsSideBar';
 import EdgeImagesTable from '../edge/ImagesTable';
 import ImagesTable from '../ImagesTable/ImagesTable';
@@ -56,10 +56,7 @@ export const LandingPage = () => {
   >();
 
   const edgeParityFlag = useFlag('edgeParity.image-list');
-  const { isBeta } = useGetEnvironment();
-  const experimentalFlag =
-    (useFlag('image-builder.new-wizard.enabled') || process.env.EXPERIMENTAL) &&
-    isBeta();
+  const experimentalFlag = useExperimentalFlag();
 
   const traditionalImageList = (
     <>

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -25,7 +25,7 @@ import { resolveRelPath } from '../../Utilities/path';
 import './ImageBuilderHeader.scss';
 
 type ImageBuilderHeaderPropTypes = {
-  experimentalFlag?: string | true | undefined;
+  experimentalFlag?: boolean;
 };
 
 export const ImageBuilderHeader = ({

--- a/src/Utilities/useExperimentalFlag.ts
+++ b/src/Utilities/useExperimentalFlag.ts
@@ -1,0 +1,26 @@
+import { useFlag } from '@unleash/proxy-client-react';
+
+import { useGetEnvironment } from './useGetEnvironment';
+
+/**
+ * @example
+ * // returns true
+ * toBoolean('true');
+ * @example
+ * // returns false
+ * toBoolean('FALSE');
+ * @example
+ * // returns false
+ * toBoolean(undefined);
+ */
+const toBoolean = (environmentVariable: string | undefined): boolean => {
+  return environmentVariable?.toLowerCase() === 'true';
+};
+
+export const useExperimentalFlag = () => {
+  const { isBeta } = useGetEnvironment();
+  const isExperimental = toBoolean(process.env.EXPERIMENTAL);
+  return (
+    (useFlag('image-builder.new-wizard.enabled') || isExperimental) && isBeta()
+  );
+};

--- a/src/test/Components/Blueprints/Blueprints.test.js
+++ b/src/test/Components/Blueprints/Blueprints.test.js
@@ -19,7 +19,7 @@ import '@testing-library/jest-dom';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   useChrome: () => ({
-    isBeta: () => false,
+    isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
   }),

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.azure.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.azure.test.tsx
@@ -45,7 +45,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
         };
       },
     },
-    isBeta: () => false,
+    isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
   }),

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.content.test.tsx
@@ -41,7 +41,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
         };
       },
     },
-    isBeta: () => false,
+    isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
   }),

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -61,7 +61,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
         };
       },
     },
-    isBeta: () => false,
+    isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
   }),

--- a/src/test/Components/CreateImageWizardV2/steps/Details/Details.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Details/Details.test.tsx
@@ -25,7 +25,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
         };
       },
     },
-    isBeta: () => false,
+    isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
   }),

--- a/src/test/Components/CreateImageWizardV2/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Packages/Packages.test.tsx
@@ -25,7 +25,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
         };
       },
     },
-    isBeta: () => false,
+    isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
   }),

--- a/src/test/Components/CreateImageWizardV2/steps/Registration/Registration.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Registration/Registration.test.tsx
@@ -28,7 +28,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
         };
       },
     },
-    isBeta: () => false,
+    isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
   }),

--- a/src/test/Components/CreateImageWizardV2/steps/Repositories/Repositories.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Repositories/Repositories.test.tsx
@@ -29,7 +29,7 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
         };
       },
     },
-    isBeta: () => false,
+    isBeta: () => true,
     isProd: () => true,
     getEnvironment: () => 'prod',
   }),

--- a/src/test/Components/LandingPage/LandingPage.test.js
+++ b/src/test/Components/LandingPage/LandingPage.test.js
@@ -37,7 +37,7 @@ describe('Landing Page', () => {
     renderWithReduxRouter('', {});
 
     // check action loads
-    await screen.findByTestId('create-image-action');
+    await screen.findByTestId('create-image-action-empty-state');
     // check table loads
     await screen.findByTestId('empty-state');
   });


### PR DESCRIPTION
When the unleash switch `image-builder.new-wizard.enabled` will get activated on stage the blueprint and new wizard will be visible on the platform.
To make them only visible in preview we need to change the condition to check if Beta is selected by the user.