### PR TITLE
Blueprints table: Add title (HMS-3385)

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -11,6 +11,7 @@ import {
   Spinner,
   Bullseye,
   Badge,
+  Title,
 } from '@patternfly/react-core';
 import {
   ActionsColumn,
@@ -179,6 +180,9 @@ const ImagesTable = ({
           isOpen={showDeleteModal}
         />
         <Toolbar>
+          <ToolbarContent>
+            <Title headingLevel="h1">All image types</Title>
+          </ToolbarContent>
           <ToolbarContent>
             {!experimentalFlag && (
               <ToolbarItem>


### PR DESCRIPTION
Adds title to blueprints table. Later we will need to extract this into a new component that changes the value depending on whether a blueprint is selected or not (if blueprint is selected, it will need to show blueprint name).

![image](https://github.com/osbuild/image-builder-frontend/assets/95542540/1e0f0363-22f4-4212-a8fc-24e1851a3bcf)
