### PR TITLE
V2Wizard: Fix padding and size of `<HelpIcon>` button

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
@@ -166,7 +166,6 @@ const ProfileSelector = () => {
           OpenSCAP profile
           <Popover
             maxWidth="30rem"
-            position="left"
             bodyContent={
               <TextContent>
                 <Text>
@@ -176,7 +175,12 @@ const ProfileSelector = () => {
               </TextContent>
             }
           >
-            <Button variant="plain" aria-label="About OpenSCAP" isInline>
+            <Button
+              variant="plain"
+              aria-label="About OpenSCAP"
+              isInline
+              className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0 pf-u-pr-0"
+            >
               <HelpIcon />
             </Button>
           </Popover>

--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -784,7 +784,6 @@ const Packages = () => {
                         aria-label="About included repositories"
                         component="span"
                         className="pf-u-p-0"
-                        size="sm"
                         isInline
                       >
                         <HelpIcon />
@@ -815,7 +814,6 @@ const Packages = () => {
                         aria-label="About other repositories"
                         component="span"
                         className="pf-u-p-0"
-                        size="sm"
                         isInline
                       >
                         <HelpIcon />
@@ -870,7 +868,6 @@ const Packages = () => {
                     variant="plain"
                     aria-label="Package description"
                     className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
-                    size="sm"
                   >
                     <HelpIcon />
                   </Button>

--- a/src/Components/CreateImageWizardV2/steps/Registration/ActivationKeyInformation.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Registration/ActivationKeyInformation.tsx
@@ -81,7 +81,6 @@ const ActivationKeyInformation = (): JSX.Element => {
                   variant="plain"
                   aria-label="About additional repositories"
                   className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
-                  size="sm"
                 >
                   <HelpIcon />
                 </Button>


### PR DESCRIPTION
This updates padding around the popover button on OpenSCAP step and makes all `<HelpIcon>` icons the default size so it's consistent throughout the Wizard.

before:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/4ee76512-59a8-4195-aec6-32fb4a119516)

after:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/faca6b45-e768-41c9-82c0-f5385411ed40)