### PR TITLE
ImagesTable: Update empty state for blueprint without images

### DIFF
--- a/src/Components/ImagesTable/EmptyState.tsx
+++ b/src/Components/ImagesTable/EmptyState.tsx
@@ -15,7 +15,6 @@ import {
 import {
   ExternalLinkAltIcon,
   PlusCircleIcon,
-  PlusIcon,
   SearchIcon,
 } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
@@ -32,20 +31,20 @@ const EmptyBlueprintsImagesTable = () => (
   <Bullseye>
     <EmptyState variant={EmptyStateVariant.lg}>
       <EmptyStateHeader
-        icon={<EmptyStateIcon icon={PlusIcon} />}
+        icon={<EmptyStateIcon icon={PlusCircleIcon} />}
         titleText="No images"
         data-testid="empty-state-header"
       />
       <EmptyStateBody>
         <Text>
-          The selected blueprint does not contain any images, build images from
-          this version or adjust the filters.
+          The selected blueprint version doesn&apos;t contain any images. Build
+          an image from this version, or adjust the filters.
         </Text>
       </EmptyStateBody>
       <EmptyStateFooter>
         <EmptyStateActions>
           <BuildImagesButton variant="link">
-            Build images for this version
+            Build latest images
           </BuildImagesButton>
         </EmptyStateActions>
       </EmptyStateFooter>


### PR DESCRIPTION
This updates empty state for blueprints without images as per recent [mocks](https://www.figma.com/file/9t3owYlJi4M23fUXWpgXCE/HMS-Image-Builder?type=design&node-id=696-15611&mode=design&t=0EaRBEOETA1fn4Yf-0).

before:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/8c378799-8eec-4ff1-92d1-192336a337bb)

after:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/b2d69a11-2871-486c-a036-8e1a88f4b3b7)