### PR TITLE
Blueprints Table: Minor fixes (HMS-3385)

### DIFF
--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -3,9 +3,6 @@ import React, { useState, useCallback } from 'react';
 import {
   Bullseye,
   Button,
-  Card,
-  CardHeader,
-  CardTitle,
   EmptyState,
   EmptyStateActions,
   EmptyStateBody,
@@ -106,23 +103,14 @@ const BlueprintsSidebar = ({
               />
             </StackItem>
             <StackItem>
-              <Card
-                ouiaId={`blueprint-card-all`}
-                isCompact
-                isClickable
+              <Button
+                ouiaId={`clear-selected-blueprint-button`}
+                variant="link"
                 isDisabled={!selectedBlueprint}
+                onClick={() => setSelectedBlueprint(undefined)}
               >
-                <CardHeader
-                  selectableActions={{
-                    selectableActionId: 'show-all-card',
-                    name: 'blueprints',
-                    variant: 'single',
-                    onClickAction: () => setSelectedBlueprint(undefined),
-                  }}
-                >
-                  <CardTitle component="a">Clear selection</CardTitle>
-                </CardHeader>
-              </Card>
+                Clear selection
+              </Button>
             </StackItem>
           </>
         )}

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -180,15 +180,17 @@ const ImagesTable = ({
         />
         <Toolbar>
           <ToolbarContent>
-            <ToolbarItem>
-              <Link
-                to={resolveRelPath('imagewizard')}
-                className="pf-c-button pf-m-primary"
-                data-testid="create-image-action"
-              >
-                Create image
-              </Link>
-            </ToolbarItem>
+            {!experimentalFlag && (
+              <ToolbarItem>
+                <Link
+                  to={resolveRelPath('imagewizard')}
+                  className="pf-c-button pf-m-primary"
+                  data-testid="create-image-action"
+                >
+                  Create image
+                </Link>
+              </ToolbarItem>
+            )}
             {experimentalFlag && (
               <>
                 <ToolbarItem>

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -72,9 +72,6 @@ export const LandingPage = () => {
   const experimentalImageList = (
     <>
       <PageSection>
-        <Quickstarts />
-      </PageSection>
-      <PageSection>
         <Sidebar hasBorder className="pf-v5-u-background-color-100">
           <SidebarPanel hasPadding width={{ default: 'width_25' }}>
             <BlueprintsSidebar

--- a/src/test/Components/Blueprints/Blueprints.test.js
+++ b/src/test/Components/Blueprints/Blueprints.test.js
@@ -195,7 +195,7 @@ describe('Blueprints', () => {
 
       // wait for debounce
       await waitFor(() => {
-        expect(screen.getAllByRole('radio')).toHaveLength(2);
+        expect(screen.getAllByRole('radio')).toHaveLength(1);
       });
     });
   });


### PR DESCRIPTION
Three simple commits:
1. Removes quickstarts
2. Removes `Create image` button from table
3. Changes `Clear selection` card to button

![image](https://github.com/osbuild/image-builder-frontend/assets/95542540/ea887a77-495c-483e-a07c-8f9745a2f565)
