### PR TITLE
Blueprints: Add test ids

### DIFF
--- a/src/Components/Blueprints/BlueprintActionsMenu.tsx
+++ b/src/Components/Blueprints/BlueprintActionsMenu.tsx
@@ -45,6 +45,7 @@ export const BlueprintActionsMenu: React.FunctionComponent<
           onClick={() => setShowBlueprintActionsMenu(!showBlueprintActionsMenu)}
           variant="plain"
           aria-label="blueprint menu toggle"
+          data-testid="blueprint-action-menu-toggle"
           isDisabled={selectedBlueprintId === undefined}
         >
           <EllipsisVIcon aria-hidden="true" />

--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -167,6 +167,7 @@ const BlueprintSearch = ({ blueprintsTotal }: blueprintSearchProps) => {
       onChange={(_event, value) => onChange(value)}
       onClear={() => onChange('')}
       resultsCount={`${blueprintsTotal} blueprints`}
+      data-testid="blueprints-search-input"
     />
   );
 };

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -99,7 +99,7 @@ export const ImageBuilderHeader = ({
                 <Link
                   to={resolveRelPath('imagewizard')}
                   className="pf-c-button pf-m-tertiary"
-                  data-testid="create-image-action"
+                  data-testid="blueprints-create-button"
                 >
                   Create
                 </Link>


### PR DESCRIPTION
This updates the data-testid of Create button in the header (`Link` component, not OUIA-compliant) and adds a data-testid to the blueprint search input (`SearchInput` component, also not OUIA-compliant).

A testId was also added to the blueprint actions dropdown (`MenuToggle`).