### PR TITLE
fixes(HMS-3778): Show image name only after it is loaded

### DIFF
--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -99,7 +99,7 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
       <Toolbar>
         <ToolbarContent>
           <Title headingLevel="h1">
-            {selectedBlueprintId
+            {selectedBlueprintName
               ? `${selectedBlueprintName} images`
               : 'All images'}
           </Title>


### PR DESCRIPTION
Sometimes, when the response from the API was a bit slow, and the name was not yet loaded, while the id was selected, this would end up by showing "undefined images".