### PR TITLE
V2Wizard: Fix padding around registration options

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Registration/Registration.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Registration/Registration.tsx
@@ -46,7 +46,7 @@ const RHSMPopover = () => {
     >
       <Button
         variant="plain"
-        className="pf-c-form__group-label-help"
+        className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
         aria-label="About remote host configuration (rhc)"
         isInline
       >
@@ -86,7 +86,7 @@ const InsightsPopover = () => {
     >
       <Button
         variant="plain"
-        className="pf-c-form__group-label-help"
+        className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
         aria-label="About remote host configuration (rhc)"
         isInline
       >
@@ -125,7 +125,7 @@ const RhcPopover = () => {
     >
       <Button
         variant="plain"
-        className="pf-c-form__group-label-help"
+        className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
         aria-label="About remote host configuration (rhc)"
         isInline
       >


### PR DESCRIPTION
This updates the padding around registration options.

before:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/ec703d26-98be-4354-a842-f46237956a88)

after:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/8a5a9497-d5ea-4f1e-b322-75b267e66e84)
