### PR TITLE
WizardV2: map oscap to wizard request

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Button, Form, Text, Title } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
@@ -10,9 +10,14 @@ import { useAppSelector } from '../../../../store/hooks';
 import { selectDistribution } from '../../../../store/wizardSlice';
 
 const OscapStep = () => {
-  const prefetchOscapProfile = imageBuilderApi.usePrefetch('getOscapProfiles');
+  const prefetchOscapProfile = imageBuilderApi.usePrefetch(
+    'getOscapProfiles',
+    {}
+  );
   const release = useAppSelector(selectDistribution);
-  prefetchOscapProfile({ distribution: release });
+  useEffect(() => {
+    prefetchOscapProfile({ distribution: release });
+  }, []);
 
   return (
     <Form>

--- a/src/Components/CreateImageWizardV2/steps/Review/Footer/Footer.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/Footer/Footer.tsx
@@ -16,6 +16,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import CreateDropdown from './CreateDropdown';
 import EditDropdown from './EditDropdown';
 
+import { useServerStore } from '../../../../../store/hooks';
 import {
   useCreateBlueprintMutation,
   useUpdateBlueprintMutation,
@@ -33,6 +34,9 @@ const ReviewWizardFooter = () => {
       reset: resetCreate,
     },
   ] = useCreateBlueprintMutation({ fixedCacheKey: 'createBlueprintKey' });
+
+  // initialize the server store with the data from RTK query
+  const serverStore = useServerStore();
   const [
     ,
     {
@@ -61,7 +65,7 @@ const ReviewWizardFooter = () => {
   const getBlueprintPayload = async () => {
     const userData = await auth?.getUser();
     const orgId = userData?.identity?.internal?.org_id;
-    const requestBody = orgId && mapRequestFromState(store, orgId);
+    const requestBody = orgId && mapRequestFromState(store, orgId, serverStore);
     return requestBody;
   };
 

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,7 +1,37 @@
 import { useDispatch, useSelector } from 'react-redux';
 
+import { useGetOscapCustomizationsQuery } from './imageBuilderApi';
+import { selectDistribution, selectProfile } from './wizardSlice';
+
 import type { RootState, AppDispatch } from './index';
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();
+
+// common hooks
+export const useOscapData = () => {
+  const release = useAppSelector(selectDistribution);
+  const openScapProfile = useAppSelector(selectProfile);
+  const { data } = useGetOscapCustomizationsQuery(
+    {
+      distribution: release,
+      // @ts-ignore if openScapProfile is undefined the query is going to get skipped
+      profile: openScapProfile,
+    },
+    { skip: !openScapProfile }
+  );
+  if (!openScapProfile) return undefined;
+  return {
+    kernel: { append: data?.kernel?.append },
+    services: {
+      enabled: data?.services?.enabled,
+      disabled: data?.services?.disabled,
+    },
+  };
+};
+
+export const useServerStore = () => {
+  const oscap = useOscapData();
+  return { ...oscap };
+};

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -66,13 +66,6 @@ export type wizardState = {
   };
   openScap: {
     profile: DistributionProfileItem | undefined;
-    kernel: {
-      kernelAppend: string | undefined;
-    };
-    services: {
-      disabled: string[] | undefined;
-      enabled: string[] | undefined;
-    };
   };
   fileSystem: {
     mode: FileSystemPartitionMode;
@@ -122,13 +115,6 @@ const initialState: wizardState = {
   },
   openScap: {
     profile: undefined,
-    kernel: {
-      kernelAppend: '',
-    },
-    services: {
-      disabled: [],
-      enabled: [],
-    },
   },
   fileSystem: {
     mode: 'automatic',
@@ -221,18 +207,6 @@ export const selectActivationKey = (state: RootState) => {
 
 export const selectProfile = (state: RootState) => {
   return state.wizard.openScap.profile;
-};
-
-export const selectKernel = (state: RootState) => {
-  return state.wizard.openScap.kernel.kernelAppend;
-};
-
-export const selectDisabledServices = (state: RootState) => {
-  return state.wizard.openScap.services.disabled;
-};
-
-export const selectEnabledServices = (state: RootState) => {
-  return state.wizard.openScap.services.enabled;
 };
 
 export const selectFileSystemPartitionMode = (state: RootState) => {
@@ -370,21 +344,6 @@ export const wizardSlice = createSlice({
       state.openScap.profile = action.payload;
     },
 
-    changeKernel: (state, action: PayloadAction<string | undefined>) => {
-      state.openScap.kernel.kernelAppend = action.payload;
-    },
-    changeDisabledServices: (
-      state,
-      action: PayloadAction<string[] | undefined>
-    ) => {
-      state.openScap.services.disabled = action.payload;
-    },
-    changeEnabledServices: (
-      state,
-      action: PayloadAction<string[] | undefined>
-    ) => {
-      state.openScap.services.enabled = action.payload;
-    },
     changeFileSystemConfiguration: (
       state,
       action: PayloadAction<Partition[]>
@@ -527,9 +486,6 @@ export const {
   changeRegistrationType,
   changeActivationKey,
   changeOscapProfile,
-  changeKernel,
-  changeDisabledServices,
-  changeEnabledServices,
   changeFileSystemConfiguration,
   setIsNextButtonTouched,
   changeFileSystemPartitionMode,


### PR DESCRIPTION
This PR adds the Openscap step to the wizard request mapper, enabling creation and editing.
I simplify the Openscap component, by reducing the duplicated data in RTK query and wizard slice.
I added a fixed `max-height` for better scrolling, and added description for each policy.


https://github.com/osbuild/image-builder-frontend/assets/11807069/c36b7d1e-56d8-4bb2-be3f-d19fc3b4aab8

