### PR TITLE
V2Wizard: Add FSC alert for bare metal images

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemConfiguration.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import {
+  Alert,
   Button,
   Popover,
   Text,
@@ -22,6 +23,7 @@ import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
   changePartitionMinSize,
   changePartitionMountpoint,
+  selectImageTypes,
   selectPartitions,
 } from '../../../../store/wizardSlice';
 import UsrSubDirectoriesDisabled from '../../UsrSubDirectoriesDisabled';
@@ -35,6 +37,7 @@ export type Partition = {
 
 const FileSystemConfiguration = () => {
   const partitions = useAppSelector((state) => selectPartitions(state));
+  const environments = useAppSelector((state) => selectImageTypes(state));
 
   return (
     <>
@@ -67,6 +70,13 @@ const FileSystemConfiguration = () => {
           </Button>
         </Text>
       </TextContent>
+      {environments.includes('image-installer') && (
+        <Alert
+          variant="warning"
+          isInline
+          title="Filesystem customizations are not applied to 'Bare metal - Installer' images"
+        />
+      )}
       <Table aria-label="File system table" variant="compact">
         <Thead>
           <Tr>


### PR DESCRIPTION
This mirrors the functionality of https://github.com/osbuild/image-builder-frontend/pull/1786 in V2Wizard.

An alert was added to the FSC step to make users aware that customisations are not being applied to bare metal - installer images.

![v2-fsc-alert](https://github.com/osbuild/image-builder-frontend/assets/49452678/b3ec6098-5ef5-4e41-8124-26c4e1e8cc72)
