### PR TITLE
V2Wizard: Fix FSC units on Edit

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemConfiguration.tsx
@@ -105,7 +105,7 @@ const FileSystemConfiguration = () => {
       addPartition({
         id,
         mountpoint: '/home',
-        min_size: UNIT_GIB.toString(),
+        min_size: '1',
         unit: 'GiB',
       })
     );
@@ -237,7 +237,7 @@ export const Row = ({
 
       <Td width={20}>xfs</Td>
       <Td width={20}>
-        <MinimumSize partition={partition} units={partition.unit} />
+        <MinimumSize partition={partition} />
       </Td>
       <Td width={10}>
         <SizeUnit partition={partition} />
@@ -335,7 +335,6 @@ const MountpointSuffix = ({ partition }: MountpointSuffixPropTypes) => {
 
 type MinimumSizePropTypes = {
   partition: Partition;
-  units: Units;
 };
 
 export type Units = 'KiB' | 'MiB' | 'GiB';
@@ -351,21 +350,7 @@ export const getConversionFactor = (units: Units) => {
   }
 };
 
-const MinimumSize = ({ partition, units }: MinimumSizePropTypes) => {
-  const conversionFactor = getConversionFactor(units);
-
-  const convertToDisplayUnits = (minSize: string) => {
-    return minSize.length > 0
-      ? (parseInt(minSize) / conversionFactor).toString()
-      : '0';
-  };
-
-  const convertToBytes = (minSize: string) => {
-    return minSize.length > 0
-      ? (parseInt(minSize) * conversionFactor).toString()
-      : '0';
-  };
-
+const MinimumSize = ({ partition }: MinimumSizePropTypes) => {
   const dispatch = useAppDispatch();
 
   return (
@@ -373,7 +358,7 @@ const MinimumSize = ({ partition, units }: MinimumSizePropTypes) => {
       ariaLabel="minimum partition size"
       helperText="Must be larger than 0"
       validator={isMountpointMinSizeValid}
-      value={convertToDisplayUnits(partition.min_size)}
+      value={partition.min_size}
       type="text"
       ouiaId="size"
       onChange={(event, minSize) => {
@@ -381,7 +366,7 @@ const MinimumSize = ({ partition, units }: MinimumSizePropTypes) => {
           dispatch(
             changePartitionMinSize({
               id: partition.id,
-              min_size: convertToBytes(minSize),
+              min_size: minSize,
             })
           );
           dispatch(

--- a/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
@@ -40,7 +40,8 @@ import {
   removePackage,
   clearPartitions,
 } from '../../../../store/wizardSlice';
-import { Partition } from '../FileSystem/FileSystemConfiguration';
+import { parseSizeUnit } from '../../utilities/parseSizeUnit';
+import { Partition, Units } from '../FileSystem/FileSystemConfiguration';
 
 const ProfileSelector = () => {
   const oscapProfile = useAppSelector(selectProfile);
@@ -102,10 +103,11 @@ const ProfileSelector = () => {
     dispatch(clearPartitions());
 
     const newPartitions = oscapPartitions.map((filesystem) => {
+      const [size, unit] = parseSizeUnit(filesystem.min_size);
       const partition: Partition = {
         mountpoint: filesystem.mountpoint,
-        min_size: filesystem.min_size.toString(),
-        unit: 'GiB',
+        min_size: size.toString(),
+        unit: unit as Units,
         id: uuidv4(),
       };
       return partition;

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTables.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTables.tsx
@@ -23,7 +23,6 @@ import {
   selectPartitions,
   selectRecommendedRepositories,
 } from '../../../../store/wizardSlice';
-import { getConversionFactor } from '../FileSystem/FileSystemConfiguration';
 
 type repoPropType = {
   repoUrl: string[] | undefined;
@@ -89,11 +88,7 @@ export const FSReviewTable = () => {
                 <Td className="pf-m-width-30">{partition.mountpoint}</Td>
                 <Td className="pf-m-width-30">xfs</Td>
                 <Td className="pf-m-width-30">
-                  {(
-                    parseInt(partition.min_size) /
-                    getConversionFactor(partition.unit)
-                  ).toString()}{' '}
-                  {partition.unit}
+                  {parseInt(partition.min_size).toString()} {partition.unit}
                 </Td>
               </Tr>
             ))}

--- a/src/Components/CreateImageWizardV2/utilities/parseSizeUnit.ts
+++ b/src/Components/CreateImageWizardV2/utilities/parseSizeUnit.ts
@@ -1,0 +1,20 @@
+import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../../constants';
+import { Units } from '../steps/FileSystem/FileSystemConfiguration';
+
+export const parseSizeUnit = (bytesize: string) => {
+  let size;
+  let unit: Units = 'GiB';
+
+  if (parseInt(bytesize) % UNIT_GIB === 0) {
+    size = parseInt(bytesize) / UNIT_GIB;
+    unit = 'GiB';
+  } else if (parseInt(bytesize) % UNIT_MIB === 0) {
+    size = parseInt(bytesize) / UNIT_MIB;
+    unit = 'MiB';
+  } else if (parseInt(bytesize) % UNIT_KIB === 0) {
+    size = parseInt(bytesize) / UNIT_KIB;
+    unit = 'KiB';
+  }
+
+  return [String(size), unit];
+};

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -26,7 +26,7 @@ import {
 } from '../Components/CreateImageWizardV2/steps/TargetEnvironment/Gcp';
 import { V1ListSourceResponseItem } from '../Components/CreateImageWizardV2/types';
 import { isBlueprintNameValid } from '../Components/CreateImageWizardV2/validators';
-import { RHEL_9, UNIT_GIB, X86_64 } from '../constants';
+import { RHEL_9, X86_64 } from '../constants';
 
 import { RootState } from '.';
 
@@ -452,7 +452,7 @@ export const wizardSlice = createSlice({
               {
                 id: uuidv4(),
                 mountpoint: '/',
-                min_size: (10 * UNIT_GIB).toString(),
+                min_size: '10',
                 unit: 'GiB',
               },
             ];
@@ -467,7 +467,7 @@ export const wizardSlice = createSlice({
           {
             id: uuidv4(),
             mountpoint: '/',
-            min_size: (10 * UNIT_GIB).toString(),
+            min_size: '10',
             unit: 'GiB',
           },
         ];

--- a/src/test/Components/CreateImageWizardV2/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
@@ -1,7 +1,12 @@
 import { screen, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
-import { CREATE_BLUEPRINT, UNIT_GIB } from '../../../../../constants';
+import {
+  CREATE_BLUEPRINT,
+  UNIT_GIB,
+  UNIT_KIB,
+  UNIT_MIB,
+} from '../../../../../constants';
 import { clickNext } from '../../../../testUtils';
 import {
   blueprintRequest,
@@ -161,7 +166,7 @@ describe('file system configuration request generated correctly', () => {
       customizations: {
         filesystem: [
           {
-            min_size: 10 * UNIT_GIB,
+            min_size: 10 * UNIT_MIB,
             mountpoint: '/',
           },
         ],
@@ -184,7 +189,7 @@ describe('file system configuration request generated correctly', () => {
       customizations: {
         filesystem: [
           {
-            min_size: 10 * UNIT_GIB,
+            min_size: 10 * UNIT_KIB,
             mountpoint: '/',
           },
         ],


### PR DESCRIPTION
Fixes #2015

This updates the logic of parsing bytesize into size/unit pair.

Currently 'GiB' is set as a default which causes problem with smaller partitions on Edit.

A validation for the min_size is in place and the rule is that the size cannot be smaller than 0 of a given unit. If there was a partition with smaller size in KiB it will break the rule when converted to GiB.