### PR TITLE
Blueprint: Empty state action is link now

### DIFF
--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -72,14 +72,13 @@ const BlueprintsSidebar = () => {
         action={
           <Link
             to={resolveRelPath('imagewizard')}
-            className="pf-c-button pf-m-primary"
-            data-testid="create-image-action"
+            data-testid="create-blueprint-action-emptystate"
           >
-            Create
+            Add blueprint
           </Link>
         }
         titleText="No blueprints yet"
-        bodyText="To get started, create a blueprint."
+        bodyText="Add a blueprint and optionally build related images."
       />
     );
   }

--- a/src/test/Components/Blueprints/Blueprints.test.js
+++ b/src/test/Components/Blueprints/Blueprints.test.js
@@ -60,6 +60,9 @@ describe('Blueprints', () => {
     await screen.findByText(blueprintNameEmptyComposes);
   });
   test('renders blueprint empty state', async () => {
+    // scrollTo is not defined in jsdom - needed for the navigation to the wizard
+    window.HTMLElement.prototype.scrollTo = function () {};
+
     server.use(
       rest.get(
         `${IMAGE_BUILDER_API}/experimental/blueprints`,
@@ -69,8 +72,17 @@ describe('Blueprints', () => {
       )
     );
 
-    renderWithReduxRouter('', {});
+    const { router } = await renderWithReduxRouter('', {});
     await screen.findByText('No blueprints yet');
+    const emptyStateAction = screen.getByRole('link', {
+      name: /Add blueprint/i,
+    });
+    expect(emptyStateAction).toBeInTheDocument();
+
+    await user.click(emptyStateAction);
+    expect(router.state.location.pathname).toBe(
+      '/insights/image-builder/imagewizard'
+    );
   });
   test('renders blueprint composes', async () => {
     renderWithReduxRouter('', {});


### PR DESCRIPTION
Convert Empty state action to a link and add test for it.

![Screenshot from 2024-03-06 13-59-16](https://github.com/osbuild/image-builder-frontend/assets/2884324/fae396f4-f30b-4f9e-a18c-1633714aa821)
