### PR TITLE
fix one warning at useEffect on Oscap file

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Oscap.tsx
+++ b/src/Components/CreateImageWizard/formComponents/Oscap.tsx
@@ -96,7 +96,7 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
     if (data?.services?.masked) {
       change('maskedServices', data.services.masked);
     }
-  }, [data]);
+  }, [data, change]);
 
   const handleToggle = () => {
     if (!isOpen) {


### PR DESCRIPTION
this commit fix a warning-
React Hook useEffect has a missing dependency: 'change'. Either include it or remove the dependency array  react-hooks/exhaustive-deps