### PR TITLE
store: Turn off immutableCheck and serializableCheck 

### DIFF
--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -86,7 +86,10 @@ startAppListening({
 // Listener middleware must be prepended according to RTK docs:
 // https://redux-toolkit.js.org/api/createListenerMiddleware#basic-usage
 export const middleware = (getDefaultMiddleware: Function) =>
-  getDefaultMiddleware()
+  getDefaultMiddleware({
+    immutableCheck: false,
+    serializableCheck: false,
+  })
     .prepend(listenerMiddleware.middleware)
     .concat(
       promiseMiddleware,


### PR DESCRIPTION
This turns off immutableCheck and serializableCheck which removes warnings `SerializableStateInvariantMiddleware took XXms, which is more than the warning threshold of 32ms.` from the test output.

Another option would be to disable the middleware in development mode as it can causes a slowdown.