### PR TITLE
V2Wizard: Deduplicate minimum size popover and set width

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemTable.tsx
@@ -21,6 +21,31 @@ import {
   selectPartitions,
 } from '../../../../store/wizardSlice';
 
+export const MinimumSizePopover = () => {
+  return (
+    <Popover
+      maxWidth="30rem"
+      bodyContent={
+        <TextContent>
+          <Text>
+            Image Builder may extend this size based on requirements, selected
+            packages, and configurations.
+          </Text>
+        </TextContent>
+      }
+    >
+      <Button
+        variant="plain"
+        aria-label="File system configuration info"
+        aria-describedby="file-system-configuration-info"
+        className="pf-u-pl-sm pf-u-pt-0 pf-u-pb-0"
+      >
+        <HelpIcon />
+      </Button>
+    </Popover>
+  );
+};
+
 const FileSystemTable = () => {
   const [draggedItemId, setDraggedItemId] = useState<string | null>(null);
   const [draggingToItemIndex, setDraggingToItemIndex] = useState<number | null>(
@@ -170,27 +195,7 @@ const FileSystemTable = () => {
           <Th></Th>
           <Th>Type</Th>
           <Th>
-            Minimum size
-            <Popover
-              hasAutoWidth
-              bodyContent={
-                <TextContent>
-                  <Text>
-                    Image Builder may extend this size based on requirements,
-                    selected packages, and configurations.
-                  </Text>
-                </TextContent>
-              }
-            >
-              <Button
-                variant="plain"
-                aria-label="File system configuration info"
-                aria-describedby="file-system-configuration-info"
-                className="pf-c-form__group-label-help"
-              >
-                <HelpIcon />
-              </Button>
-            </Popover>
+            Minimum size <MinimumSizePopover />
           </Th>
           <Th />
           <Th />

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
@@ -13,7 +13,7 @@ import {
   TextVariants,
   FormGroup,
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon, HelpIcon } from '@patternfly/react-icons';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
 
 import ActivationKeyInformation from './../Registration/ActivationKeyInformation';
 import { PackagesTable, RepositoriesTable } from './ReviewStepTables';
@@ -53,6 +53,7 @@ import {
   selectRecommendedRepositories,
 } from '../../../../store/wizardSlice';
 import { toMonthAndYear } from '../../../../Utilities/time';
+import { MinimumSizePopover } from '../FileSystem/FileSystemTable';
 import { MajorReleasesLifecyclesChart } from '../ImageOutput/ReleaseLifecycle';
 import OscapProfileInformation from '../Oscap/OscapProfileInformation';
 import { PopoverActivation } from '../Registration/ActivationKeysList';
@@ -147,27 +148,7 @@ export const FSCList = () => {
         {fileSystemPartitionMode === 'manual' && (
           <>
             <TextListItem component={TextListItemVariants.dt}>
-              Image size (minimum)
-              <Popover
-                hasAutoWidth
-                bodyContent={
-                  <TextContent>
-                    <Text>
-                      Image Builder may extend this size based on requirements,
-                      selected packages, and configurations.
-                    </Text>
-                  </TextContent>
-                }
-              >
-                <Button
-                  variant="plain"
-                  aria-label="File system configuration info"
-                  aria-describedby="file-system-configuration-info"
-                  className="pf-c-form__group-label-help"
-                >
-                  <HelpIcon />
-                </Button>
-              </Popover>
+              Image size (minimum) <MinimumSizePopover />
             </TextListItem>
             <MinSize />
           </>


### PR DESCRIPTION
This sets a maximum width to the minimum size popover. Also moved code to a reusable component.

before:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/8b39aee4-fea2-4281-ba62-26dff5b65ec8)

after:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/b462be92-5c3a-4866-af5f-cb5f38edd6c2)
