### PR TITLE
BlueprintTable: Invalidate tags on deleteBlueprint

### DIFF
--- a/src/store/enhancedImageBuilderApi.ts
+++ b/src/store/enhancedImageBuilderApi.ts
@@ -190,7 +190,11 @@ const enhancedApi = imageBuilderApi.enhanceEndpoints({
       },
     },
     deleteBlueprint: {
-      invalidatesTags: [{ type: 'Blueprints' }],
+      invalidatesTags: [
+        { type: 'Blueprints' },
+        { type: 'BlueprintComposes' },
+        { type: 'Compose' },
+      ],
       onQueryStarted: async (_, { dispatch, queryFulfilled }) => {
         queryFulfilled
           .then(() => {


### PR DESCRIPTION
Invalidates Composes and ComposeBlueprints tags upon deleting a blueprint so that composes are re-fetched and the table is updated appropriately.

Previously, a deleted blueprints composes would still show in the table until the page was refreshed.