### PR TITLE
V2 Wizard: Disable back on first step (HMS-2781)

### DIFF
--- a/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/CreateImageWizard.tsx
@@ -58,10 +58,12 @@ import { resolveRelPath } from '../../Utilities/path';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
 type CustomWizardFooterPropType = {
+  disableBack?: boolean;
   disableNext: boolean;
 };
 
 export const CustomWizardFooter = ({
+  disableBack: disableBack,
   disableNext: disableNext,
 }: CustomWizardFooterPropType) => {
   const { goToNextStep, goToPrevStep, close } = useWizardContext();
@@ -79,6 +81,7 @@ export const CustomWizardFooter = ({
         ouiaId="wizard-back-btn"
         variant="secondary"
         onClick={goToPrevStep}
+        isDisabled={disableBack}
       >
         Back
       </Button>
@@ -160,6 +163,7 @@ const CreateImageWizard = ({ startStepIndex = 1 }: CreateImageWizardProps) => {
             footer={
               <CustomWizardFooter
                 disableNext={targetEnvironments.length === 0}
+                disableBack={true}
               />
             }
           >


### PR DESCRIPTION
Disables the back button on the first step of the wizard. Disabling the back button (as opposed to hiding it) is how the wizard works in the Patternfly official examples.

![image](https://github.com/osbuild/image-builder-frontend/assets/95542540/262b306a-c511-4bad-8db4-fe4e8ea19149)
