### PR TITLE
V2Wizard: Center messages in packages table (HMS-2781)

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -44,7 +44,7 @@ export type IBPackageWithRepositoryInfo = {
 const EmptySearch = () => {
   return (
     <Tr>
-      <Td colSpan={4}>
+      <Td colSpan={5}>
         <Bullseye>
           <EmptyState variant={EmptyStateVariant.sm}>
             <EmptyStateHeader icon={<EmptyStateIcon icon={SearchIcon} />} />
@@ -63,7 +63,7 @@ const EmptySearch = () => {
 const NoResultsFound = () => {
   return (
     <Tr>
-      <Td colSpan={4}>
+      <Td colSpan={5}>
         <Bullseye>
           <EmptyState variant={EmptyStateVariant.sm}>
             <EmptyStateHeader titleText="No results found" headingLevel="h4" />
@@ -78,7 +78,7 @@ const NoResultsFound = () => {
 const TooManyResults = () => {
   return (
     <Tr>
-      <Td colSpan={4}>
+      <Td colSpan={5}>
         <Bullseye>
           <EmptyState variant={EmptyStateVariant.sm}>
             <EmptyStateHeader
@@ -99,7 +99,7 @@ const TooManyResults = () => {
 const TooManyResultsWithExactMatch = () => {
   return (
     <Tr>
-      <Td colSpan={4}>
+      <Td colSpan={5}>
         <Bullseye>
           <EmptyState variant={EmptyStateVariant.sm}>
             <EmptyStateHeader


### PR DESCRIPTION
The copy in the packages table (too many results to show, etc...) was not centered because the table actually has 5 columns, not 4. This fixes the problem.

![image](https://github.com/osbuild/image-builder-frontend/assets/95542540/f630edc6-4a75-4b95-af21-90d3ec4b4570)
