### PR TITLE
V2 Wizard: Add Blueprints title to sidebar (HMS-2781)

### DIFF
--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -13,6 +13,9 @@ import {
   Sidebar,
   SidebarContent,
   SidebarPanel,
+  Title,
+  Toolbar,
+  ToolbarContent,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons';
 import { useFlag } from '@unleash/proxy-client-react';
@@ -75,11 +78,17 @@ export const LandingPage = () => {
         <Sidebar hasBorder className="pf-v5-u-background-color-100">
           <SidebarPanel
             variant="sticky"
-            hasPadding
             width={{ default: 'width_25' }}
             className="sidebar-panel"
           >
-            <BlueprintsSidebar />
+            <Toolbar>
+              <ToolbarContent>
+                <Title headingLevel="h1">{'Blueprints'}</Title>
+              </ToolbarContent>
+            </Toolbar>
+            <SidebarContent hasPadding>
+              <BlueprintsSidebar />
+            </SidebarContent>
           </SidebarPanel>
           <SidebarContent>
             <ImagesTable />


### PR DESCRIPTION
Added Blueprints title to align with mocks.

![image](https://github.com/osbuild/image-builder-frontend/assets/95542540/609eac7d-82e5-43a1-bd6b-39bf594b2ef1)
