### PR TITLE
V2Wizard: Initialize packages with OpenSCAP

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
@@ -34,6 +34,10 @@ import {
   selectEnabledServices,
   changeDisabledServices,
   changeEnabledServices,
+  clearOscapPackages,
+  addPackage,
+  selectPackages,
+  removePackage,
 } from '../../../../store/wizardSlice';
 
 const ProfileSelector = () => {
@@ -42,6 +46,7 @@ const ProfileSelector = () => {
   let disabledServices = useAppSelector(selectDisabledServices);
   let enabledServices = useAppSelector(selectEnabledServices);
   const release = useAppSelector(selectDistribution);
+  const packages = useAppSelector(selectPackages);
   const dispatch = useAppDispatch();
   const [profileName, setProfileName] = useState<string | undefined>('None');
   const [isOpen, setIsOpen] = useState(false);
@@ -96,6 +101,25 @@ const ProfileSelector = () => {
     }
   }, [data]);
 
+  useEffect(() => {
+    dispatch(clearOscapPackages());
+    for (const pkg in data?.packages) {
+      if (
+        packages.map((pkg) => pkg.name).includes(data?.packages[Number(pkg)])
+      ) {
+        dispatch(removePackage(data?.packages[Number(pkg)]));
+      }
+      dispatch(
+        addPackage({
+          name: data?.packages[Number(pkg)],
+          summary: 'Required by chosen OpenSCAP profile',
+          repository: 'distro',
+          isRequiredByOpenScap: true,
+        })
+      );
+    }
+  }, [data?.packages, dispatch]);
+
   const handleToggle = () => {
     if (!isOpen) {
       refetch();
@@ -108,6 +132,7 @@ const ProfileSelector = () => {
     dispatch(changeKernel(undefined));
     dispatch(changeDisabledServices(undefined));
     dispatch(changeEnabledServices(undefined));
+    dispatch(clearOscapPackages());
     setProfileName(undefined);
   };
 

--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -36,10 +36,13 @@ import {
   addPackage,
 } from '../../../../store/wizardSlice';
 
+type PackageRepository = 'distro' | 'custom' | '';
+
 export type IBPackageWithRepositoryInfo = {
   name: Package['name'];
   summary: Package['summary'];
-  repository: string;
+  repository: PackageRepository;
+  isRequiredByOpenScap: boolean;
 };
 
 const EmptySearch = () => {
@@ -180,6 +183,7 @@ const Packages = () => {
       transformedDistroData = dataDistroPackages.data.map((values) => ({
         ...values,
         repository: 'distro',
+        isRequiredByOpenScap: false,
       }));
     }
 
@@ -188,6 +192,7 @@ const Packages = () => {
         name: values.package_name!,
         summary: values.summary!,
         repository: 'custom',
+        isRequiredByOpenScap: false,
       }));
     }
 

--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -247,7 +247,7 @@ const Packages = () => {
     if (isSelecting) {
       dispatch(addPackage(pkg));
     } else {
-      dispatch(removePackage(pkg));
+      dispatch(removePackage(pkg.name));
     }
   };
 

--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -156,6 +156,7 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
         name: pkg,
         summary: '',
         repository: '',
+        isRequiredByOpenScap: false,
       })) || [],
   };
 };

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -455,10 +455,10 @@ export const wizardSlice = createSlice({
     },
     removePackage: (
       state,
-      action: PayloadAction<IBPackageWithRepositoryInfo>
+      action: PayloadAction<IBPackageWithRepositoryInfo['name']>
     ) => {
       state.packages.splice(
-        state.packages.findIndex((pkg) => pkg.name === action.payload.name),
+        state.packages.findIndex((pkg) => pkg.name === action.payload),
         1
       );
     },

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -462,6 +462,11 @@ export const wizardSlice = createSlice({
         1
       );
     },
+    clearOscapPackages: (state) => {
+      state.packages = state.packages.filter(
+        (pkg) => pkg.isRequiredByOpenScap !== true
+      );
+    },
     changeBlueprintName: (state, action: PayloadAction<string>) => {
       state.details.blueprintName = action.payload;
     },
@@ -509,6 +514,7 @@ export const {
   changePayloadRepositories,
   addPackage,
   removePackage,
+  clearOscapPackages,
   changeBlueprintName,
   changeBlueprintDescription,
   loadWizardState,

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.compliance.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.compliance.test.tsx
@@ -106,12 +106,16 @@ describe('Step Compliance', () => {
     //   })
     //   ).not.toBeInTheDocument();
 
+    await clickNext(); // skip Repositories
+
     // check that there are no Packages contained when selecting the "None" profile option
-    //   await clickNext();
-    //  await screen.findByRole('heading', {
-    //    name: /Additional Red Hat packages/i,
-    //   });
-    //  await screen.findByText(/no packages added/i);
+    await clickNext();
+    await screen.findByRole('heading', {
+      name: /Additional packages/i,
+    });
+    await screen.findByText(
+      /Search above to add additionalpackages to your image/
+    );
   });
 
   test('create an image with an oscap profile', async () => {
@@ -165,14 +169,16 @@ describe('Step Compliance', () => {
     //    await screen.findByRole('heading', { name: /File system configuration/i });
     //   await screen.findByText(/tmp/i);
 
-    // check that the Packages contain a nftable package
-    //  await clickNext();
+    await clickNext(); // skip Repositories
 
-    //   await screen.findByRole('heading', {
-    //     name: /Additional Red Hat packages/i,
-    //   });
-    //   await screen.findByText(/nftables/i);
-    //    await screen.findByText(/libselinux/i);
+    // check that the Packages contain a nftable package
+    await clickNext();
+    await screen.findByRole('heading', {
+      name: /Additional packages/i,
+    });
+    await user.click(await screen.findByText('Selected'));
+    await screen.findByText(/nftables/i);
+    await screen.findByText(/libselinux/i);
   });
 });
 //


### PR DESCRIPTION
This initializes packages upon a selection of an OpenSCAP profile.

Current logic also fixes a bug previously present in V1 - when changing an OpenSCAP profile with other previously chosen packages, the packages outside of the profile persist and don't get removed.