### PR TITLE
V2Wizard: Fix VMware capitalisation

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
@@ -163,7 +163,7 @@ const TargetEnvironment = () => {
             data-testid="target-private"
           >
             <Checkbox
-              label="VMWare vSphere"
+              label="VMware vSphere"
               isChecked={
                 environments.includes('vsphere') ||
                 environments.includes('vsphere-ova')
@@ -172,9 +172,9 @@ const TargetEnvironment = () => {
                 setHasVSphere(!hasVSphere);
                 handleToggleEnvironment('vsphere-ova');
               }}
-              aria-label="VMWare checkbox"
+              aria-label="VMware checkbox"
               id="checkbox-vmware"
-              name="VMWare"
+              name="VMware"
               data-testid="checkbox-vmware"
             />
           </FormGroup>
@@ -185,7 +185,7 @@ const TargetEnvironment = () => {
             {supportedEnvironments?.includes('vsphere-ova') && (
               <Radio
                 name="vsphere-radio"
-                aria-label="VMWare vSphere radio button OVA"
+                aria-label="VMware vSphere radio button OVA"
                 id="vsphere-radio-ova"
                 label={
                   <>
@@ -197,7 +197,7 @@ const TargetEnvironment = () => {
                         <TextContent>
                           <Text>
                             An OVA file is a virtual appliance used by
-                            virtualization platforms such as VMWare vSphere. It
+                            virtualization platforms such as VMware vSphere. It
                             is a package that contains files used to describe a
                             virtual machine, which includes a VMDK image, OVF
                             descriptor file and a manifest file.
@@ -225,7 +225,7 @@ const TargetEnvironment = () => {
             <Radio
               className="pf-u-mt-sm"
               name="vsphere-radio"
-              aria-label="VMWare vSphere radio button VMDK"
+              aria-label="VMware vSphere radio button VMDK"
               id="vsphere-radio-vmdk"
               label={
                 <>


### PR DESCRIPTION
This replaces VMWare -> VMware as per mocks.

mocks:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/eda2f1f1-18f5-43f6-bed4-c302afce73bc)
