### PR TITLE
deps: Remove @types/uuid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,6 @@
         "@types/react": "18.2.64",
         "@types/react-dom": "18.2.21",
         "@types/react-redux": "7.1.33",
-        "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "7.1.0",
         "@typescript-eslint/parser": "7.1.1",
         "babel-jest": "29.7.0",
@@ -4861,12 +4860,6 @@
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==",
-      "dev": true
     },
     "node_modules/@types/webpack": {
       "version": "4.41.34",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@types/react": "18.2.64",
     "@types/react-dom": "18.2.21",
     "@types/react-redux": "7.1.33",
-    "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "7.1.0",
     "@typescript-eslint/parser": "7.1.1",
     "babel-jest": "29.7.0",


### PR DESCRIPTION
This removes @types/uuid from devDependencies. The dependency was initially added as a part of https://github.com/osbuild/image-builder-frontend/pull/1658, but the import which caused the addition was later removed from the code.