### PR TITLE
V2Wizard: Add `wizardMode` and repo removal modal

### DIFF
--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -90,6 +90,7 @@ export const mapRequestFromState = (
  * @returns wizardState
  */
 export const mapRequestToState = (request: BlueprintResponse): wizardState => {
+  const wizardMode = 'edit';
   const gcp = request.image_requests.find(
     (image) => image.image_type === 'gcp'
   );
@@ -109,6 +110,7 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
     .options as AzureUploadRequestOptions;
 
   return {
+    wizardMode,
     details: {
       blueprintName: request.name,
       blueprintDescription: request.description,

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -28,6 +28,8 @@ import { RHEL_9, X86_64 } from '../constants';
 
 import { RootState } from '.';
 
+type WizardModeOptions = 'create' | 'edit';
+
 export type RegistrationType =
   | 'register-later'
   | 'register-now'
@@ -39,6 +41,7 @@ export type wizardState = {
     serverUrl: string;
     baseUrl: string;
   };
+  wizardMode: WizardModeOptions;
   architecture: ImageRequest['architecture'];
   distribution: Distributions;
   imageTypes: ImageTypes[];
@@ -98,6 +101,7 @@ const initialState: wizardState = {
     serverUrl: '',
     baseUrl: '',
   },
+  wizardMode: 'create',
   architecture: X86_64,
   distribution: RHEL_9,
   imageTypes: [],
@@ -145,6 +149,10 @@ const initialState: wizardState = {
 
 export const selectServerUrl = (state: RootState) => {
   return state.wizard.env.serverUrl;
+};
+
+export const selectWizardMode = (state: RootState) => {
+  return state.wizard.wizardMode;
 };
 
 export const selectBaseUrl = (state: RootState) => {


### PR DESCRIPTION
This adds a new field indicating create/edit mode of the wizard to the state.

An alert an a modal were also added to warn users when removing custom repositories that this action can break their packages.