### PR TITLE
Wizard: Resolve deprecation warning in test output

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/ReleaseLifecycle.tsx
+++ b/src/Components/CreateImageWizard/formComponents/ReleaseLifecycle.tsx
@@ -30,7 +30,7 @@ import { toMonthAndYear } from '../../../Utilities/time';
 Chart.register(annotationPlugin);
 Chart.register(...registerables);
 
-const currentDate = new Date().toString();
+const currentDate = new Date().toISOString();
 
 export const chartMajorVersionCfg = {
   data: {

--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseLifecycle.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/ReleaseLifecycle.tsx
@@ -26,7 +26,7 @@ import 'chartjs-adapter-moment';
 Chart.register(annotationPlugin);
 Chart.register(...registerables);
 
-const currentDate = new Date().toString();
+const currentDate = new Date().toISOString();
 
 export const chartMajorVersionCfg = {
   data: {


### PR DESCRIPTION
This resolves the following warning: `Deprecation warning: value provided is not in a recognized RFC2822 or ISO format.` in test output.