### PR TITLE
V2Wizard: Hide an option to manually configure FSC for ISO targets

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FileSystem/index.tsx
@@ -8,10 +8,12 @@ import FileSystemPartition from './FileSystemPartition';
 
 import { useAppSelector } from '../../../../store/hooks';
 import { selectFileSystemPartitionMode } from '../../../../store/wizardSlice';
+import { useHasIsoTargetOnly } from '../../utilities/hasIsoTargetOnly';
 export type FileSystemPartitionMode = 'automatic' | 'manual';
 
 const FileSystemStep = () => {
   const fileSystemPartitionMode = useAppSelector(selectFileSystemPartitionMode);
+  const hasIsoTargetOnly = useHasIsoTargetOnly();
 
   return (
     <Form>
@@ -19,7 +21,9 @@ const FileSystemStep = () => {
         File system configuration
       </Title>
       <Text>Define the partitioning of the image</Text>
-      {fileSystemPartitionMode === 'automatic' ? (
+      {hasIsoTargetOnly ? (
+        <FileSystemAutomaticPartition />
+      ) : fileSystemPartitionMode === 'automatic' ? (
         <>
           <FileSystemPartition />
           <FileSystemAutomaticPartition />

--- a/src/Components/CreateImageWizardV2/utilities/hasIsoTargetOnly.ts
+++ b/src/Components/CreateImageWizardV2/utilities/hasIsoTargetOnly.ts
@@ -1,0 +1,7 @@
+import { useAppSelector } from '../../../store/hooks';
+import { selectImageTypes } from '../../../store/wizardSlice';
+
+export const useHasIsoTargetOnly = () => {
+  const environments = useAppSelector(selectImageTypes);
+  return environments.length === 1 && environments.includes('image-installer');
+};

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -80,6 +80,13 @@ const getSourceDropdown = async () => {
   return sourceDropdown;
 };
 
+const clickFromImageOutputToFsc = async () => {
+  await clickNext();
+  await userEvent.click(await screen.findByText(/Register later/));
+  await clickNext();
+  await clickNext(); // skip OSCAP
+};
+
 beforeAll(() => {
   // scrollTo is not defined in jsdom
   window.HTMLElement.prototype.scrollTo = function () {};
@@ -819,6 +826,32 @@ describe('Step File system configuration', () => {
     await waitFor(() => expect(mountPointAlerts[0]).not.toBeInTheDocument());
     await waitFor(() => expect(mountPointAlerts[1]).not.toBeInTheDocument());
     expect(await getNextButton()).toBeEnabled();
+  });
+
+  test('Manual partitioning is hidden for ISO targets only', async () => {
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
+    await user.click(await screen.findByTestId('checkbox-image-installer'));
+    await clickFromImageOutputToFsc();
+    expect(
+      screen.queryByText(/manually configure partitions/i)
+    ).not.toBeInTheDocument();
+  });
+
+  test('Manual partitioning is shown for ISO target and other target', async () => {
+    ({ router } = await renderCustomRoutesWithReduxRouter(
+      'imagewizard',
+      {},
+      routes
+    ));
+    await user.click(await screen.findByTestId('checkbox-image-installer'));
+    await user.click(await screen.findByTestId('checkbox-guest-image'));
+    await clickFromImageOutputToFsc();
+    await user.click(await screen.findByText(/manually configure partitions/i));
+    await screen.findByText('Configure partitions');
   });
 });
 

--- a/src/test/Components/CreateImageWizardV2/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
@@ -31,10 +31,10 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 }));
 
 const goToFileSystemConfigurationStep = async () => {
-  const bareMetalCheckBox = await screen.findByRole('checkbox', {
-    name: /bare metal installer checkbox/i,
+  const guestImageCheckBox = await screen.findByRole('checkbox', {
+    name: /virtualization guest image checkbox/i,
   });
-  await userEvent.click(bareMetalCheckBox);
+  await userEvent.click(guestImageCheckBox);
   await clickNext(); // Registration
   await clickRegisterLater();
   await clickNext(); // OpenSCAP

--- a/src/test/Components/CreateImageWizardV2/steps/Oscap/Oscap.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Oscap/Oscap.test.tsx
@@ -32,10 +32,10 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 }));
 
 const goToOscapStep = async () => {
-  const bareMetalCheckBox = await screen.findByRole('checkbox', {
-    name: /bare metal installer checkbox/i,
+  const guestImageCheckBox = await screen.findByRole('checkbox', {
+    name: /virtualization guest image checkbox/i,
   });
-  await userEvent.click(bareMetalCheckBox);
+  await userEvent.click(guestImageCheckBox);
   await clickNext(); // Registration
   await clickRegisterLater();
   await clickNext(); // OpenSCAP

--- a/src/test/Components/CreateImageWizardV2/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Packages/Packages.test.tsx
@@ -39,10 +39,10 @@ jest.mock('@unleash/proxy-client-react', () => ({
 }));
 
 const goToPackagesStep = async () => {
-  const bareMetalCheckBox = await screen.findByRole('checkbox', {
-    name: /bare metal installer checkbox/i,
+  const guestImageCheckBox = await screen.findByRole('checkbox', {
+    name: /virtualization guest image checkbox/i,
   });
-  await userEvent.click(bareMetalCheckBox);
+  await userEvent.click(guestImageCheckBox);
   await clickNext(); // Registration
   await clickRegisterLater();
   await clickNext(); // OpenSCAP

--- a/src/test/Components/CreateImageWizardV2/steps/Registration/Registration.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Registration/Registration.test.tsx
@@ -78,7 +78,7 @@ const goToReviewStep = async () => {
 describe('registration request generated correctly', () => {
   const imageRequest: ImageRequest = {
     architecture: 'x86_64',
-    image_type: 'image-installer',
+    image_type: 'guest-image',
     upload_request: {
       options: {},
       type: 'aws.s3',

--- a/src/test/Components/CreateImageWizardV2/steps/Repositories/Repositories.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Repositories/Repositories.test.tsx
@@ -1,4 +1,4 @@
-import { findByLabelText, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT } from '../../../../../constants';
@@ -36,10 +36,10 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 }));
 
 const goToRepositoriesStep = async () => {
-  const bareMetalCheckBox = await screen.findByRole('checkbox', {
-    name: /bare metal installer checkbox/i,
+  const guestImageCheckBox = await screen.findByRole('checkbox', {
+    name: /virtualization guest image checkbox/i,
   });
-  await userEvent.click(bareMetalCheckBox);
+  await userEvent.click(guestImageCheckBox);
   await clickNext(); // Registration
   await clickRegisterLater();
   await clickNext(); // OpenSCAP

--- a/src/test/Components/CreateImageWizardV2/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Snapshot/Snapshot.test.tsx
@@ -36,10 +36,10 @@ jest.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 }));
 
 const goToSnapshotStep = async () => {
-  const bareMetalCheckBox = await screen.findByRole('checkbox', {
-    name: /bare metal installer checkbox/i,
+  const guestImageCheckBox = await screen.findByRole('checkbox', {
+    name: /virtualization guest image checkbox/i,
   });
-  await userEvent.click(bareMetalCheckBox);
+  await userEvent.click(guestImageCheckBox);
   await clickNext(); // Registration
   await clickRegisterLater();
   await clickNext(); // OpenSCAP

--- a/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizardV2/wizardTestUtils.tsx
@@ -40,7 +40,7 @@ const routes = [
 
 export const imageRequest: ImageRequest = {
   architecture: 'x86_64',
-  image_type: 'image-installer',
+  image_type: 'guest-image',
   upload_request: {
     options: {},
     type: 'aws.s3',
@@ -80,10 +80,10 @@ export const render = async (searchParams = {}) => {
 };
 
 export const goToRegistrationStep = async () => {
-  const bareMetalCheckBox = await screen.findByRole('checkbox', {
-    name: /bare metal installer checkbox/i,
+  const guestImageCheckBox = await screen.findByRole('checkbox', {
+    name: /virtualization guest image checkbox/i,
   });
-  await userEvent.click(bareMetalCheckBox);
+  await userEvent.click(guestImageCheckBox);
   await clickNext();
 };
 


### PR DESCRIPTION
Fixes #1788

This removes an option to manually configure FSC for ISO targets only.

A custom hook `useHasIsoTargetOnly` was added as it will be later needed in `requestMapper`. The current behaviour is so the option to manually configure partitions is not shown to the user for ISO targets only, but the possible FSC customisations from OSCAP profile get applied anyway.

The easiest way to solve this will be checking for `hasIsoTargetOnly` in `requestMapper` and populating the request with customisations / empty array based on the result.

The other way would be stopping the FSC from being populated during OSCAP profile selection. This created a bug when user was still able to click between steps in the nav menu and when they returned to the FSC step the partitions were not populated until the OSCAP profile got changed.