### PR TITLE
WizardV2: validate uniqueness of name (HMS-3801)

### DIFF
--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -864,16 +864,16 @@ describe('Step Details', () => {
     await setUp();
 
     // Enter image name
+    const invalidName = 'a'.repeat(101);
+    await enterBlueprintName(invalidName);
+    expect(await getNextButton()).toHaveClass('pf-m-disabled');
+    expect(await getNextButton()).toBeDisabled();
     const nameInput = await screen.findByRole('textbox', {
       name: /blueprint name/i,
     });
-    const invalidName = 'a'.repeat(101);
-    await user.type(nameInput, invalidName);
-    expect(await getNextButton()).toHaveClass('pf-m-disabled');
-    expect(await getNextButton()).toBeDisabled();
     await user.clear(nameInput);
 
-    await user.type(nameInput, 'valid-name');
+    await enterBlueprintName(); // valid name
     expect(await getNextButton()).not.toHaveClass('pf-m-disabled');
     expect(await getNextButton()).toBeEnabled();
 
@@ -938,10 +938,7 @@ describe('Step Review', () => {
     await clickNext();
     await clickNext();
     // skip Details
-    const blueprintName = await screen.findByRole('textbox', {
-      name: /blueprint name/i,
-    });
-    await user.type(blueprintName, 'valid-name');
+    await enterBlueprintName();
     await clickNext();
   };
 
@@ -999,10 +996,7 @@ describe('Step Review', () => {
     // skip repositories
     await clickNext();
     await clickNext();
-    const blueprintName = await screen.findByRole('textbox', {
-      name: /blueprint name/i,
-    });
-    await user.type(blueprintName, 'valid-name');
+    await enterBlueprintName();
     await clickNext();
   };
 

--- a/src/test/Components/CreateImageWizardV2/steps/Details/Details.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Details/Details.test.tsx
@@ -74,6 +74,17 @@ describe('validates name', () => {
     const nextButton = await getNextButton();
     expect(nextButton).toBeEnabled();
   });
+
+  test('with non-unique name', async () => {
+    await render();
+    await goToRegistrationStep();
+    await clickRegisterLater();
+    await goToDetailsStep();
+    await enterBlueprintName('Lemon Pie');
+
+    const nextButton = await getNextButton();
+    expect(nextButton).toBeDisabled();
+  });
 });
 
 describe('registration request generated correctly', () => {

--- a/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -12,7 +12,7 @@ import {
   clickNext,
   renderCustomRoutesWithReduxRouter,
 } from '../../../../testUtils';
-import { render } from '../../wizardTestUtils';
+import { render, enterBlueprintName } from '../../wizardTestUtils';
 
 const routes = [
   {
@@ -59,10 +59,7 @@ const clickToReview = async () => {
   await clickNext(); // skip FSC
   await clickNext(); // skip Repositories
   await clickNext(); // skip Packages
-  const nameInput = await screen.findByRole('textbox', {
-    name: /blueprint name/i,
-  });
-  await userEvent.type(nameInput, 'name');
+  await enterBlueprintName();
   await clickNext(); // skip Details
 };
 

--- a/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { act, screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { MockedRequest } from 'msw';
 
@@ -12,10 +12,10 @@ import {
 import { server } from '../../mocks/server';
 import { clickNext, renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
-export function spyOnRequest(pathname: string) {
+export function spyOnRequest(pathname: string, requestMethod: string = 'POST') {
   return new Promise((resolve) => {
     const listener = async (req: MockedRequest) => {
-      if (req.url.pathname === pathname) {
+      if (req.url.pathname === pathname && req.method === requestMethod) {
         const requestData = await req.clone().json();
         resolve(requestData);
         // Cleanup listener after successful intercept
@@ -99,6 +99,10 @@ export const enterBlueprintName = async (name: string = 'Red Velvet') => {
     name: /blueprint name/i,
   });
   await userEvent.type(blueprintName, name);
+  // Wait for async validation to fire
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 350));
+  });
 };
 
 export const interceptBlueprintRequest = async (requestPathname: string) => {

--- a/src/test/fixtures/blueprints.ts
+++ b/src/test/fixtures/blueprints.ts
@@ -88,7 +88,7 @@ export const mockGetBlueprints: GetBlueprintsApiResponse = {
     },
     {
       id: '147032db-8697-4638-8fdd-6f428100d8fc',
-      name: 'Red Velvet',
+      name: 'Pink Velvet',
       description: 'Layered cake with icing',
       version: 1,
       last_modified_at: '2021-09-08T21:00:00.000Z',

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -124,11 +124,16 @@ export const handlers = [
     }
   ),
   rest.get(`${IMAGE_BUILDER_API}/experimental/blueprints`, (req, res, ctx) => {
+    const nameParam = req.url.searchParams.get('name');
     const search = req.url.searchParams.get('search');
     const limit = req.url.searchParams.get('limit') || '10';
     const offset = req.url.searchParams.get('offset') || '0';
     const resp = Object.assign({}, mockGetBlueprints);
-    if (search) {
+    if (nameParam) {
+      resp.data = resp.data.filter(({ name }) => {
+        return nameParam === name;
+      });
+    } else if (search) {
       let regexp;
       try {
         regexp = new RegExp(search);


### PR DESCRIPTION
Fetches Bluepritnts with the same name as inputed and when there is already one in the database, fails the validation.

This is implemented by adding async validation to the StateValidatedInput, which is bit complex as we wanted to add debounce for that validation as well, so it doesn't fire too frequently.