### PR TITLE
ESLint: Turn ban-ts-comment rule on

### DIFF
--- a/.eslintrc-typescript.yml
+++ b/.eslintrc-typescript.yml
@@ -3,5 +3,11 @@ extends: [
   ]
 
 rules:
-  "@typescript-eslint/ban-ts-comment": off
+  "@typescript-eslint/ban-ts-comment":
+    - error
+    - ts-expect-error: 'allow-with-description'
+      ts-ignore: 'allow-with-description'
+      ts-nocheck: true
+      ts-check: true
+      minimumDescriptionLength: 5
   "@typescript-eslint/ban-types": off

--- a/src/Components/CreateImageWizard/formComponents/Oscap.tsx
+++ b/src/Components/CreateImageWizard/formComponents/Oscap.tsx
@@ -111,8 +111,7 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
     change('kernel', undefined);
     change('disabledServices', undefined);
     change('enabledServices', undefined);
-    // @ts-ignore
-    setProfileName(undefined);
+    setProfileName('');
     reinitDependingSteps(change);
   };
 

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTables.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTables.tsx
@@ -15,12 +15,15 @@ type repoPropType = {
 };
 
 const RepoName = ({ repoUrl }: repoPropType) => {
-  const { data, isSuccess, isFetching, isError } = useListRepositoriesQuery({
-    // @ts-ignore
-    url: repoUrl,
-    contentType: 'rpm',
-    origin: 'external',
-  });
+  const { data, isSuccess, isFetching, isError } = useListRepositoriesQuery(
+    {
+      // @ts-ignore if repoUrl is undefined the query is going to get skipped, so it's safe to ignore the linter here
+      url: repoUrl,
+      contentType: 'rpm',
+      origin: 'external',
+    },
+    { skip: !repoUrl }
+  );
 
   const errorLoading = () => {
     return (

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
@@ -516,7 +516,7 @@ export const RegisterNowList = () => {
     })();
   });
   const { isError } = useShowActivationKeyQuery(
-    // @ts-ignore - type of 'activationKey' might not be strictly compatible with the expected type for 'name'.
+    // @ts-ignore type of 'activationKey' might not be strictly compatible with the expected type for 'name'.
     { name: activationKey },
     {
       skip: !activationKey,

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureResourceGroups.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureResourceGroups.tsx
@@ -24,8 +24,7 @@ export const AzureResourceGroups = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const { data: sourceDetails, isFetching } = useGetSourceUploadInfoQuery(
-    // @ts-ignore
-    { id: azureSource },
+    { id: parseInt(azureSource as string) },
     {
       skip: !azureSource,
     }

--- a/src/store/enhancedImageBuilderApi.ts
+++ b/src/store/enhancedImageBuilderApi.ts
@@ -50,8 +50,7 @@ const enhancedApi = imageBuilderApi.enhanceEndpoints({
         queryFulfilled
           .then(() => {
             dispatch(
-              // Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
-              // @ts-expect-error
+              // @ts-expect-error Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
               imageBuilderApi.util.invalidateTags(['Blueprints', 'Blueprint'])
             );
             dispatch(
@@ -78,8 +77,7 @@ const enhancedApi = imageBuilderApi.enhanceEndpoints({
       onQueryStarted: async (_, { dispatch, queryFulfilled }) => {
         queryFulfilled
           .then(() => {
-            // Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
-            // @ts-expect-error
+            // @ts-expect-error Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
             dispatch(imageBuilderApi.util.invalidateTags(['Blueprints']));
             dispatch(
               addNotification({
@@ -110,8 +108,7 @@ const enhancedApi = imageBuilderApi.enhanceEndpoints({
           .then(() => {
             dispatch(
               imageBuilderApi.util.invalidateTags([
-                // Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
-                // @ts-expect-error
+                // @ts-expect-error Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
                 { type: 'Clone', id: composeId },
               ])
             );
@@ -169,8 +166,7 @@ const enhancedApi = imageBuilderApi.enhanceEndpoints({
         queryFulfilled
           .then(() => {
             dispatch(
-              // Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
-              // @ts-expect-error
+              // @ts-expect-error Typescript is unaware of tag types being defined concurrently in enhanceEndpoints()
               imageBuilderApi.util.invalidateTags(['Blueprints', 'Compose'])
             );
             dispatch(


### PR DESCRIPTION
This turns ban-ts-comment rule on, adds some configuration to it and fixes the errors caused by changing linting.

The current rule allows ts-expect-error and ts-ignore, but only when accompanied by a description with a minimum length of 5 characters.