### PR TITLE
ESLint: Make no-unused-vars rule stricter

### DIFF
--- a/.eslintrc-typescript.yml
+++ b/.eslintrc-typescript.yml
@@ -11,5 +11,3 @@ rules:
       ts-check: true
       minimumDescriptionLength: 5
   "@typescript-eslint/ban-types": off
-  "@typescript-eslint/no-unused-vars":
-    - warn

--- a/src/Components/CreateImageWizardV2/steps/Snapshot/Snapshot.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Snapshot/Snapshot.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 
 import {
-  Alert,
   Button,
   DatePicker,
   Flex,
@@ -12,9 +11,6 @@ import {
   Title,
 } from '@patternfly/react-core';
 
-import ConditionalTooltip from './components/ConditionalTooltip';
-
-import { useListFeaturesQuery } from '../../../../store/contentSourcesApi';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
   selectSnapshotDate,


### PR DESCRIPTION
This switches the `no-unused-vars` from warning to error and fixes the errors this caused.