### PR TITLE
ImagesTable: Update column headers

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -197,9 +197,9 @@ const ImagesTable = () => {
           <Thead>
             <Tr>
               <Th style={{ minWidth: itemCount === 0 ? '30px' : 'auto' }} />
-              <Th>Image name</Th>
-              <Th>Created/Updated</Th>
-              <Th>Release</Th>
+              <Th>Name</Th>
+              <Th>Updated</Th>
+              <Th>OS</Th>
               <Th>Target</Th>
               {experimentalFlag && <Th>Version</Th>}
               <Th>Status</Th>

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -53,9 +53,9 @@ describe('Images Table', () => {
     // remove first row from list since it is just header labels
     const header = rows.shift();
     // test the header has correct labels
-    expect(header.cells[1]).toHaveTextContent('Image name');
-    expect(header.cells[2]).toHaveTextContent('Created');
-    expect(header.cells[3]).toHaveTextContent('Release');
+    expect(header.cells[1]).toHaveTextContent('Name');
+    expect(header.cells[2]).toHaveTextContent('Updated');
+    expect(header.cells[3]).toHaveTextContent('OS');
     expect(header.cells[4]).toHaveTextContent('Target');
     expect(header.cells[5]).toHaveTextContent('Status');
     expect(header.cells[6]).toHaveTextContent('Instance');


### PR DESCRIPTION
This updates the name of column headers as per recent mocks.

mocks:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/ed13ea76-b0de-4b7b-831c-d7256a4a9eff)
