### PR TITLE
Blueprints Table: Add "new" alert

### DIFF
--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -21,6 +21,7 @@ import { Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import './LandingPage.scss';
 
+import { NewAlert } from './NewAlert';
 import Quickstarts from './Quickstarts';
 
 import { manageEdgeImagesUrlName } from '../../Utilities/edge';
@@ -69,6 +70,9 @@ export const LandingPage = () => {
   const experimentalImageList = (
     <>
       <PageSection>
+        <NewAlert />
+      </PageSection>
+      <PageSection className="pf-v5-u-pt-0">
         <Sidebar hasBorder className="pf-v5-u-background-color-100">
           <SidebarPanel hasPadding width={{ default: 'width_25' }}>
             <BlueprintsSidebar />

--- a/src/Components/LandingPage/NewAlert.tsx
+++ b/src/Components/LandingPage/NewAlert.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+
+import { Alert, Text } from '@patternfly/react-core';
+
+export const NewAlert = () => {
+  return (
+    <Alert title="New in Images: Blueprints!">
+      <Text>
+        Blueprints make it easier for you to manage your images. Images expire
+        after two weeks, but blueprints last forever. Create a blueprint for
+        your “golden image”, modify it over time as your needs change, and use
+        it to build and deploy images on demand.
+      </Text>
+    </Alert>
+  );
+};


### PR DESCRIPTION
Adds an alert to explain the basic concept of blueprints to users. Actual copy (and presence of emojis) is pending feedback from UX/copy, this is just a placeholder for now.
![image](https://github.com/osbuild/image-builder-frontend/assets/95542540/a5943ff1-8fcd-4405-98f0-e044439cdba5)
