### PR TITLE
V1Wizard: masked services -> disabled services (HMS-3661)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -103,17 +103,12 @@ const onSave = (values) => {
     if (
       (Array.isArray(values['enabledServices']) &&
         values['enabledServices'].length > 0) ||
-      (Array.isArray(values['disabledServices']) &&
-        values['disabledServices'].length > 0) ||
       (Array.isArray(values['maskedServices']) &&
         values['maskedServices'].length > 0)
     ) {
       customizations.services = {};
       if (values['enabledServices'].length > 0) {
         customizations.services.enabled = values['enabledServices'];
-      }
-      if (values['disabledServices'].length > 0) {
-        customizations.services.disabled = values['disabledServices'];
       }
       if (values['maskedServices'].length > 0) {
         customizations.services.masked = values['maskedServices'];
@@ -540,8 +535,6 @@ const requestToState = (composeRequest, isProd, enableOscap) => {
       formState['kernel'] = composeRequest?.customizations?.kernel;
       formState['enabledServices'] =
         composeRequest?.customizations?.services?.enabled;
-      formState['disabledServices'] =
-        composeRequest?.customizations?.services?.disabled;
       formState['maskedServices'] =
         composeRequest?.customizations?.services?.masked;
     }

--- a/src/Components/CreateImageWizard/formComponents/Oscap.tsx
+++ b/src/Components/CreateImageWizard/formComponents/Oscap.tsx
@@ -93,9 +93,6 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
     if (data?.services?.enabled) {
       change('enabledServices', data.services.enabled);
     }
-    if (data?.services?.disabled) {
-      change('disabledServices', data.services.disabled);
-    }
     if (data?.services?.masked) {
       change('maskedServices', data.services.masked);
     }
@@ -112,7 +109,6 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
     setProfile(undefined);
     change(input.name, undefined);
     change('kernel', undefined);
-    change('disabledServices', undefined);
     change('enabledServices', undefined);
     change('maskedServices', undefined);
     setProfileName('');

--- a/src/Components/CreateImageWizard/formComponents/OscapProfileInformation.tsx
+++ b/src/Components/CreateImageWizard/formComponents/OscapProfileInformation.tsx
@@ -34,8 +34,6 @@ const OscapProfileInformation = (): JSX.Element => {
 
   const enabledServicesDisplayString =
     oscapProfileInfo?.services?.enabled?.join(' ');
-  const disabledServicesDisplayString =
-    oscapProfileInfo?.services?.disabled?.join(' ');
   const maskedServicesDisplayString =
     oscapProfileInfo?.services?.masked?.join(' ');
 
@@ -95,7 +93,7 @@ const OscapProfileInformation = (): JSX.Element => {
               </TextListItem>
               <TextListItem component={TextListItemVariants.dd}>
                 <CodeBlock>
-                  <CodeBlockCode>{disabledServicesDisplayString}</CodeBlockCode>
+                  <CodeBlockCode>{maskedServicesDisplayString}</CodeBlockCode>
                 </CodeBlock>
               </TextListItem>
               <TextListItem
@@ -107,17 +105,6 @@ const OscapProfileInformation = (): JSX.Element => {
               <TextListItem component={TextListItemVariants.dd}>
                 <CodeBlock>
                   <CodeBlockCode>{enabledServicesDisplayString}</CodeBlockCode>
-                </CodeBlock>
-              </TextListItem>
-              <TextListItem
-                component={TextListItemVariants.dt}
-                className="pf-u-min-width"
-              >
-                Masked services:
-              </TextListItem>
-              <TextListItem component={TextListItemVariants.dd}>
-                <CodeBlock>
-                  <CodeBlockCode>{maskedServicesDisplayString}</CodeBlockCode>
                 </CodeBlock>
               </TextListItem>
             </TextList>

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
@@ -155,10 +155,9 @@ describe('Step Compliance', () => {
     );
     await screen.findByText(/kernel arguments:/i);
     await screen.findByText(/audit_backlog_limit=8192 audit=1/i);
-    await screen.findByText(/nfs-server/i);
     await screen.findByText(/disabled services:/i);
+    await screen.findByText(/nfs-server/i);
     await screen.findByText(/enabled services:/i);
-    await screen.findByText(/masked services:/i);
     await screen.findByText(/crond/i);
 
     // check that the FSC contains a /tmp partition

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.compliance.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.compliance.test.tsx
@@ -157,7 +157,6 @@ describe('Step Compliance', () => {
     await screen.findByText(/kernel arguments:/i);
     await screen.findByText(/audit_backlog_limit=8192 audit=1/i);
     await screen.findByText(/disabled services:/i);
-    await screen.findByText(/nfs-server/i);
     await screen.findByText(/enabled services:/i);
     await screen.findByText(/crond/i);
 

--- a/src/test/fixtures/oscap.ts
+++ b/src/test/fixtures/oscap.ts
@@ -36,7 +36,7 @@ export const oscapCustomizations = (
         append: 'audit_backlog_limit=8192 audit=1',
       },
       services: {
-        disabled: ['nfs-server'],
+        masked: ['nfs-server'],
         enabled: ['crond'],
       },
     };


### PR DESCRIPTION
For the UX the user doesn't really need to know that the services are masked, rather than disabled in the backend. We can simplify this and show the masked services as disabled.