### PR TITLE
V2Wizard: Add search parameter for target selection (HMS-3684)

### DIFF
--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -53,6 +53,7 @@ import {
   selectGcpShareMethod,
   selectImageTypes,
   selectRegistrationType,
+  addImageType,
 } from '../../store/wizardSlice';
 import { resolveRelPath } from '../../Utilities/path';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
@@ -105,6 +106,10 @@ const CreateImageWizard = ({ startStepIndex = 1 }: CreateImageWizardProps) => {
       dispatch(changeDistribution(RHEL_8));
     searchParams.get('arch') === AARCH64 &&
       dispatch(changeArchitecture(AARCH64));
+    searchParams.get('target') === 'iso' &&
+      dispatch(addImageType('image-installer'));
+    searchParams.get('target') === 'qcow' &&
+      dispatch(addImageType('guest-image'));
     // This useEffect hook should run *only* on mount and therefore has an empty
     // dependency array. eslint's exhaustive-deps rule does not support this use.
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -108,7 +108,7 @@ const CreateImageWizard = ({ startStepIndex = 1 }: CreateImageWizardProps) => {
       dispatch(changeArchitecture(AARCH64));
     searchParams.get('target') === 'iso' &&
       dispatch(addImageType('image-installer'));
-    searchParams.get('target') === 'qcow' &&
+    searchParams.get('target') === 'qcow2' &&
       dispatch(addImageType('guest-image'));
     // This useEffect hook should run *only* on mount and therefore has an empty
     // dependency array. eslint's exhaustive-deps rule does not support this use.

--- a/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -338,7 +338,7 @@ describe('set target using query parameter', () => {
   });
 
   test('guest-installer (query parameter provided)', async () => {
-    await render({ target: 'qcow' });
+    await render({ target: 'qcow2' });
     await clickToReview();
     const targetExpandable = await screen.findByRole('button', {
       name: /Target environments/,


### PR DESCRIPTION
Add an optional search parameter to the wizard like so:

`/insights/image-builder/imagewizard?target=iso`
or
`/insights/image-builder/imagewizard?target=qcow`

This results in wizard being opened and iso or qcow target being pre-selected. The Insights assistant chat bot will make use of this feature.