### PR TITLE
V2 Wizard: OpenSCAP edit tests (HMS-2781)

### DIFF
--- a/src/Components/CreateImageWizardV2/EditImageWizard.tsx
+++ b/src/Components/CreateImageWizardV2/EditImageWizard.tsx
@@ -7,7 +7,7 @@ import { mapRequestToState } from './utilities/requestMapper';
 
 import { useAppDispatch } from '../../store/hooks';
 import { useGetBlueprintQuery } from '../../store/imageBuilderApi';
-import { loadWizardState, initializeWizard } from '../../store/wizardSlice';
+import { loadWizardState } from '../../store/wizardSlice';
 import { resolveRelPath } from '../../Utilities/path';
 
 type EditImageWizardProps = {
@@ -18,15 +18,18 @@ const EditImageWizard = ({ blueprintId }: EditImageWizardProps) => {
   const dispatch = useAppDispatch();
   const navigate = useNavigate();
 
-  const { data: blueprintDetails, error } = useGetBlueprintQuery({
+  const {
+    data: blueprintDetails,
+    error,
+    isSuccess,
+  } = useGetBlueprintQuery({
     id: blueprintId,
   });
+
   useEffect(() => {
     if (blueprintId && blueprintDetails) {
       const editBlueprintState = mapRequestToState(blueprintDetails);
       dispatch(loadWizardState(editBlueprintState));
-    } else {
-      dispatch(initializeWizard());
     }
   }, [blueprintId, blueprintDetails, dispatch]);
   useEffect(() => {
@@ -36,7 +39,7 @@ const EditImageWizard = ({ blueprintId }: EditImageWizardProps) => {
       navigate(resolveRelPath(''));
     }
   }, [error, navigate]);
-  return <CreateImageWizard isEdit />;
+  return isSuccess ? <CreateImageWizard isEdit /> : undefined;
 };
 
 export default EditImageWizard;

--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -120,6 +120,18 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
   const azureUploadOptions = azure?.upload_request
     .options as AzureUploadRequestOptions;
 
+  const fileSystem = request.customizations.filesystem
+    ? {
+        mode: 'manual',
+        partitions: request.customizations.filesystem,
+        isNextButtonTouched: true,
+      }
+    : {
+        mode: 'automatic',
+        partitions: [],
+        isNextButtonTouched: true,
+      };
+
   return {
     wizardMode,
     details: {
@@ -134,12 +146,7 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
       profile: request.customizations.openscap
         ?.profile_id as DistributionProfileItem,
     },
-    fileSystem: {
-      mode: 'automatic',
-      partitions: [],
-      isNextButtonTouched: true,
-    },
-
+    fileSystem: fileSystem,
     architecture: request.image_requests[0].architecture,
     distribution: request.distribution,
     imageTypes: request.image_requests.map((image) => image.image_type),

--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -1,4 +1,5 @@
 import { Store } from 'redux';
+import { v4 as uuidv4 } from 'uuid';
 
 import { RootState } from '../../../store';
 import {
@@ -53,6 +54,8 @@ import {
   convertMMDDYYYYToYYYYMMDD,
   convertYYYYMMDDTOMMDDYYYY,
 } from '../../../Utilities/time';
+import { FileSystemPartitionMode } from '../steps/FileSystem';
+import { Partition, Units } from '../steps/FileSystem/FileSystemConfiguration';
 import {
   convertSchemaToIBCustomRepo,
   convertSchemaToIBPayloadRepo,
@@ -89,6 +92,18 @@ export const mapRequestFromState = (
   };
 };
 
+const convertFilesystemToPartition = (filesystem: Filesystem): Partition => {
+  const id = uuidv4();
+  const unit: Units = 'GiB';
+  const partition = {
+    mountpoint: filesystem.mountpoint,
+    min_size: String(filesystem.min_size),
+    id: id,
+    unit: unit,
+  };
+  return partition;
+};
+
 /**
  * This function maps the blueprint response to the wizard state, used to populate the wizard with the blueprint details
  * @param request BlueprintResponse
@@ -122,12 +137,14 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
 
   const fileSystem = request.customizations.filesystem
     ? {
-        mode: 'manual',
-        partitions: request.customizations.filesystem,
+        mode: 'manual' as FileSystemPartitionMode,
+        partitions: request.customizations.filesystem.map((fs) =>
+          convertFilesystemToPartition(fs)
+        ),
         isNextButtonTouched: true,
       }
     : {
-        mode: 'automatic',
+        mode: 'automatic' as FileSystemPartitionMode,
         partitions: [],
         isNextButtonTouched: true,
       };

--- a/src/constants.js
+++ b/src/constants.js
@@ -4,6 +4,7 @@ export const EDGE_API = '/api/edge/v1';
 export const CONTENT_SOURCES_API = '/api/content-sources/v1';
 export const PROVISIONING_API = '/api/provisioning/v1';
 export const CREATE_BLUEPRINT = `${IMAGE_BUILDER_API}/experimental/blueprints`;
+export const EDIT_BLUEPRINT = `${IMAGE_BUILDER_API}/experimental/blueprints`;
 
 export const CDN_PROD_URL = 'https://cdn.redhat.com/';
 export const CDN_STAGE_URL = 'https://cdn.stage.redhat.com/';

--- a/src/test/Components/Blueprints/Blueprints.test.js
+++ b/src/test/Components/Blueprints/Blueprints.test.js
@@ -212,7 +212,7 @@ describe('Blueprints', () => {
       await user.click(button);
 
       await waitFor(() => {
-        expect(screen.getAllByRole('checkbox')).toHaveLength(1);
+        expect(screen.getAllByRole('checkbox')).toHaveLength(2);
       });
     });
   });

--- a/src/test/Components/CreateImageWizardV2/steps/Details/Details.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Details/Details.test.tsx
@@ -10,7 +10,7 @@ import {
   enterBlueprintName,
   goToRegistrationStep,
   interceptBlueprintRequest,
-  render,
+  renderCreateMode,
 } from '../../wizardTestUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -54,7 +54,7 @@ const goToReviewStep = async () => {
 
 describe('validates name', () => {
   test('with invalid name', async () => {
-    await render();
+    await renderCreateMode();
     await goToRegistrationStep();
     await clickRegisterLater();
     await goToDetailsStep();
@@ -66,7 +66,7 @@ describe('validates name', () => {
   });
 
   test('with valid name', async () => {
-    await render();
+    await renderCreateMode();
     await goToRegistrationStep();
     await clickRegisterLater();
     await goToDetailsStep();
@@ -79,7 +79,7 @@ describe('validates name', () => {
 
 describe('registration request generated correctly', () => {
   test('without description', async () => {
-    await render();
+    await renderCreateMode();
     await goToRegistrationStep();
     await clickRegisterLater();
     await goToDetailsStep();
@@ -93,7 +93,7 @@ describe('registration request generated correctly', () => {
   });
 
   test('with description', async () => {
-    await render();
+    await renderCreateMode();
     await goToRegistrationStep();
     await clickRegisterLater();
     await goToDetailsStep();

--- a/src/test/Components/CreateImageWizardV2/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
@@ -8,7 +8,7 @@ import {
   clickRegisterLater,
   enterBlueprintName,
   interceptBlueprintRequest,
-  render,
+  renderCreateMode,
 } from '../../wizardTestUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -104,7 +104,7 @@ const goToReviewStep = async () => {
 
 describe('file system configuration request generated correctly', () => {
   test('10 GiB / correct', async () => {
-    await render();
+    await renderCreateMode();
     await goToFileSystemConfigurationStep();
     await clickManuallyConfigurePartitions();
     await goToReviewStep();
@@ -126,7 +126,7 @@ describe('file system configuration request generated correctly', () => {
   });
 
   test('15 GiB / correct', async () => {
-    await render();
+    await renderCreateMode();
     await goToFileSystemConfigurationStep();
     await clickManuallyConfigurePartitions();
     await changePartitionSize();
@@ -149,7 +149,7 @@ describe('file system configuration request generated correctly', () => {
   });
 
   test('MiB / correct', async () => {
-    await render();
+    await renderCreateMode();
     await goToFileSystemConfigurationStep();
     await clickManuallyConfigurePartitions();
     await changePartitionUnitsToMiB();
@@ -172,7 +172,7 @@ describe('file system configuration request generated correctly', () => {
   });
 
   test('KiB / correct', async () => {
-    await render();
+    await renderCreateMode();
     await goToFileSystemConfigurationStep();
     await clickManuallyConfigurePartitions();
     await changePartitionUnitsToKiB();
@@ -195,7 +195,7 @@ describe('file system configuration request generated correctly', () => {
   });
 
   test('/home correct', async () => {
-    await render();
+    await renderCreateMode();
     await goToFileSystemConfigurationStep();
     await clickManuallyConfigurePartitions();
     await addPartition();
@@ -222,7 +222,7 @@ describe('file system configuration request generated correctly', () => {
   });
 
   test('/home/cakerecipes correct', async () => {
-    await render();
+    await renderCreateMode();
     await goToFileSystemConfigurationStep();
     await clickManuallyConfigurePartitions();
     await addPartition();

--- a/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -12,7 +12,7 @@ import {
   clickNext,
   renderCustomRoutesWithReduxRouter,
 } from '../../../../testUtils';
-import { render } from '../../wizardTestUtils';
+import { renderCreateMode } from '../../wizardTestUtils';
 
 const routes = [
   {
@@ -283,53 +283,53 @@ describe('Check step consistency', () => {
 
 describe('set release using query parameter', () => {
   test('rhel 9 by default (no query parameter)', async () => {
-    await render();
+    await renderCreateMode();
     await screen.findByText('Red Hat Enterprise Linux (RHEL) 9');
   });
 
   test('rhel 9 by default (invalid query parameter)', async () => {
-    await render({ release: 'rhel9001' });
+    await renderCreateMode({ release: 'rhel9001' });
     await screen.findByText('Red Hat Enterprise Linux (RHEL) 9');
   });
 
   test('rhel 8 (query parameter provided)', async () => {
-    await render({ release: 'rhel8' });
+    await renderCreateMode({ release: 'rhel8' });
     await screen.findByText('Red Hat Enterprise Linux (RHEL) 8');
   });
 });
 
 describe('set architecture using query parameter', () => {
   test('x86_64 by default (no query parameter)', async () => {
-    await render();
+    await renderCreateMode();
     await screen.findByText('x86_64');
   });
 
   test('x86_64 by default (invalid query parameter)', async () => {
-    await render({ arch: 'arm' });
+    await renderCreateMode({ arch: 'arm' });
     await screen.findByText('x86_64');
   });
 
   test('aarch64 (query parameter provided)', async () => {
-    await render({ arch: 'aarch64' });
+    await renderCreateMode({ arch: 'aarch64' });
     await screen.findByText('aarch64');
   });
 });
 
 describe('set target using query parameter', () => {
   test('no target by default (no query parameter)', async () => {
-    await render();
+    await renderCreateMode();
     const nextButton = await screen.findByRole('button', { name: /Next/ });
     expect(nextButton).toBeDisabled();
   });
 
   test('no target by default (invalid query parameter)', async () => {
-    await render({ target: 'azure' });
+    await renderCreateMode({ target: 'azure' });
     const nextButton = await screen.findByRole('button', { name: /Next/ });
     expect(nextButton).toBeDisabled();
   });
 
   test('image-installer (query parameter provided)', async () => {
-    await render({ target: 'iso' });
+    await renderCreateMode({ target: 'iso' });
     await clickToReview();
     const targetExpandable = await screen.findByRole('button', {
       name: /Target environments/,
@@ -339,7 +339,7 @@ describe('set target using query parameter', () => {
   });
 
   test('guest-installer (query parameter provided)', async () => {
-    await render({ target: 'qcow2' });
+    await renderCreateMode({ target: 'qcow2' });
     await clickToReview();
     const targetExpandable = await screen.findByRole('button', {
       name: /Target environments/,

--- a/src/test/Components/CreateImageWizardV2/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Packages/Packages.test.tsx
@@ -9,7 +9,7 @@ import {
   clickRegisterLater,
   enterBlueprintName,
   interceptBlueprintRequest,
-  render,
+  renderCreateMode,
 } from '../../wizardTestUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -108,7 +108,7 @@ describe('packages request generated correctly', () => {
   const expectedPackages: string[] = ['test'];
 
   test('with custom packages', async () => {
-    await render();
+    await renderCreateMode();
     await goToPackagesStep();
     await searchForPackage();
     await selectFirstPackage();
@@ -126,7 +126,7 @@ describe('packages request generated correctly', () => {
   });
 
   test('deselecting a package removes it from the request', async () => {
-    await render();
+    await renderCreateMode();
     await goToPackagesStep();
     await searchForPackage();
     await selectFirstPackage();
@@ -158,7 +158,7 @@ describe('package recommendations', () => {
   const expectedPackagesWithoutRecommendations: string[] = ['test'];
 
   test('selecting single recommendation adds it to the request', async () => {
-    await render();
+    await renderCreateMode();
     await goToPackagesStep();
     await searchForPackage();
     await selectFirstPackage();
@@ -178,7 +178,7 @@ describe('package recommendations', () => {
   });
 
   test('clicking "Add all packages" adds all recommendations to the request', async () => {
-    await render();
+    await renderCreateMode();
     await goToPackagesStep();
     await searchForPackage();
     await selectFirstPackage();
@@ -198,7 +198,7 @@ describe('package recommendations', () => {
   });
 
   test('deselecting a package recommendation removes it from the request', async () => {
-    await render();
+    await renderCreateMode();
     await goToPackagesStep();
     await searchForPackage();
     await selectFirstPackage();

--- a/src/test/Components/CreateImageWizardV2/steps/Registration/Registration.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Registration/Registration.test.tsx
@@ -9,7 +9,7 @@ import {
 import { clickNext } from '../../../../testUtils';
 import {
   enterBlueprintName,
-  render,
+  renderCreateMode,
   interceptBlueprintRequest,
   goToRegistrationStep,
   clickRegisterLater,
@@ -94,7 +94,7 @@ describe('registration request generated correctly', () => {
   };
 
   test('register + insights + rhc', async () => {
-    await render();
+    await renderCreateMode();
     await goToRegistrationStep();
     await selectActivationKey();
     await goToReviewStep();
@@ -117,7 +117,7 @@ describe('registration request generated correctly', () => {
   });
 
   test('register + insights', async () => {
-    await render();
+    await renderCreateMode();
     await goToRegistrationStep();
     await clickShowAdditionalConnectionOptions();
     await deselectEnableRemoteRemediations();
@@ -142,7 +142,7 @@ describe('registration request generated correctly', () => {
   });
 
   test('register', async () => {
-    await render();
+    await renderCreateMode();
     await goToRegistrationStep();
     await clickShowAdditionalConnectionOptions();
     await deselectPredictiveAnalytics();
@@ -167,7 +167,7 @@ describe('registration request generated correctly', () => {
   });
 
   test('register Later', async () => {
-    await render();
+    await renderCreateMode();
     await goToRegistrationStep();
     await clickShowAdditionalConnectionOptions();
     await clickRegisterLater();

--- a/src/test/Components/CreateImageWizardV2/steps/Repositories/Repositories.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Repositories/Repositories.test.tsx
@@ -13,7 +13,7 @@ import {
   clickRegisterLater,
   enterBlueprintName,
   interceptBlueprintRequest,
-  render,
+  renderCreateMode,
 } from '../../wizardTestUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -124,7 +124,7 @@ describe('repositories request generated correctly', () => {
   };
 
   test('with custom repositories', async () => {
-    await render();
+    await renderCreateMode();
     await goToRepositoriesStep();
     await selectFirstRepository();
     await goToReviewStep();
@@ -142,7 +142,7 @@ describe('repositories request generated correctly', () => {
   });
 
   test('with custom repository with module_hotfixes', async () => {
-    await render();
+    await renderCreateMode();
     await goToRepositoriesStep();
     await selectNginxRepository();
     await goToReviewStep();
@@ -160,7 +160,7 @@ describe('repositories request generated correctly', () => {
   });
 
   test('deselecting a custom repository removes it from the request', async () => {
-    await render();
+    await renderCreateMode();
     await goToRepositoriesStep();
     await selectFirstRepository();
     await deselectFirstRepository();

--- a/src/test/Components/CreateImageWizardV2/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Snapshot/Snapshot.test.tsx
@@ -13,7 +13,7 @@ import {
   clickRegisterLater,
   enterBlueprintName,
   interceptBlueprintRequest,
-  render,
+  renderCreateMode,
 } from '../../wizardTestUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -112,7 +112,7 @@ describe('repository snapshot tab - ', () => {
   ];
 
   test('select use a snapshot with 1 repo selected', async () => {
-    await render();
+    await renderCreateMode();
     await goToSnapshotStep();
     await selectUseSnapshot();
     await updateDatePickerWithValue('04/22/2024');
@@ -143,7 +143,7 @@ describe('repository snapshot tab - ', () => {
   });
 
   test('select use a snapshot with no repos selected', async () => {
-    await render();
+    await renderCreateMode();
     await goToSnapshotStep();
     await selectUseSnapshot();
     await updateDatePickerWithValue('04/22/2024');

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsTarget.test.tsx
@@ -12,7 +12,7 @@ import {
   clickRegisterLater,
   enterBlueprintName,
   interceptBlueprintRequest,
-  render,
+  renderCreateMode,
 } from '../../../wizardTestUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -52,7 +52,7 @@ const goToReview = async () => {
 };
 
 const selectAwsTarget = async () => {
-  await render();
+  await renderCreateMode();
   const awsCard = await screen.findByTestId('upload-aws');
   await userEvent.click(awsCard);
   await clickNext();

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureTarget.test.tsx
@@ -12,7 +12,7 @@ import {
   clickRegisterLater,
   enterBlueprintName,
   interceptBlueprintRequest,
-  render,
+  renderCreateMode,
 } from '../../../wizardTestUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -52,7 +52,7 @@ const goToReview = async () => {
 };
 
 const selectAzureTarget = async () => {
-  await render();
+  await renderCreateMode();
   const azureCard = await screen.findByTestId('upload-azure');
   await userEvent.click(azureCard);
   await clickNext();

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/GCPTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/GCPTarget.test.tsx
@@ -15,7 +15,7 @@ import {
   enterBlueprintName,
   imageRequest,
   interceptBlueprintRequest,
-  render,
+  renderCreateMode,
 } from '../../wizardTestUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -67,7 +67,7 @@ const createGCPCloudImage = (
 };
 
 const clickGCPTarget = async () => {
-  await render();
+  await renderCreateMode();
   const googleOption = await screen.findByTestId('upload-google');
   await userEvent.click(googleOption);
   await clickNext();

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/TargetEnvironment.test.tsx
@@ -22,7 +22,7 @@ import {
   goToRegistrationStep,
   imageRequest,
   interceptBlueprintRequest,
-  render,
+  renderCreateMode,
 } from '../../wizardTestUtils';
 
 jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
@@ -130,7 +130,7 @@ const goToReviewStep = async () => {
 
 describe('distribution request generated correctly', () => {
   test('rhel-8', async () => {
-    await render();
+    await renderCreateMode();
     await selectRhel8();
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
@@ -144,7 +144,7 @@ describe('distribution request generated correctly', () => {
   });
 
   test('rhel-9', async () => {
-    await render();
+    await renderCreateMode();
     await selectRhel9();
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
@@ -158,7 +158,7 @@ describe('distribution request generated correctly', () => {
   });
 
   test('centos-9', async () => {
-    await render();
+    await renderCreateMode();
     await selectCentos9();
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
@@ -172,7 +172,7 @@ describe('distribution request generated correctly', () => {
   });
 
   test('centos-8', async () => {
-    await render();
+    await renderCreateMode();
     await selectCentos8();
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
@@ -188,7 +188,7 @@ describe('distribution request generated correctly', () => {
 
 describe('architecture request generated correctly', () => {
   test('x86_64', async () => {
-    await render();
+    await renderCreateMode();
     await selectX86_64();
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
@@ -206,7 +206,7 @@ describe('architecture request generated correctly', () => {
   });
 
   test('aarch64', async () => {
-    await render();
+    await renderCreateMode();
     await selectAarch64();
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);

--- a/src/test/fixtures/blueprints.ts
+++ b/src/test/fixtures/blueprints.ts
@@ -4,6 +4,9 @@ import {
   CreateBlueprintResponse,
   GetBlueprintComposesApiResponse,
   GetBlueprintApiResponse,
+  CreateBlueprintRequest,
+  ImageRequest,
+  BlueprintResponse,
 } from '../../store/imageBuilderApi';
 
 export const mockBlueprintsCreation: CreateBlueprintResponse[] = [
@@ -12,9 +15,22 @@ export const mockBlueprintsCreation: CreateBlueprintResponse[] = [
   },
 ];
 
+export const mockBlueprintIds = {
+  darkChocolate: '677b010b-e95e-4694-9813-d11d847f1bfc',
+  oscap: '260823fd-0a51-43fd-bc1c-77255848de04',
+};
+
+const mockBlueprintNames = {
+  oscap: 'oscap',
+};
+
+const mockBlueprintDescriptions = {
+  oscap: '',
+};
+
 export const mockGetBlueprints: GetBlueprintsApiResponse = {
   links: { first: 'first', last: 'last' },
-  meta: { count: 11 },
+  meta: { count: 12 },
   data: [
     {
       id: '677b010b-e95e-4694-9813-d11d847f1bfc',
@@ -90,6 +106,13 @@ export const mockGetBlueprints: GetBlueprintsApiResponse = {
       id: '147032db-8697-4638-8fdd-6f428100d8fc',
       name: 'Red Velvet',
       description: 'Layered cake with icing',
+      version: 1,
+      last_modified_at: '2021-09-08T21:00:00.000Z',
+    },
+    {
+      id: mockBlueprintIds['oscap'],
+      name: mockBlueprintNames['oscap'],
+      description: mockBlueprintDescriptions['oscap'],
       version: 1,
       last_modified_at: '2021-09-08T21:00:00.000Z',
     },
@@ -217,7 +240,7 @@ export const updatedBlueprints: GetBlueprintsApiResponse = {
   })),
 };
 
-export const mockBlueprintDetail: GetBlueprintApiResponse = {
+export const darkChocolateBlueprintResponse: GetBlueprintApiResponse = {
   ...mockGetBlueprints.data[0],
   image_requests: mockBlueprintComposes.data[0].request.image_requests,
   distribution: mockBlueprintComposes.data[0].request.distribution,
@@ -231,4 +254,71 @@ export const mockBlueprintDetail: GetBlueprintApiResponse = {
       rhc: true,
     },
   },
+};
+
+export const baseImageRequest: ImageRequest = {
+  architecture: 'x86_64',
+  image_type: 'guest-image',
+  upload_request: {
+    options: {},
+    type: 'aws.s3',
+  },
+};
+
+export const baseCreateBlueprintRequest: CreateBlueprintRequest = {
+  name: 'Red Velvet',
+  description: '',
+  distribution: 'rhel-93',
+  image_requests: [baseImageRequest],
+  customizations: {},
+};
+
+const expectedOpenscapCisL1 = {
+  profile_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+};
+
+const expectedPackagesCisL1 = ['aide', 'neovim'];
+
+const expectedServicesCisL1 = {
+  enabled: ['crond', 'neovim-service'],
+  disabled: ['rpcbind', 'autofs', 'nftables'],
+  masked: ['nfs-server', 'emacs-service'],
+};
+
+const expectedKernelCisL1 = {
+  append: 'audit_backlog_limit=8192 audit=1',
+};
+
+const expectedFilesystemCisL1 = [
+  { min_size: 10737418240, mountpoint: '/' },
+  { min_size: 1073741824, mountpoint: '/tmp' },
+  { min_size: 1073741824, mountpoint: '/home' },
+];
+
+export const oscapCreateBlueprintRequest: CreateBlueprintRequest = {
+  ...baseCreateBlueprintRequest,
+  name: mockBlueprintNames['oscap'],
+  description: mockBlueprintDescriptions['oscap'],
+  customizations: {
+    packages: expectedPackagesCisL1,
+    openscap: expectedOpenscapCisL1,
+    services: expectedServicesCisL1,
+    kernel: expectedKernelCisL1,
+    filesystem: expectedFilesystemCisL1,
+  },
+};
+
+export const oscapBlueprintResponse: BlueprintResponse = {
+  ...oscapCreateBlueprintRequest,
+  id: mockBlueprintIds['oscap'],
+  description: mockBlueprintDescriptions['oscap'],
+};
+
+export const getMockBlueprintResponses = (id: string) => {
+  switch (id) {
+    case mockBlueprintIds['darkChocolate']:
+      return darkChocolateBlueprintResponse;
+    case mockBlueprintIds['oscap']:
+      return oscapBlueprintResponse;
+  }
 };

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -13,9 +13,9 @@ import {
 } from '../fixtures/activationKeys';
 import { mockArchitecturesByDistro } from '../fixtures/architectures';
 import {
+  getMockBlueprintResponses,
   mockBlueprintComposes,
   mockBlueprintComposesOutOfSync,
-  mockBlueprintDetail,
   mockEmptyBlueprintsComposes,
   mockGetBlueprints,
 } from '../fixtures/blueprints';
@@ -189,7 +189,15 @@ export const handlers = [
   rest.get(
     `${IMAGE_BUILDER_API}/experimental/blueprints/:id`,
     (req, res, ctx) => {
-      return res(ctx.status(200), ctx.json(mockBlueprintDetail));
+      const id = req.params['id'];
+      return res(ctx.status(200), ctx.json(getMockBlueprintResponses(id)));
+    }
+  ),
+  rest.put(
+    `${IMAGE_BUILDER_API}/experimental/blueprints/:id`,
+    (req, res, ctx) => {
+      const id = req.params['id'];
+      return res(ctx.status(200), ctx.json({ id: id }));
     }
   ),
   rest.post(


### PR DESCRIPTION
Edit mode is now fully tested and working for OpenSCAP profiles. A
handler for the PUT request was added and the fixtures were updated to
support this.

`EditImageWizard.tsx`: Previously we dispatched `initializeWizard()`
while waiting for the blueprintDetails to load. This meant that the
state was incorrect (empty) while the blueprintDetails request was
in flight.

`requestMapper.tsx`: Correctly populate state in edit mode if the
blueprint contains a custom file system – previously custom mountpoints
were dropped and automatic mode was selected.

`spyOnRequest()`: Differentiate between request types (e.g. GET, PUT)
for the same endpoint.