### PR TITLE
V2Wizard: Fix plural sources

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/index.tsx
@@ -72,7 +72,7 @@ const Aws = () => {
           id="radio-with-description"
           label="Use an account configured from Sources."
           name="radio-7"
-          description="Use a configured sources to launch environments directly from the console."
+          description="Use a configured source to launch environments directly from the console."
           isChecked={shareMethod === 'sources'}
           onChange={() => {
             dispatch(changeAwsSourceId(undefined));

--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/index.tsx
@@ -95,7 +95,7 @@ const Azure = () => {
           id="radio-with-description"
           label="Use an account configured from Sources."
           name="radio-7"
-          description="Use a configured sources to launch environments directly from the console."
+          description="Use a configured source to launch environments directly from the console."
           isChecked={shareMethod === 'sources'}
           onChange={() => {
             dispatch(changeAzureSource(''));


### PR DESCRIPTION
We're actually selecting a singular source to share the image with. It's the same in V1 wizard.