### PR TITLE
V2 Wizard: Add search parameter for arch selection (HMS-3684)

### DIFF
--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -31,11 +31,12 @@ import {
   isGcpEmailValid,
 } from './validators';
 
-import { RHEL_8 } from '../../constants';
+import { RHEL_8, AARCH64 } from '../../constants';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import './CreateImageWizard.scss';
 import {
   changeDistribution,
+  changeArchitecture,
   initializeWizard,
   selectActivationKey,
   selectAwsAccountId,
@@ -102,6 +103,8 @@ const CreateImageWizard = ({ startStepIndex = 1 }: CreateImageWizardProps) => {
     dispatch(initializeWizard());
     searchParams.get('release') === 'rhel8' &&
       dispatch(changeDistribution(RHEL_8));
+    searchParams.get('arch') === AARCH64 &&
+      dispatch(changeArchitecture(AARCH64));
     // This useEffect hook should run *only* on mount and therefore has an empty
     // dependency array. eslint's exhaustive-deps rule does not support this use.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -276,3 +276,20 @@ describe('set release using query parameter', () => {
     await screen.findByText('Red Hat Enterprise Linux (RHEL) 8');
   });
 });
+
+describe('set architecture using query parameter', () => {
+  test('x86_64 by default (no query parameter)', async () => {
+    await render();
+    await screen.findByText('x86_64');
+  });
+
+  test('x86_64 by default (invalid query parameter)', async () => {
+    await render({ arch: 'arm' });
+    await screen.findByText('x86_64');
+  });
+
+  test('aarch64 (query parameter provided)', async () => {
+    await render({ arch: 'aarch64' });
+    await screen.findByText('aarch64');
+  });
+});


### PR DESCRIPTION
Add an optional search parameter to the wizard like so:

/insights/image-builder/imagewizard?arch=aarch64

This results in the wizard being opened and 'aarch64' being pre-selected as the architecture. The Insights assistant chat bot and our websites (access.redhat.com and developers.redhat.com) will make use of this feature.

This is a follow-up of #1798, porting the same functionality to the v2 wizard.