### PR TITLE
V2Wizard: Add masked services to the "Disabled services" code block

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Oscap/OscapProfileInformation.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/OscapProfileInformation.tsx
@@ -40,8 +40,12 @@ export const OscapProfileInformation = (): JSX.Element => {
 
   const enabledServicesDisplayString =
     oscapProfileInfo?.services?.enabled?.join(' ');
-  const disableServicesDisplayString =
-    oscapProfileInfo?.services?.disabled?.join(' ');
+  const disabledAndMaskedServices = [
+    ...(oscapProfileInfo?.services?.disabled ?? []),
+    ...(oscapProfileInfo?.services?.masked ?? []),
+  ];
+  const disabledAndMaskedServicesDisplayString =
+    disabledAndMaskedServices.join(' ');
 
   return (
     <>
@@ -99,7 +103,9 @@ export const OscapProfileInformation = (): JSX.Element => {
               </TextListItem>
               <TextListItem component={TextListItemVariants.dd}>
                 <CodeBlock>
-                  <CodeBlockCode>{disableServicesDisplayString}</CodeBlockCode>
+                  <CodeBlockCode>
+                    {disabledAndMaskedServicesDisplayString}
+                  </CodeBlockCode>
                 </CodeBlock>
               </TextListItem>
               <TextListItem

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.compliance.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.compliance.test.tsx
@@ -99,12 +99,12 @@ describe('Step Compliance', () => {
 
     // check that the FSC does not contain a /tmp partition
     await clickNext();
-    //    await screen.findByRole('heading', { name: /File system configuration/i });
-    //  expect(
-    //   screen.queryByRole('cell', {
-    //     name: /tmp/i,
-    //   })
-    //   ).not.toBeInTheDocument();
+    await screen.findByRole('heading', { name: /File system configuration/i });
+    expect(
+      screen.queryByRole('cell', {
+        name: /tmp/i,
+      })
+    ).not.toBeInTheDocument();
 
     await clickNext(); // skip Repositories
 
@@ -161,13 +161,16 @@ describe('Step Compliance', () => {
     await screen.findByText(/kernel arguments:/i);
     await screen.findByText(/audit_backlog_limit=8192 audit=1/i);
     await screen.findByText(/disabled services:/i);
+    await screen.findByText(
+      /rpcbind autofs nftables nfs-server emacs-service/i
+    );
     await screen.findByText(/enabled services:/i);
     await screen.findByText(/crond/i);
 
     // check that the FSC contains a /tmp partition
     await clickNext();
-    //    await screen.findByRole('heading', { name: /File system configuration/i });
-    //   await screen.findByText(/tmp/i);
+    await screen.findByRole('heading', { name: /File system configuration/i });
+    await screen.findByText(/tmp/i);
 
     await clickNext(); // skip Repositories
 

--- a/src/test/Components/CreateImageWizardV2/steps/Oscap/Oscap.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Oscap/Oscap.test.tsx
@@ -96,6 +96,7 @@ const expectedPackagesCisL1 = ['aide', 'neovim'];
 
 const expectedServicesCisL1 = {
   enabled: ['crond', 'neovim-service'],
+  disabled: ['rpcbind', 'autofs', 'nftables'],
   masked: ['nfs-server', 'emacs-service'],
 };
 

--- a/src/test/fixtures/oscap.ts
+++ b/src/test/fixtures/oscap.ts
@@ -33,6 +33,7 @@ export const oscapCustomizations = (
       },
       services: {
         masked: ['nfs-server', 'emacs-service'],
+        disabled: ['rpcbind', 'autofs', 'nftables'],
         enabled: ['crond', 'neovim-service'],
       },
     };


### PR DESCRIPTION
Fixes #1985

This concatenates masked service to the disabled services so both get rendered in the "Disabled service" code block.

Test to check this was also added.