### PR TITLE
V1Wizard: Add search parameter for target selection (HMS-3684)

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
+++ b/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
@@ -18,6 +18,7 @@ import {
 import { HelpIcon } from '@patternfly/react-icons';
 import PropTypes from 'prop-types';
 import { useField } from 'react-final-form';
+import { useSearchParams } from 'react-router-dom';
 
 import { useGetArchitecturesQuery } from '../../../store/imageBuilderApi';
 import { provisioningApi } from '../../../store/provisioningApi';
@@ -62,6 +63,16 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
   const prefetchSources = provisioningApi.usePrefetch('getSourceList');
   const { isBeta } = useGetEnvironment();
   const release = getState()?.values?.release;
+
+  const [searchParams] = useSearchParams();
+
+  // Set the target via search parameter
+  // Used by Insights assistant or external hyperlinks (access.redhat.com, developers.redhat.com)
+  const preloadTarget = searchParams.get('target');
+  useEffect(() => {
+    preloadTarget === 'iso' && handleSetEnvironment('image-installer', true);
+    preloadTarget === 'qcow' && handleSetEnvironment('guest-image', true);
+  }, [preloadTarget]);
 
   useEffect(() => {
     if (getState()?.values?.[input.name]) {

--- a/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
+++ b/src/Components/CreateImageWizard/formComponents/TargetEnvironment.js
@@ -71,7 +71,7 @@ const TargetEnvironment = ({ label, isRequired, ...props }) => {
   const preloadTarget = searchParams.get('target');
   useEffect(() => {
     preloadTarget === 'iso' && handleSetEnvironment('image-installer', true);
-    preloadTarget === 'qcow' && handleSetEnvironment('guest-image', true);
+    preloadTarget === 'qcow2' && handleSetEnvironment('guest-image', true);
   }, [preloadTarget]);
 
   useEffect(() => {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1612,7 +1612,7 @@ describe('set target using query parameter', () => {
 
   test('guest-installer (query parameter provided)', async () => {
     ({ router } = await renderCustomRoutesWithReduxRouter(
-      'imagewizard?target=qcow',
+      'imagewizard?target=qcow2',
       {},
       routes
     ));


### PR DESCRIPTION
Add an optional search parameter to the V1Wizard like so:

`/insights/image-builder/imagewizard?target=iso`
or
`/insights/image-builder/imagewizard?target=qcow`

This results in wizard being opened and iso or qcow target being pre-selected. The Insights assistant chat bot will make use of this feature.