### PR TITLE
V2Wizard: Show selected packages in included repos

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -424,13 +424,9 @@ const Packages = () => {
     } else {
       const selectedPackages = [...packages];
       if (toggleSourceRepos === 'toggle-included-repos') {
-        return selectedPackages.filter(
-          (pkg) => pkg.repository !== 'recommended'
-        );
+        return selectedPackages;
       } else {
-        return selectedPackages.filter(
-          (pkg) => pkg.repository === 'recommended'
-        );
+        return [];
       }
     }
   };

--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -257,6 +257,35 @@ const Packages = () => {
     );
   };
 
+  const TryLookingUnderIncluded = () => {
+    return (
+      <Tr>
+        <Td colSpan={5}>
+          <Bullseye>
+            <EmptyState variant={EmptyStateVariant.sm}>
+              <EmptyStateHeader
+                titleText="No selected packages"
+                headingLevel="h4"
+              />
+              <EmptyStateBody>
+                There are no selected packages in Other repos. Try looking under
+                &quot;
+                <Button
+                  variant="link"
+                  onClick={() => setToggleSourceRepos('toggle-included-repos')}
+                  isInline
+                >
+                  Included repos
+                </Button>
+                &quot;.
+              </EmptyStateBody>
+            </EmptyState>
+          </Bullseye>
+        </Td>
+      </Tr>
+    );
+  };
+
   const NoResultsFound = () => {
     const { isBeta } = useGetEnvironment();
     return (
@@ -825,6 +854,10 @@ const Packages = () => {
             isSuccessRecommendedPackages &&
             transformedPackages.length === 0 &&
             toggleSelected === 'toggle-available' && <NoResultsFound />}
+          {searchTerm &&
+            toggleSelected === 'toggle-selected' &&
+            toggleSourceRepos === 'toggle-other-repos' &&
+            packages.length > 0 && <TryLookingUnderIncluded />}
           {searchTerm &&
             transformedPackages.length >= 100 &&
             handleExactMatch()}


### PR DESCRIPTION
Previously when a package from an other repo was selected, it was still shown under "Other repos" toggle.

As a recommended repository gets added together with the package, it should be shown under "Included repos".

![empty-state](https://github.com/osbuild/image-builder-frontend/assets/49452678/2a13faa3-66f9-42be-b052-2445cc8be29d)
