### PR TITLE
fix(HMS-3851): remove 'recreate image' from kebab dropdown

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -426,6 +426,7 @@ type AwsRowPropTypes = {
 
 const AwsRow = ({ compose, composeStatus, rowIndex }: AwsRowPropTypes) => {
   const navigate = useNavigate();
+  const experimentalFlag = useExperimentalFlag();
 
   const target = <AwsTarget compose={compose} />;
 
@@ -436,7 +437,9 @@ const AwsRow = ({ compose, composeStatus, rowIndex }: AwsRowPropTypes) => {
   const details = <AwsDetails compose={compose} />;
 
   const actions = (
-    <ActionsColumn items={awsActions(compose, composeStatus, navigate)} />
+    <ActionsColumn
+      items={awsActions(compose, composeStatus, navigate, experimentalFlag)}
+    />
   );
 
   return (
@@ -507,7 +510,9 @@ const Row = ({
           {actions ? (
             actions
           ) : (
-            <ActionsColumn items={defaultActions(compose, navigate)} />
+            <ActionsColumn
+              items={defaultActions(compose, navigate, experimentalFlag)}
+            />
           )}
         </Td>
       </Tr>
@@ -522,14 +527,19 @@ const Row = ({
 
 const defaultActions = (
   compose: ComposesResponseItem,
-  navigate: NavigateFunction
+  navigate: NavigateFunction,
+  experimentalFlag: boolean
 ) => [
-  {
-    title: 'Recreate image',
-    onClick: () => {
-      navigate(resolveRelPath(`imagewizard/${compose.id}`));
-    },
-  },
+  ...(experimentalFlag
+    ? []
+    : [
+        {
+          title: 'Recreate image',
+          onClick: () => {
+            navigate(resolveRelPath(`imagewizard/${compose.id}`));
+          },
+        },
+      ]),
   {
     title: (
       <a
@@ -548,14 +558,15 @@ const defaultActions = (
 const awsActions = (
   compose: ComposesResponseItem,
   status: ComposeStatus | undefined,
-  navigate: NavigateFunction
+  navigate: NavigateFunction,
+  experimentalFlag: boolean
 ) => [
   {
     title: 'Share to new region',
     onClick: () => navigate(resolveRelPath(`share/${compose.id}`)),
     isDisabled: status?.image_status.status === 'success' ? false : true,
   },
-  ...defaultActions(compose, navigate),
+  ...defaultActions(compose, navigate, experimentalFlag),
 ];
 
 export default ImagesTable;


### PR DESCRIPTION
This PR solves issue #1824 and removes the `recreate image` option.

![Screenshot 2024-03-27 at 19 15 34](https://github.com/osbuild/image-builder-frontend/assets/11807069/73adc8b3-8a03-40d2-ad29-cd9b5886aad0)

As you can see, `Download compose request` is the only left item, but I'm not sure what is the point to keep it? Blueprints import/export should replace it, no?