### PR TITLE
WizardV2: add 'register-later' to state mapper

### DIFF
--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -144,9 +144,11 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
       payloadRepositories: request.customizations.payload_repositories || [],
     },
     registration: {
-      registrationType: request.customizations?.subscription?.rhc
-        ? 'register-now-rhc'
-        : 'register-now-insights',
+      registrationType: request.customizations?.subscription
+        ? request.customizations.subscription.rhc
+          ? 'register-now-rhc'
+          : 'register-now-insights'
+        : 'register-later',
       activationKey: request.customizations.subscription?.['activation-key'],
     },
     packages:


### PR DESCRIPTION
Fix #1865 

This PR maps the `register-later` subscription type during editing.