### PR TITLE
test: Increase timeout for CreateImageWizard test

### DIFF
--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -907,7 +907,7 @@ describe('Step Details', () => {
 
     expect(await getNextButton()).not.toHaveClass('pf-m-disabled');
     expect(await getNextButton()).toBeEnabled();
-  });
+  }, 20000);
 });
 
 describe('Step Review', () => {


### PR DESCRIPTION
The "Step Details image name invalid for more than 63 chars" is often timing out. The timeout was already increased in V2, this makes the same change for V1.