### PR TITLE
scripts: Run parts of `api` script in correct order

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "test": "TZ=UTC jest --verbose --no-cache",
     "test:single": "jest --verbose -w 1",
     "build": "webpack --config config/prod.webpack.config.js",
-    "api": "npm-run-all api:*",
+    "api": "npm-run-all api:pull api:generate",
     "api:generate": "bash api/codegen.sh",
     "api:pull": "bash api/pull.sh",
     "verify": "npm-run-all build lint test"


### PR DESCRIPTION
This ensures `api:pull` and `api:generate` run in correct order when running `npm run api`.