### PR TITLE
Blueprints: keep blueprint card selected after editing (HMS-3385)

### DIFF
--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -31,9 +31,15 @@ const BlueprintCard = ({ blueprint }: blueprintProps) => {
   const [, { isLoading }] = useDeleteBlueprintMutation({
     fixedCacheKey: 'delete-blueprint',
   });
+
   return (
     <>
-      <Card ouiaId={`blueprint-card-${blueprint.id}`} isCompact isClickable>
+      <Card
+        isSelected={blueprint.id === selectedBlueprintId}
+        ouiaId={`blueprint-card-${blueprint.id}`}
+        isCompact
+        isClickable
+      >
         <CardHeader
           data-testid={blueprint.id}
           selectableActions={{


### PR DESCRIPTION
Fixes #1770.

If you select a blueprint, edit it, and return to the table, the blueprint should still be selected and its images should appear in the table. 

This fixes a bug where the blueprint card was not selected upon returning to the table after editing. Note that the images table was showing only the images associated with that blueprint as intended.