### PR TITLE
Experimental: fix the ability to force experimental in developement

### DIFF
--- a/src/Utilities/useExperimentalFlag.ts
+++ b/src/Utilities/useExperimentalFlag.ts
@@ -19,7 +19,7 @@ const toBoolean = (environmentVariable: string | undefined): boolean => {
 
 export const useExperimentalFlag = () => {
   const { isBeta } = useGetEnvironment();
-  const isExperimental = toBoolean(process.env.EXPERIMENTAL);
+  const isExperimental = toBoolean(process.env.EXPERIMENTAL?.toString());
   return (
     (useFlag('image-builder.new-wizard.enabled') || isExperimental) && isBeta()
   );


### PR DESCRIPTION
The useExperimental broken the ability to enforce experimental on developement environment, it is a good idea to be able to do so at least for now.
This fixes it.