### PR TITLE
V2 Wizard: Fix snapshot_date field

### DIFF
--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.tsx
@@ -203,7 +203,7 @@ const getImageRequests = (state: RootState): ImageRequest[] => {
       type: uploadTypeByTargetEnv(type),
       options: getImageOptions(type, state),
     },
-    snapshot_date: useLatest ? '' : snapshotDate,
+    snapshot_date: useLatest ? undefined : snapshotDate,
   }));
 };
 

--- a/src/test/Components/CreateImageWizardV2/steps/Registration/Registration.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Registration/Registration.test.tsx
@@ -79,7 +79,6 @@ describe('registration request generated correctly', () => {
   const imageRequest: ImageRequest = {
     architecture: 'x86_64',
     image_type: 'image-installer',
-    snapshot_date: '',
     upload_request: {
       options: {},
       type: 'aws.s3',

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsTarget.test.tsx
@@ -94,7 +94,6 @@ describe('aws image type request generated correctly', () => {
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
       image_type: 'aws',
-      snapshot_date: '',
       upload_request: {
         options: {
           share_with_sources: ['123'],
@@ -121,7 +120,6 @@ describe('aws image type request generated correctly', () => {
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
       image_type: 'aws',
-      snapshot_date: '',
       upload_request: {
         options: {
           share_with_accounts: ['123123123123'],

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureTarget.test.tsx
@@ -121,7 +121,6 @@ describe('azure image type request generated correctly', () => {
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
       image_type: 'azure',
-      snapshot_date: '',
       upload_request: {
         options: {
           source_id: '666',
@@ -152,7 +151,6 @@ describe('azure image type request generated correctly', () => {
     const expectedImageRequest: ImageRequest = {
       architecture: 'x86_64',
       image_type: 'azure',
-      snapshot_date: '',
       upload_request: {
         type: 'azure',
         options: {

--- a/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
@@ -41,7 +41,6 @@ const routes = [
 export const imageRequest: ImageRequest = {
   architecture: 'x86_64',
   image_type: 'image-installer',
-  snapshot_date: '',
   upload_request: {
     options: {},
     type: 'aws.s3',

--- a/src/test/fixtures/blueprints.ts
+++ b/src/test/fixtures/blueprints.ts
@@ -144,7 +144,6 @@ export const mockBlueprintComposes: GetBlueprintComposesApiResponse = {
           {
             architecture: 'x86_64',
             image_type: 'aws',
-            snapshot_date: '',
             upload_request: {
               type: 'aws',
               options: {
@@ -166,7 +165,6 @@ export const mockBlueprintComposes: GetBlueprintComposesApiResponse = {
           {
             architecture: 'x86_64',
             image_type: 'aws',
-            snapshot_date: '',
             upload_request: {
               type: 'aws',
               options: {
@@ -188,7 +186,6 @@ export const mockBlueprintComposes: GetBlueprintComposesApiResponse = {
           {
             architecture: 'x86_64',
             image_type: 'gcp',
-            snapshot_date: '',
             upload_request: {
               type: 'gcp',
               options: {


### PR DESCRIPTION
The snapshot_date in the image_request must be a date. snapshot_date is an optional field and if no snapshot is used, the field should be undefined. Previously it was an empty string and this caused image builder to return a code 400 with message "Snapshot date is not in DateOnly (yyyy-mm-dd) format".