### PR TITLE
Minor improvements to Blueprints UI (HMS-3848)

### DIFF
--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -52,7 +52,6 @@ const BlueprintCard = ({ blueprint }: blueprintProps) => {
             {isLoading && blueprint.id === selectedBlueprintId && (
               <Spinner size="md" />
             )}
-            &nbsp;&nbsp;
             {blueprint.name}
           </CardTitle>
         </CardHeader>

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -196,7 +196,7 @@ const ImagesTable = () => {
         <Table variant="compact" data-testid="images-table">
           <Thead>
             <Tr>
-              <Th />
+              <Th style={{ minWidth: itemCount === 0 ? '30px' : 'auto' }} />
               <Th>Image name</Th>
               <Th>Created/Updated</Th>
               <Th>Release</Th>

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -101,7 +101,7 @@ export const ImageBuilderHeader = ({
                   className="pf-c-button pf-m-tertiary"
                   data-testid="blueprints-create-button"
                 >
-                  Create
+                  Create blueprint
                 </Link>
               </FlexItem>
               <FlexItem>


### PR DESCRIPTION
The position of each header for the images table differs based on the content. We might want to try and have it fixed (percentage?), but I think it might make sense to leave the formatting based on the content. Therefore, only for empty table, I tried to make it a bit more consistent. Let me know what you think about hardcoding this.