### PR TITLE
V2Wizard: Gate table title behind experimental

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -178,9 +178,11 @@ const ImagesTable = () => {
           isOpen={showDeleteModal}
         />
         <Toolbar>
-          <ToolbarContent>
-            <Title headingLevel="h1">All image types</Title>
-          </ToolbarContent>
+          {experimentalFlag && (
+            <ToolbarContent>
+              <Title headingLevel="h1">All image types</Title>
+            </ToolbarContent>
+          )}
           <ToolbarContent>
             {!experimentalFlag && (
               <ToolbarItem>


### PR DESCRIPTION
This adds gating the ImagesTable title behind experimental so it doesn't render in the "classic" table.