### PR TITLE
experimental: Allow switching experimental on in stable

### DIFF
--- a/src/Utilities/useExperimentalFlag.ts
+++ b/src/Utilities/useExperimentalFlag.ts
@@ -20,7 +20,6 @@ const toBoolean = (environmentVariable: string | undefined): boolean => {
 export const useExperimentalFlag = () => {
   const { isBeta } = useGetEnvironment();
   const isExperimental = toBoolean(process.env.EXPERIMENTAL?.toString());
-  return (
-    (useFlag('image-builder.new-wizard.enabled') || isExperimental) && isBeta()
-  );
+  const flagSuffix = isBeta() ? 'enabled' : 'stable';
+  return useFlag(`image-builder.new-wizard.${flagSuffix}`) || isExperimental;
 };

--- a/src/test/Components/ImagesTable/ImagesTable.test.js
+++ b/src/test/Components/ImagesTable/ImagesTable.test.js
@@ -25,6 +25,8 @@ jest.mock('@unleash/proxy-client-react', () => ({
         return false;
       case 'image-builder.new-wizard.enabled':
         return false;
+      case 'image-builder.new-wizard.stable':
+        return false;
       default:
         return true;
     }

--- a/src/test/Components/LandingPage/LandingPage.test.js
+++ b/src/test/Components/LandingPage/LandingPage.test.js
@@ -16,7 +16,16 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 jest.mock('@unleash/proxy-client-react', () => ({
   useUnleashContext: () => jest.fn(),
-  useFlag: jest.fn((flag) => (flag === 'edgeParity.image-list' ? false : true)),
+  useFlag: jest.fn((flag) => {
+    switch (flag) {
+      case 'edgeParity.image-list':
+        return false;
+      case 'image-builder.new-wizard.stable':
+        return false;
+      default:
+        return true;
+    }
+  }),
 }));
 
 describe('Landing Page', () => {


### PR DESCRIPTION
This allows us to flip the new wizard in stable :)
I've created the feature flag `image-builder.new-wizard.stable` in both stage and prod, so we can test it out in stage-stable first