### PR TITLE
V2Wizard: Update copy on empty state

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -264,12 +264,11 @@ const Packages = () => {
           <Bullseye>
             <EmptyState variant={EmptyStateVariant.sm}>
               <EmptyStateHeader
-                titleText="No selected packages"
+                titleText="No selected packages in Other repos"
                 headingLevel="h4"
               />
               <EmptyStateBody>
-                There are no selected packages in Other repos. Try looking under
-                &quot;
+                Try looking under &quot;
                 <Button
                   variant="link"
                   onClick={() => setToggleSourceRepos('toggle-included-repos')}
@@ -300,8 +299,8 @@ const Packages = () => {
                   headingLevel="h4"
                 />
                 <EmptyStateBody>
-                  Adjust your search and try again, or search from your
-                  repositories and popular repositories
+                  Adjust your search and try again, or search in other
+                  repositories (your repositories and popular repositories).
                 </EmptyStateBody>
                 <EmptyStateFooter>
                   <EmptyStateActions>
@@ -314,17 +313,20 @@ const Packages = () => {
                   </EmptyStateActions>
                   <EmptyStateActions>
                     <Button
+                      className="pf-u-pt-md"
                       variant="link"
                       isInline
                       component="a"
                       target="_blank"
+                      iconPosition="right"
+                      icon={<ExternalLinkAltIcon />}
                       href={
                         isBeta()
                           ? '/preview/insights/content'
                           : '/insights/content'
                       }
                     >
-                      View other repositories
+                      Manage your repositories and popular repositories
                     </Button>
                   </EmptyStateActions>
                 </EmptyStateFooter>


### PR DESCRIPTION
This updates copy on empty state when no packages are found with "Available" and "Included repos" toggled.

![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/60699b03-646d-4fe1-a1a1-ac6e9a8bb96b)

Copy on "Selected" and "Other repos" was also updated.

![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/4c9af7bd-8156-4f08-9b72-105fcfca5cc2)