### PR TITLE
V2Wizard: Remove aspectRatio

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseLifecycle.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseLifecycle.tsx
@@ -78,8 +78,7 @@ export const chartMajorVersionCfg = {
       },
     },
     responsive: true,
-    maintainAspectRatio: true,
-    aspectRatio: 1 | 5,
+    maintainAspectRatio: false,
     plugins: {
       tooltip: {
         enabled: false,


### PR DESCRIPTION
This removes aspectRatio from the ReleaseLifecycle chart. The set aspectRatio was causing incorrect rendering of the annotation line, making time travel during image building inevitable.