### PR TITLE
V2Wizard: Reinitialize AWS/Azure/GCP after deselecting target

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizardV2/steps/ImageOutput/TargetEnvironment.tsx
@@ -21,6 +21,9 @@ import {
 import { provisioningApi } from '../../../../store/provisioningApi';
 import {
   addImageType,
+  reinitializeAws,
+  reinitializeAzure,
+  reinitializeGcp,
   removeImageType,
   selectArchitecture,
   selectDistribution,
@@ -50,6 +53,16 @@ const TargetEnvironment = () => {
 
   const handleToggleEnvironment = (environment: ImageTypes) => {
     if (environments.includes(environment)) {
+      switch (environment) {
+        case 'aws':
+          dispatch(reinitializeAws());
+          break;
+        case 'azure':
+          dispatch(reinitializeAzure());
+          break;
+        case 'gcp':
+          dispatch(reinitializeGcp());
+      }
       dispatch(removeImageType(environment));
     } else {
       dispatch(addImageType(environment));

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -354,6 +354,11 @@ export const wizardSlice = createSlice({
     changeAwsSourceId: (state, action: PayloadAction<string | undefined>) => {
       state.aws.sourceId = action.payload;
     },
+    reinitializeAws: (state) => {
+      state.aws.accountId = '';
+      state.aws.shareMethod = 'sources';
+      state.aws.source = undefined;
+    },
     changeAzureTenantId: (state, action: PayloadAction<string>) => {
       state.azure.tenantId = action.payload;
     },
@@ -372,6 +377,13 @@ export const wizardSlice = createSlice({
     changeAzureResourceGroup: (state, action: PayloadAction<string>) => {
       state.azure.resourceGroup = action.payload;
     },
+    reinitializeAzure: (state) => {
+      state.azure.shareMethod = 'sources';
+      state.azure.tenantId = '';
+      state.azure.subscriptionId = '';
+      state.azure.source = '';
+      state.azure.resourceGroup = '';
+    },
     changeGcpShareMethod: (state, action: PayloadAction<GcpShareMethod>) => {
       switch (action.payload) {
         case 'withInsights':
@@ -388,6 +400,11 @@ export const wizardSlice = createSlice({
     },
     changeGcpEmail: (state, action: PayloadAction<string>) => {
       state.gcp.email = action.payload;
+    },
+    reinitializeGcp: (state) => {
+      state.gcp.shareMethod = 'withGoogle';
+      state.gcp.accountType = 'user';
+      state.gcp.email = '';
     },
     changeRegistrationType: (
       state,
@@ -623,14 +640,17 @@ export const {
   changeAwsAccountId,
   changeAwsShareMethod,
   changeAwsSourceId,
+  reinitializeAws,
   changeAzureTenantId,
   changeAzureShareMethod,
   changeAzureSubscriptionId,
   changeAzureSource,
   changeAzureResourceGroup,
+  reinitializeAzure,
   changeGcpShareMethod,
   changeGcpAccountType,
   changeGcpEmail,
+  reinitializeGcp,
   changeRegistrationType,
   changeActivationKey,
   changeOscapProfile,

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Aws/AwsTarget.test.tsx
@@ -6,7 +6,7 @@ import {
   CreateBlueprintRequest,
   ImageRequest,
 } from '../../../../../../store/imageBuilderApi';
-import { clickNext } from '../../../../../testUtils';
+import { clickBack, clickNext } from '../../../../../testUtils';
 import {
   blueprintRequest,
   clickRegisterLater,
@@ -55,6 +55,17 @@ const selectAwsTarget = async () => {
   await render();
   const awsCard = await screen.findByTestId('upload-aws');
   await userEvent.click(awsCard);
+  await clickNext();
+};
+
+const deselectAwsAndSelectGuestImage = async () => {
+  const awsCard = await screen.findByTestId('upload-aws');
+  await userEvent.click(awsCard);
+  await userEvent.click(
+    await screen.findByRole('checkbox', {
+      name: /virtualization guest image checkbox/i,
+    })
+  );
   await clickNext();
 };
 
@@ -134,5 +145,17 @@ describe('aws image type request generated correctly', () => {
     };
 
     expect(receivedRequest).toEqual(expectedRequest);
+  });
+
+  test('after selecting and deselecting aws', async () => {
+    await selectAwsTarget();
+    await goToAwsStep();
+    await selectSource();
+    await clickBack();
+    await deselectAwsAndSelectGuestImage();
+    await goToReview();
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    expect(receivedRequest).toEqual(blueprintRequest);
   });
 });

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/Azure/AzureTarget.test.tsx
@@ -6,7 +6,7 @@ import {
   CreateBlueprintRequest,
   ImageRequest,
 } from '../../../../../../store/imageBuilderApi';
-import { clickNext } from '../../../../../testUtils';
+import { clickBack, clickNext } from '../../../../../testUtils';
 import {
   blueprintRequest,
   clickRegisterLater,
@@ -55,6 +55,17 @@ const selectAzureTarget = async () => {
   await render();
   const azureCard = await screen.findByTestId('upload-azure');
   await userEvent.click(azureCard);
+  await clickNext();
+};
+
+const deselectAzureAndSelectGuestImage = async () => {
+  const azureCard = await screen.findByTestId('upload-azure');
+  await userEvent.click(azureCard);
+  await userEvent.click(
+    await screen.findByRole('checkbox', {
+      name: /virtualization guest image checkbox/i,
+    })
+  );
   await clickNext();
 };
 
@@ -167,5 +178,17 @@ describe('azure image type request generated correctly', () => {
     };
 
     expect(receivedRequest).toEqual(expectedRequest);
+  });
+
+  test('after selecting and deselecting azure', async () => {
+    await selectAzureTarget();
+    await goToAzureStep();
+    await selectSource();
+    await clickBack();
+    await deselectAzureAndSelectGuestImage();
+    await goToReview();
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    expect(receivedRequest).toEqual(blueprintRequest);
   });
 });

--- a/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/GCPTarget.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/TargetEnvironment/GCPTarget.test.tsx
@@ -8,7 +8,7 @@ import {
   ImageRequest,
   ImageTypes,
 } from '../../../../../store/imageBuilderApi';
-import { clickNext } from '../../../../testUtils';
+import { clickBack, clickNext } from '../../../../testUtils';
 import {
   blueprintRequest,
   clickRegisterLater,
@@ -70,6 +70,17 @@ const clickGCPTarget = async () => {
   await render();
   const googleOption = await screen.findByTestId('upload-google');
   await userEvent.click(googleOption);
+  await clickNext();
+};
+
+const deselectGcpAndSelectGuestImage = async () => {
+  const googleCard = await screen.findByTestId('upload-google');
+  await userEvent.click(googleCard);
+  await userEvent.click(
+    await screen.findByRole('checkbox', {
+      name: /virtualization guest image checkbox/i,
+    })
+  );
   await clickNext();
 };
 
@@ -153,5 +164,16 @@ describe('gcp image type request generated correctly', () => {
       image_requests: [expectedImageRequest],
     };
     expect(receivedRequest).toEqual(expectedRequest);
+  });
+
+  test('after selecting and deselecting gcp', async () => {
+    await clickGCPTarget();
+    await selectGoogleAccount('google-domain');
+    await clickBack();
+    await deselectGcpAndSelectGuestImage();
+    await goToReview();
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    expect(receivedRequest).toEqual(blueprintRequest);
   });
 });


### PR DESCRIPTION
Fixes #1555
    
This reinitializes the state of AWS/Azure/GCP target after it's tile was deselected. This way the state for the target won't be hanging there.