### PR TITLE
Blueprints: selected Blueprint Empty state action

### DIFF
--- a/src/Components/Blueprints/BuildImagesButton.tsx
+++ b/src/Components/Blueprints/BuildImagesButton.tsx
@@ -1,12 +1,20 @@
 import React from 'react';
 
-import { Button } from '@patternfly/react-core';
+import { Button, ButtonProps } from '@patternfly/react-core';
 
 import { selectSelectedBlueprintId } from '../../store/BlueprintSlice';
 import { useAppSelector } from '../../store/hooks';
 import { useComposeBlueprintMutation } from '../../store/imageBuilderApi';
 
-export const BuildImagesButton = () => {
+type BuildImagesButtonPropTypes = {
+  variant?: ButtonProps['variant'];
+  children?: React.ReactNode;
+};
+
+export const BuildImagesButton = ({
+  variant,
+  children,
+}: BuildImagesButtonPropTypes) => {
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
   const [buildBlueprint, { isLoading: imageBuildLoading }] =
     useComposeBlueprintMutation();
@@ -19,8 +27,9 @@ export const BuildImagesButton = () => {
       onClick={onBuildHandler}
       isDisabled={!selectedBlueprintId}
       isLoading={imageBuildLoading}
+      variant={variant}
     >
-      Build images
+      {children ? children : 'Build images'}
     </Button>
   );
 };

--- a/src/Components/ImagesTable/EmptyState.tsx
+++ b/src/Components/ImagesTable/EmptyState.tsx
@@ -15,11 +15,12 @@ import {
 import {
   ExternalLinkAltIcon,
   PlusCircleIcon,
-  CubesIcon,
+  PlusIcon,
 } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
 
 import { resolveRelPath } from '../../Utilities/path';
+import { BuildImagesButton } from '../Blueprints/BuildImagesButton';
 
 type ImagesEmptyStateProps = {
   selectedBlueprint?: string;
@@ -29,16 +30,23 @@ const EmptyBlueprintsImagesTable = () => (
   <Bullseye>
     <EmptyState variant={EmptyStateVariant.lg}>
       <EmptyStateHeader
-        icon={<EmptyStateIcon icon={CubesIcon} />}
+        icon={<EmptyStateIcon icon={PlusIcon} />}
         titleText="No images"
         data-testid="empty-state-header"
       />
       <EmptyStateBody>
         <Text>
-          The selected blueprint does not contain any images, build an image
-          from this version or adjust the filters.
+          The selected blueprint does not contain any images, build images from
+          this version or adjust the filters.
         </Text>
       </EmptyStateBody>
+      <EmptyStateFooter>
+        <EmptyStateActions>
+          <BuildImagesButton variant="link">
+            Build images for this version
+          </BuildImagesButton>
+        </EmptyStateActions>
+      </EmptyStateFooter>
     </EmptyState>
   </Bullseye>
 );


### PR DESCRIPTION
Add action in the Images Table empty state when Blueprint is selected. Change the icon to plus as it better underlines the action needed to remedy.

![image](https://github.com/osbuild/image-builder-frontend/assets/2884324/8b4dedfb-be83-4e56-983a-6262e3491d95)

