### PR TITLE
V2Wizard: Show packages only with a search term

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -900,7 +900,9 @@ const Packages = () => {
           {searchTerm &&
             transformedPackages.length >= 100 &&
             handleExactMatch()}
-          {transformedPackages.length < 100 && composePkgTable()}
+          {(searchTerm || toggleSelected === 'toggle-selected') &&
+            transformedPackages.length < 100 &&
+            composePkgTable()}
         </Tbody>
       </Table>
       <Pagination


### PR DESCRIPTION
Fixes #2012

Packages from custom repos stayed in the table upon clearing the search input. This show the results only when searchTerm is not empty.