### PR TITLE
V2Wizard: Update "Too many results" copy

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -51,7 +51,7 @@ const EmptySearch = () => {
             <EmptyStateBody>
               Search above to add additional
               <br />
-              packages to your image
+              packages to your image.
             </EmptyStateBody>
           </EmptyState>
         </Bullseye>
@@ -67,7 +67,7 @@ const NoResultsFound = () => {
         <Bullseye>
           <EmptyState variant={EmptyStateVariant.sm}>
             <EmptyStateHeader titleText="No results found" headingLevel="h4" />
-            <EmptyStateBody>Adjust your search and try again</EmptyStateBody>
+            <EmptyStateBody>Adjust your search and try again.</EmptyStateBody>
           </EmptyState>
         </Bullseye>
       </Td>
@@ -82,11 +82,33 @@ const TooManyResults = () => {
         <Bullseye>
           <EmptyState variant={EmptyStateVariant.sm}>
             <EmptyStateHeader
+              icon={<EmptyStateIcon icon={SearchIcon} />}
               titleText="Too many results to display"
               headingLevel="h4"
             />
             <EmptyStateBody>
-              Please make the search more specific and try again
+              Please make the search more specific and try again.
+            </EmptyStateBody>
+          </EmptyState>
+        </Bullseye>
+      </Td>
+    </Tr>
+  );
+};
+
+const TooManyResultsWithExactMatch = () => {
+  return (
+    <Tr>
+      <Td colSpan={4}>
+        <Bullseye>
+          <EmptyState variant={EmptyStateVariant.sm}>
+            <EmptyStateHeader
+              titleText="Too many results to display"
+              headingLevel="h4"
+            />
+            <EmptyStateBody>
+              To see more results, please make the search more specific and try
+              again.
             </EmptyStateBody>
           </EmptyState>
         </Bullseye>
@@ -301,7 +323,7 @@ const Packages = () => {
               </>
             )}
           </Tr>
-          <TooManyResults />
+          <TooManyResultsWithExactMatch />
         </>
       );
     } else {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
@@ -177,7 +177,6 @@ describe('Step Packages', () => {
 
     test('should display default state', async () => {
       await setUp();
-
       await screen.findByText(
         'Search above to add additionalpackages to your image'
       );

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.content.test.tsx
@@ -190,7 +190,7 @@ describe('Step Packages', () => {
     await setUp();
 
     await screen.findByText(
-      'Search above to add additionalpackages to your image'
+      'Search above to add additionalpackages to your image.'
     );
   });
 


### PR DESCRIPTION
This updates copy shown in a table when too many results are fetched. Also a period was added to the end of the empty state bodies.

Without an exact match
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/d1686821-0dbd-44b5-b0a1-f9cc21425078)

With an exact match
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/d50f0155-b07f-4ea8-b67c-7c9b8f3d4e91)
