### PR TITLE
V2 Wizard: Fix OpenSCAP step (HMS-2781)

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemPartition.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemPartition.tsx
@@ -1,20 +1,23 @@
 import React from 'react';
 
 import { FormGroup, Label, Radio } from '@patternfly/react-core';
-import { v4 as uuidv4 } from 'uuid';
 
-import { UNIT_GIB } from '../../../../constants';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
-  changeFileSystemConfiguration,
   changeFileSystemPartitionMode,
   selectFileSystemPartitionMode,
+  selectProfile,
 } from '../../../../store/wizardSlice';
 
 const FileSystemPartition = () => {
-  const id = uuidv4();
   const dispatch = useAppDispatch();
   const fileSystemPartitionMode = useAppSelector(selectFileSystemPartitionMode);
+  const hasOscapProfile = useAppSelector(selectProfile);
+
+  if (hasOscapProfile) {
+    return undefined;
+  }
+
   return (
     <FormGroup>
       <Radio
@@ -33,7 +36,6 @@ const FileSystemPartition = () => {
         isChecked={fileSystemPartitionMode === 'automatic'}
         onChange={() => {
           dispatch(changeFileSystemPartitionMode('automatic'));
-          dispatch(changeFileSystemConfiguration([]));
         }}
       />
       <Radio
@@ -45,16 +47,6 @@ const FileSystemPartition = () => {
         isChecked={fileSystemPartitionMode === 'manual'}
         onChange={() => {
           dispatch(changeFileSystemPartitionMode('manual'));
-          dispatch(
-            changeFileSystemConfiguration([
-              {
-                id: id,
-                mountpoint: '/',
-                min_size: (10 * UNIT_GIB).toString(),
-                unit: 'GiB',
-              },
-            ])
-          );
         }}
       />
     </FormGroup>

--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -67,7 +67,6 @@ export type IBPackageWithRepositoryInfo = {
   name: Package['name'];
   summary: Package['summary'];
   repository: PackageRepository;
-  isRequiredByOpenScap: boolean;
 };
 
 const Packages = () => {
@@ -386,7 +385,6 @@ const Packages = () => {
       transformedDistroData = dataDistroPackages.data.map((values) => ({
         ...values,
         repository: 'distro',
-        isRequiredByOpenScap: false,
       }));
     }
 
@@ -395,7 +393,6 @@ const Packages = () => {
         name: values.package_name!,
         summary: values.summary!,
         repository: 'custom',
-        isRequiredByOpenScap: false,
       }));
     }
 
@@ -413,7 +410,6 @@ const Packages = () => {
         name: values.package_name!,
         summary: values.summary!,
         repository: 'recommended',
-        isRequiredByOpenScap: false,
       }));
 
       combinedPackageData = combinedPackageData.concat(

--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -54,8 +54,8 @@ import {
 import { GcpAccountType } from '../steps/TargetEnvironment/Gcp';
 
 type ServerStore = {
-  kernel?: { append?: string };
-  services?: { enabled?: string[]; disabled?: string[] };
+  kernel?: { append?: string }; // TODO use API types
+  services?: { enabled?: string[]; disabled?: string[]; masked?: string[] }; // TODO use API types
 };
 
 /**
@@ -172,7 +172,6 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
         name: pkg,
         summary: '',
         repository: '',
-        isRequiredByOpenScap: false,
       })) || [],
     stepValidations: {},
   };
@@ -305,11 +304,13 @@ const getCustomizations = (
 const getServices = (serverStore: ServerStore): Services | undefined => {
   const enabledServices = serverStore.services?.enabled;
   const disabledServices = serverStore.services?.disabled;
+  const maskedServices = serverStore.services?.masked;
 
-  if (enabledServices || disabledServices) {
+  if (enabledServices || disabledServices || maskedServices) {
     return {
       enabled: enabledServices,
       disabled: disabledServices,
+      masked: maskedServices,
     };
   }
   return undefined;

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -27,7 +27,11 @@ export const useOscapData = () => {
     services: {
       enabled: data?.services?.enabled,
       disabled: data?.services?.disabled,
+      masked: data?.services?.masked,
     },
+    packages: data?.packages,
+    filesystem: data?.filesystem,
+    profileName: data?.openscap?.profile_name,
   };
 };
 

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.js
@@ -165,14 +165,14 @@ describe('Step Compliance', () => {
     await screen.findByRole('heading', { name: /File system configuration/i });
     await screen.findByText(/tmp/i);
 
-    // check that the Packages contain a nftable package
+    // check that the Packages contains correct packages
     await clickNext();
 
     await screen.findByRole('heading', {
       name: /Additional Red Hat packages/i,
     });
-    await screen.findByText(/nftables/i);
-    await screen.findByText(/libselinux/i);
+    await screen.findByText(/aide/i);
+    await screen.findByText(/neovim/i);
   });
 });
 

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.compliance.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.compliance.test.tsx
@@ -171,14 +171,14 @@ describe('Step Compliance', () => {
 
     await clickNext(); // skip Repositories
 
-    // check that the Packages contain a nftable package
+    // check that the Packages contains correct packages
     await clickNext();
     await screen.findByRole('heading', {
       name: /Additional packages/i,
     });
     await user.click(await screen.findByText(/Selected/));
-    await screen.findByText(/nftables/i);
-    await screen.findByText(/libselinux/i);
+    await screen.findByText(/aide/i);
+    await screen.findByText(/neovim/i);
   });
 });
 //

--- a/src/test/Components/CreateImageWizardV2/steps/Oscap/Oscap.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Oscap/Oscap.test.tsx
@@ -1,0 +1,194 @@
+import { screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { CREATE_BLUEPRINT } from '../../../../../constants';
+import { CreateBlueprintRequest } from '../../../../../store/imageBuilderApi';
+import { clickNext } from '../../../../testUtils';
+import {
+  blueprintRequest,
+  clickRegisterLater,
+  enterBlueprintName,
+  interceptBlueprintRequest,
+  render,
+} from '../../wizardTestUtils';
+
+jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
+  useChrome: () => ({
+    auth: {
+      getUser: () => {
+        return {
+          identity: {
+            internal: {
+              org_id: 5,
+            },
+          },
+        };
+      },
+    },
+    isBeta: () => true,
+    isProd: () => true,
+    getEnvironment: () => 'prod',
+  }),
+}));
+
+const goToOscapStep = async () => {
+  const bareMetalCheckBox = await screen.findByRole('checkbox', {
+    name: /bare metal installer checkbox/i,
+  });
+  await userEvent.click(bareMetalCheckBox);
+  await clickNext(); // Registration
+  await clickRegisterLater();
+  await clickNext(); // OpenSCAP
+};
+
+const selectProfile = async () => {
+  await userEvent.click(
+    await screen.findByRole('textbox', {
+      name: /select a profile/i,
+    })
+  );
+
+  await userEvent.click(
+    await screen.findByText(
+      /cis red hat enterprise linux 8 benchmark for level 1 - workstation/i
+    )
+  );
+};
+
+const selectDifferentProfile = async () => {
+  await userEvent.click(
+    await screen.findByRole('textbox', {
+      name: /select a profile/i,
+    })
+  );
+
+  await userEvent.click(
+    await screen.findByText(
+      /cis red hat enterprise linux 8 benchmark for level 2 - workstation/i
+    )
+  );
+};
+
+const selectNone = async () => {
+  await userEvent.click(
+    await screen.findByRole('textbox', {
+      name: /select a profile/i,
+    })
+  );
+
+  await userEvent.click(await screen.findByText(/none/i));
+};
+
+const goToReviewStep = async () => {
+  await clickNext(); // File system configuration
+  await clickNext(); // Custom repositories
+  await clickNext(); // Additional packages
+  await clickNext(); // Details
+  await enterBlueprintName();
+  await clickNext(); // Review
+};
+
+const expectedOpenscapCisL1 = {
+  profile_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+};
+
+const expectedPackagesCisL1 = ['aide', 'neovim'];
+
+const expectedServicesCisL1 = {
+  enabled: ['crond', 'neovim-service'],
+  masked: ['nfs-server', 'emacs-service'],
+};
+
+const expectedKernelCisL1 = {
+  append: 'audit_backlog_limit=8192 audit=1',
+};
+
+const expectedFilesystemCisL1 = [
+  { min_size: 10737418240, mountpoint: '/' },
+  { min_size: 1073741824, mountpoint: '/tmp' },
+  { min_size: 1073741824, mountpoint: '/home' },
+];
+
+const expectedOpenscapCisL2 = {
+  profile_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l2',
+};
+
+const expectedPackagesCisL2 = ['aide', 'emacs'];
+
+const expectedServicesCisL2 = {
+  enabled: ['crond', 'emacs-service'],
+  masked: ['nfs-server', 'neovim-service'],
+};
+
+const expectedKernelCisL2 = {
+  append: 'audit_backlog_limit=8192 audit=2',
+};
+
+const expectedFilesystemCisL2 = [
+  { min_size: 10737418240, mountpoint: '/' },
+  { min_size: 1073741824, mountpoint: '/tmp' },
+  { min_size: 1073741824, mountpoint: '/app' },
+];
+
+describe('oscap', () => {
+  test('add a profile', async () => {
+    await render();
+    await goToOscapStep();
+    await selectProfile();
+    await goToReviewStep();
+
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    const expectedRequest: CreateBlueprintRequest = {
+      ...blueprintRequest,
+      customizations: {
+        packages: expectedPackagesCisL1,
+        openscap: expectedOpenscapCisL1,
+        services: expectedServicesCisL1,
+        kernel: expectedKernelCisL1,
+        filesystem: expectedFilesystemCisL1,
+      },
+    };
+
+    expect(receivedRequest).toEqual(expectedRequest);
+  });
+
+  test('remove a profile', async () => {
+    await render();
+    await goToOscapStep();
+    await selectProfile();
+    await selectNone();
+    await goToReviewStep();
+
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    const expectedRequest: CreateBlueprintRequest = {
+      ...blueprintRequest,
+    };
+
+    expect(receivedRequest).toEqual(expectedRequest);
+  });
+
+  test('change profile', async () => {
+    await render();
+    await goToOscapStep();
+    await selectProfile();
+    await selectDifferentProfile();
+    await goToReviewStep();
+
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    const expectedRequest: CreateBlueprintRequest = {
+      ...blueprintRequest,
+      customizations: {
+        packages: expectedPackagesCisL2,
+        openscap: expectedOpenscapCisL2,
+        services: expectedServicesCisL2,
+        kernel: expectedKernelCisL2,
+        filesystem: expectedFilesystemCisL2,
+      },
+    };
+
+    expect(receivedRequest).toEqual(expectedRequest);
+  });
+});

--- a/src/test/fixtures/oscap.ts
+++ b/src/test/fixtures/oscap.ts
@@ -16,7 +16,10 @@ export const oscapCustomizations = (
 ): GetOscapCustomizationsApiResponse => {
   if (profile === 'xccdf_org.ssgproject.content_profile_cis_workstation_l1') {
     return {
-      filesystem: [{ min_size: 1073741824, mountpoint: '/tmp' }],
+      filesystem: [
+        { min_size: 1073741824, mountpoint: '/tmp' },
+        { min_size: 1073741824, mountpoint: '/home' },
+      ],
       openscap: {
         profile_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
         profile_name:
@@ -24,26 +27,22 @@ export const oscapCustomizations = (
         profile_description:
           'This is a mocked profile description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean posuere velit enim, tincidunt porttitor nisl elementum eu.',
       },
-      packages: [
-        'aide',
-        'sudo',
-        'rsyslog',
-        'firewalld',
-        'nftables',
-        'libselinux',
-      ],
+      packages: ['aide', 'neovim'],
       kernel: {
         append: 'audit_backlog_limit=8192 audit=1',
       },
       services: {
-        masked: ['nfs-server'],
-        enabled: ['crond'],
+        masked: ['nfs-server', 'emacs-service'],
+        enabled: ['crond', 'neovim-service'],
       },
     };
   }
   if (profile === 'xccdf_org.ssgproject.content_profile_cis_workstation_l2') {
     return {
-      filesystem: [{ min_size: 1073741824, mountpoint: '/tmp' }],
+      filesystem: [
+        { min_size: 1073741824, mountpoint: '/tmp' },
+        { min_size: 1073741824, mountpoint: '/app' },
+      ],
       openscap: {
         profile_id: 'content_profile_cis_workstation_l2',
         profile_name:
@@ -51,20 +50,13 @@ export const oscapCustomizations = (
         profile_description:
           'This is a mocked profile description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean posuere velit enim, tincidunt porttitor nisl elementum eu.',
       },
-      packages: [
-        'aide',
-        'sudo',
-        'rsyslog',
-        'firewalld',
-        'nftables',
-        'libselinux',
-      ],
+      packages: ['aide', 'emacs'],
       kernel: {
-        append: 'audit_backlog_limit=8192 audit=1',
+        append: 'audit_backlog_limit=8192 audit=2',
       },
       services: {
-        disabled: ['nfs-server', 'nftables'],
-        enabled: ['crond', 'firewalld'],
+        masked: ['nfs-server', 'neovim-service'],
+        enabled: ['crond', 'emacs-service'],
       },
     };
   }
@@ -88,7 +80,7 @@ export const oscapCustomizations = (
       append: 'audit_backlog_limit=8192 audit=1',
     },
     services: {
-      disabled: ['nfs-server', 'rpcbind', 'autofs', 'nftables'],
+      masked: ['nfs-server', 'rpcbind', 'autofs', 'nftables'],
       enabled: ['crond', 'firewalld', 'systemd-journald', 'rsyslog', 'auditd'],
     },
   };


### PR DESCRIPTION
OpenSCAP profile info is now correctly loaded into the state and verified to be in the final request with tests.

I modified the fixtures for the OpenSCAP profiles. My changes ensure we have a Venn-diagram like overlap when changing from one profile to another where one package is the same, one package is removed, and one package is added. The same is true for the services and partitions. For kernel args it is not so important as that is just a string (as opposed to an array), so it is enough to be different.

I was able to eliminate a useEffect by replacing it with a lazy query trigger function. Setting the second arg `preferCacheValue` to `true` means that a request is only made if cached data is not available.

I modified the Redux reducers a bit to add some additional safety. 

`changeFileSystemPartitionMode` is now responsible for initializing the partitions field in the state by adding the root partition – previously this was done in the components themselves by dispatching `addPartition`. This reducer can always be safely dispatched – if the mode is ‘manual’, dispatching it with a payload of ‘manual’ will not result in any changes to the state. 

`addPackage` is also safer now. When a package is added, the list of packages is checked. If there is a package with an identical name, the new package overwrites the previous package. This is useful because the description may be different for the same package – for instance, when adding an OpenSCAP package, we use a custom description (‘this package required by OpenSCAP’).