### PR TITLE
fixes(HMS-3853): fix blueprint clear selection

### DIFF
--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -39,15 +39,12 @@ const BlueprintCard = ({ blueprint }: blueprintProps) => {
         ouiaId={`blueprint-card-${blueprint.id}`}
         isCompact
         isClickable
+        onClick={() => dispatch(setBlueprintId(blueprint.id))}
+        isSelectableRaised
+        hasSelectableInput
+        selectableInputAriaLabel={`Select blueprint ${blueprint.name}`}
       >
-        <CardHeader
-          data-testid={blueprint.id}
-          selectableActions={{
-            selectableActionId: blueprint.id,
-            name: 'blueprints',
-            onClickAction: () => dispatch(setBlueprintId(blueprint.id)),
-          }}
-        >
+        <CardHeader data-testid={blueprint.id}>
           <CardTitle>
             {isLoading && blueprint.id === selectedBlueprintId && (
               <Spinner size="md" />

--- a/src/test/Components/Blueprints/Blueprints.test.js
+++ b/src/test/Components/Blueprints/Blueprints.test.js
@@ -33,17 +33,9 @@ jest.mock('@unleash/proxy-client-react', () => ({
 }));
 
 const selectBlueprintById = async (user, bpId) => {
-  const nameMatcher = (_, element) =>
-    element.getAttribute('name') === 'blueprints';
-
-  const radioButtons = await screen.findAllByRole('radio', {
-    name: nameMatcher,
-  });
-  const elementById = radioButtons.find(
-    (button) => button.getAttribute('id') === bpId
-  );
-  await user.click(elementById);
-  return elementById;
+  const blueprint = await screen.findByTestId(bpId);
+  await user.click(blueprint);
+  return blueprint;
 };
 
 describe('Blueprints', () => {
@@ -182,7 +174,9 @@ describe('Blueprints', () => {
       // wait for debounce
       await waitFor(
         () => {
-          expect(screen.getAllByRole('radio')).toHaveLength(1);
+          expect(
+            screen.getByTestId(blueprintIdEmptyComposes)
+          ).toBeInTheDocument();
         },
         {
           timeout: 1500,
@@ -195,7 +189,7 @@ describe('Blueprints', () => {
     test('paging of blueprints', async () => {
       renderWithReduxRouter('', {});
 
-      expect(await screen.findAllByRole('radio')).toHaveLength(10);
+      expect(await screen.findAllByRole('checkbox')).toHaveLength(10);
 
       const option = await screen.findByTestId('blueprints-pagination-bottom');
       const prevButton = within(option).getByRole('button', {
@@ -218,7 +212,7 @@ describe('Blueprints', () => {
       await user.click(button);
 
       await waitFor(() => {
-        expect(screen.getAllByRole('radio')).toHaveLength(1);
+        expect(screen.getAllByRole('checkbox')).toHaveLength(1);
       });
     });
   });


### PR DESCRIPTION
This PR fixes https://github.com/osbuild/image-builder-frontend/issues/1766 and happens due to [patternfly's bug](https://github.com/patternfly/patternfly-react/issues/9875)
For a workaround i used deprecated ` isSelectableRaised` and ` hasSelectableInput` props, which recommended by patternfly team.