### PR TITLE
V2Wizard: Fix VMware popovers

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 
 import {
+  Button,
   Checkbox,
   FormGroup,
   Popover,
@@ -205,7 +206,14 @@ const TargetEnvironment = () => {
                         </TextContent>
                       }
                     >
-                      <HelpIcon className="pf-u-ml-sm" />
+                      <Button
+                        className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
+                        variant="plain"
+                        aria-label="About OpenSCAP"
+                        isInline
+                      >
+                        <HelpIcon />
+                      </Button>
                     </Popover>
                   </>
                 }
@@ -244,7 +252,14 @@ const TargetEnvironment = () => {
                       </TextContent>
                     }
                   >
-                    <HelpIcon className="pf-u-ml-sm" />
+                    <Button
+                      className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
+                      variant="plain"
+                      aria-label="About OpenSCAP"
+                      isInline
+                    >
+                      <HelpIcon />
+                    </Button>
                   </Popover>
                 </>
               }


### PR DESCRIPTION
The popovers for VMware sphere types were not buttons. This caused weird behaviour with "ban" cursor when disabled and not opening popover when enabled.

"ban" cursor:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/e32075d3-11c7-4dbc-a7d7-ef095af86916)