### PR TITLE
V1Wizard: Add full bottom pagination to Repositories

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/Repositories.js
+++ b/src/Components/CreateImageWizard/formComponents/Repositories.js
@@ -23,6 +23,7 @@ import {
   EmptyStateFooter,
   ToggleGroup,
   ToggleGroupItem,
+  PaginationVariant,
 } from '@patternfly/react-core';
 import {
   Dropdown,
@@ -427,7 +428,6 @@ const Repositories = (props) => {
                     perPage={perPage}
                     page={page}
                     onSetPage={handleSetPage}
-                    widgetId="compact-example"
                     onPerPageSelect={handlePerPageSelect}
                     isCompact
                   />
@@ -522,6 +522,14 @@ const Repositories = (props) => {
                 </Table>
               </PanelMain>
             </Panel>
+            <Pagination
+              itemCount={filteredRepositoryURLs.length}
+              perPage={perPage}
+              page={page}
+              onSetPage={handleSetPage}
+              onPerPageSelect={handlePerPageSelect}
+              variant={PaginationVariant.bottom}
+            />
           </>
         )}
       </>

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.js
@@ -1016,7 +1016,7 @@ describe('Step Custom repositories', () => {
     const firstRepoCheckbox = await getFirstRepoCheckbox();
 
     const getNextPageButton = async () =>
-      await screen.findByRole('button', {
+      await screen.findAllByRole('button', {
         name: /go to next page/i,
       });
 
@@ -1026,7 +1026,7 @@ describe('Step Custom repositories', () => {
     await user.click(firstRepoCheckbox);
     expect(firstRepoCheckbox.checked).toEqual(true);
 
-    await user.click(nextPageButton);
+    await user.click(nextPageButton[0]);
 
     const getSelectedButton = async () =>
       await screen.findByRole('button', {


### PR DESCRIPTION
This adds a full pagination to the bottom of the Repositories step. This allows the user to get to the very end of the repositories list easily.