### PR TITLE
POC: use snapshot testing for wizard request

### DIFF
--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -12,7 +12,10 @@ import {
 import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 
-import { enterBlueprintName } from './wizardTestUtils';
+import {
+  createBlueprintCreationSnapshot,
+  enterBlueprintName,
+} from './wizardTestUtils';
 
 import CreateImageWizard from '../../../Components/CreateImageWizardV2/CreateImageWizard';
 import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
@@ -438,7 +441,7 @@ describe('Step Upload to AWS', () => {
     await user.click(
       await screen.findByRole('button', { name: /Save changes to blueprint/ })
     );
-
+    createBlueprintCreationSnapshot();
     // returns back to the landing page
     await waitFor(() =>
       expect(router?.state.location.pathname).toBe('/insights/image-builder')

--- a/src/test/Components/CreateImageWizardV2/__snapshots__/CreateImageWizard.test.tsx.snap
+++ b/src/test/Components/CreateImageWizardV2/__snapshots__/CreateImageWizard.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Step Upload to AWS compose request share_with_sources field is correct 1`] = `
+{
+  "customizations": {},
+  "description": "",
+  "distribution": "rhel-93",
+  "image_requests": [
+    {
+      "architecture": "x86_64",
+      "image_type": "aws",
+      "upload_request": {
+        "options": {
+          "share_with_sources": [
+            "123",
+          ],
+        },
+        "type": "aws",
+      },
+    },
+  ],
+  "name": "Red Velvet",
+}
+`;

--- a/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
@@ -111,3 +111,17 @@ export const interceptBlueprintRequest = async (requestPathname: string) => {
 
   return await receivedRequestPromise;
 };
+
+declare global {
+  interface Global {
+    requestBodyForTest: CreateBlueprintRequest | undefined;
+  }
+}
+
+
+export const createBlueprintCreationSnapshot = async () => {
+  // @ts-ignore
+  expect(global.requestBodyForTest).toBeDefined();
+ // @ts-ignore
+  expect(global.requestBodyForTest).toMatchSnapshot();
+};

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -153,10 +153,12 @@ export const handlers = [
       return res(ctx.status(200));
     }
   ),
-  rest.post(CREATE_BLUEPRINT, (req, res, ctx) => {
+  rest.post(CREATE_BLUEPRINT, async (req, res, ctx) => {
     const response = {
       id: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
     };
+    const requestBody = await req.json();
+    global.requestBodyForTest = requestBody;
     return res(ctx.status(201), ctx.json(response));
   }),
   rest.get(


### PR DESCRIPTION
This is a POC for using snapshot testing to allow an easy way to test wizard's request permutations.