### PR TITLE
Blueprints: No Build Image button without a blueprint

### DIFF
--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -104,22 +104,22 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
               : 'All images'}
           </Title>
         </ToolbarContent>
-        <ToolbarContent>
-          <ToolbarItem>
-            <BuildImagesButton />
-          </ToolbarItem>
-          <ToolbarItem>
-            <BlueprintActionsMenu setShowDeleteModal={setShowDeleteModal} />
-          </ToolbarItem>
-          {selectedBlueprintId && (
+        {selectedBlueprintId && (
+          <ToolbarContent>
+            <ToolbarItem>
+              <BuildImagesButton />
+            </ToolbarItem>
+            <ToolbarItem>
+              <BlueprintActionsMenu setShowDeleteModal={setShowDeleteModal} />
+            </ToolbarItem>
             <ToolbarItem>
               <BlueprintVersionFilter onFilterChange={() => setPage(1)} />
             </ToolbarItem>
-          )}
-          <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
-            {pagination}
-          </ToolbarItem>
-        </ToolbarContent>
+            <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+              {pagination}
+            </ToolbarItem>
+          </ToolbarContent>
+        )}
       </Toolbar>
     </>
   );


### PR DESCRIPTION
This hides the Build Image button and blueprint actions kabob when no blueprint is selected as per recent mocks.

mocks:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/efa4a857-ae16-442d-9c50-c6f58c8f06b3)
