### PR TITLE
Blueprints: Rename Clear selection button and center it

### DIFF
--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -9,6 +9,8 @@ import {
   EmptyStateFooter,
   EmptyStateHeader,
   EmptyStateIcon,
+  Flex,
+  FlexItem,
   SearchInput,
   Spinner,
   Stack,
@@ -100,14 +102,18 @@ const BlueprintsSidebar = () => {
               <BlueprintSearch blueprintsTotal={blueprintsTotal} />
             </StackItem>
             <StackItem>
-              <Button
-                ouiaId={`clear-selected-blueprint-button`}
-                variant="link"
-                isDisabled={!selectedBlueprintId}
-                onClick={() => dispatch(setBlueprintId(undefined))}
-              >
-                Clear selection
-              </Button>
+              <Flex justifyContent={{ default: 'justifyContentCenter' }}>
+                <FlexItem>
+                  <Button
+                    ouiaId={`clear-selected-blueprint-button`}
+                    variant="link"
+                    isDisabled={!selectedBlueprintId}
+                    onClick={() => dispatch(setBlueprintId(undefined))}
+                  >
+                    View all
+                  </Button>
+                </FlexItem>
+              </Flex>
             </StackItem>
           </>
         )}


### PR DESCRIPTION
This renames the Clear selection button in the blueprints side bar and aligns it to the center.

mocks: 
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/3bacac4e-033f-4ad1-84f2-139b7e4cc288)