### PR TITLE
V1 Wizard: Add search parameter for arch selection (HMS-3684)

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ArchSelect.js
+++ b/src/Components/CreateImageWizard/formComponents/ArchSelect.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { FormSpy } from '@data-driven-forms/react-form-renderer';
 import useFieldApi from '@data-driven-forms/react-form-renderer/use-field-api';
@@ -10,13 +10,23 @@ import {
   SelectVariant,
 } from '@patternfly/react-core/deprecated';
 import PropTypes from 'prop-types';
+import { useSearchParams } from 'react-router-dom';
 
-import { ARCHS } from '../../../constants';
+import { ARCHS, AARCH64 } from '../../../constants';
 
 const ArchSelect = ({ label, isRequired, ...props }) => {
   const { change, getState } = useFormApi();
   const { input } = useFieldApi(props);
   const [isOpen, setIsOpen] = useState(false);
+
+  const [searchParams] = useSearchParams();
+
+  // Set the architecture via search parameter
+  // Used by Insights assistant or external hyperlinks (access.redhat.com, developers.redhat.com)
+  const preloadArch = searchParams.get('arch');
+  useEffect(() => {
+    preloadArch === AARCH64 && change(input.name, AARCH64);
+  }, [change, input.name, preloadArch]);
 
   const setArch = (_, selection) => {
     change(input.name, selection);

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1685,3 +1685,31 @@ describe('set release using query parameter', () => {
     await screen.findByText('Red Hat Enterprise Linux (RHEL) 8');
   });
 });
+describe('set architecture using query parameter', () => {
+  test('x86_64 by default (no query parameter)', async () => {
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
+    await screen.findByText('x86_64');
+  });
+
+  test('x86_64 by default (invalid query parameter)', async () => {
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard?arch=arm',
+      {},
+      routes
+    ));
+    await screen.findByText('x86_64');
+  });
+
+  test('aarch64 (query parameter provided)', async () => {
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard?arch=aarch64',
+      {},
+      routes
+    ));
+    await screen.findByText('aarch64');
+  });
+});


### PR DESCRIPTION
Add an optional search parameter to the wizard like so:

```
/insights/image-builder/imagewizard?arch=aarch64
```

This results in the wizard being opened and `aarch64` being pre-selected as the architecture (as opposed to the default `x86_64`). The Insights assistant chat bot and our websites (access.redhat.com and developers.redhat.com) will make use of this feature.

This has been shamelessly cargo-culted from 349377267251a395e2b96a8f1afb97af85a8f401