### PR TITLE
Promote OpenSCAP to prod stable (HMS-2077)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.js
+++ b/src/Components/CreateImageWizard/CreateImageWizard.js
@@ -614,8 +614,7 @@ const CreateImageWizard = () => {
 
   // Only allow oscap to be used in Beta even if the flag says the feature is
   // activated.
-  const oscapFeatureFlag =
-    useFlag('image-builder.wizard.oscap.enabled') && isBeta();
+  const oscapFeatureFlag = useFlag('image-builder.wizard.oscap.enabled');
   let initialState = requestToState(composeRequest, isProd(), oscapFeatureFlag);
   const stepHistory = formStepHistory(
     composeRequest,

--- a/src/Components/CreateImageWizard/formComponents/Oscap.tsx
+++ b/src/Components/CreateImageWizard/formComponents/Oscap.tsx
@@ -197,16 +197,27 @@ const ProfileSelector = ({ input }: ProfileSelectorProps) => {
                 key="oscap-none-option"
               />,
             ].concat(
-              profiles.map((profile_id, index) => {
-                return (
-                  <OScapSelectOption
-                    key={index}
-                    profile_id={profile_id}
-                    setProfileName={setProfileName}
-                    input={value}
-                  />
-                );
-              })
+              profiles
+                // stig and stig_gui don't boot at the moment,
+                // so we should filter them out
+                .filter((profile_id) => {
+                  const brokenProfiles = [
+                    'xccdf_org.ssgproject.content_profile_stig',
+                    'xccdf_org.ssgproject.content_profile_stig_gui',
+                  ];
+
+                  return !brokenProfiles.includes(profile_id);
+                })
+                .map((profile_id, index) => {
+                  return (
+                    <OScapSelectOption
+                      key={index}
+                      profile_id={profile_id}
+                      setProfileName={setProfileName}
+                      input={value}
+                    />
+                  );
+                })
             );
           }
         }}


### PR DESCRIPTION
- disable `stig` and `stig_gui` profiles since they don't boot
- ~add `firewalld` to packages needed for `PCI-DSS` profile.~
- promote OpenSCAP to prod stable

I removed the second step since https://github.com/osbuild/image-builder/pull/1110 landed