### PR TITLE
Wizard: Add FSC alert for bare metal images

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
@@ -302,6 +302,12 @@ const FileSystemConfiguration = ({ ...props }) => {
     return <Spinner size="lg" />;
   }
 
+  const hasIsoTarget = () => {
+    const isoTarget =
+      getState().values['target-environment']?.['image-installer'];
+    return isoTarget;
+  };
+
   return (
     <FormSpy>
       {() => (
@@ -355,6 +361,13 @@ const FileSystemConfiguration = ({ ...props }) => {
               </Button>
             </Text>
           </TextContent>
+          {hasIsoTarget() && (
+            <Alert
+              variant="warning"
+              isInline
+              title="Filesystem customizations are not applied to 'Bare metal - Installer' images"
+            />
+          )}
           <Table
             aria-label="File system table"
             className={isDragging && styles.modifiers.dragOver}


### PR DESCRIPTION
FSC customisations are not being applied to bare metal - installer images, this adds an alert to make users aware of the fact.

![fsc-alert](https://github.com/osbuild/image-builder-frontend/assets/49452678/2bac4d55-f17c-490c-9c29-fb3ebf3b8c64)