### PR TITLE
src/constants: Use major rhel distros by default

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -40,8 +40,8 @@ export const CREATE_RHEL_IMAGES_WITH_AUTOMATED_MANAGEMENT_URL =
 export const OSBUILD_SERVICE_ARCHITECTURE_URL =
   'https://osbuild.org/docs/service/architecture/';
 
-export const RHEL_8 = 'rhel-89';
-export const RHEL_9 = 'rhel-94';
+export const RHEL_8 = 'rhel-8';
+export const RHEL_9 = 'rhel-9';
 export const CENTOS_8 = 'centos-8';
 export const CENTOS_9 = 'centos-9';
 export const X86_64 = 'x86_64';

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -73,7 +73,7 @@ describe('Images Table', () => {
       const cells = await within(row).findAllByRole('cell');
       expect(cells[1]).toHaveTextContent(imageNameValues[index]);
       expect(cells[2]).toHaveTextContent('Apr 27, 2021');
-      expect(cells[3]).toHaveTextContent('RHEL 8.9');
+      expect(cells[3]).toHaveTextContent('RHEL 8');
     });
 
     // TODO Test remaining table content.

--- a/src/test/fixtures/architectures.ts
+++ b/src/test/fixtures/architectures.ts
@@ -4,7 +4,7 @@ export const mockArchitecturesByDistro = (
   distro: Distributions
 ): Architectures => {
   const mockDistros: { [key: string]: Architectures } = {
-    'rhel-94': [
+    'rhel-9': [
       {
         arch: 'x86_64',
         image_types: [
@@ -23,7 +23,7 @@ export const mockArchitecturesByDistro = (
         repositories: [
           {
             baseurl:
-              'https://cdn.redhat.com/content/dist/rhel9/9.2/x86_64/baseos/os',
+              'https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os',
             rhsm: true,
           },
         ],
@@ -34,13 +34,13 @@ export const mockArchitecturesByDistro = (
         repositories: [
           {
             baseurl:
-              'https://cdn.redhat.com/content/dist/rhel9/9.2/aarch64/baseos/os',
+              'https://cdn.redhat.com/content/dist/rhel9/9/aarch64/baseos/os',
             rhsm: true,
           },
         ],
       },
     ],
-    'rhel-89': [
+    'rhel-8': [
       {
         arch: 'x86_64',
         image_types: [
@@ -60,7 +60,7 @@ export const mockArchitecturesByDistro = (
         repositories: [
           {
             baseurl:
-              'https://cdn.redhat.com/content/dist/rhel8/8.8/x86_64/baseos/os',
+              'https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os',
             rhsm: true,
           },
         ],
@@ -71,7 +71,7 @@ export const mockArchitecturesByDistro = (
         repositories: [
           {
             baseurl:
-              'https://cdn.redhat.com/content/dist/rhel8/8.8/aarch64/baseos/os',
+              'https://cdn.redhat.com/content/dist/rhel8/8/aarch64/baseos/os',
             rhsm: true,
           },
         ],


### PR DESCRIPTION
The tradeoff is not being able to discern between a minor version and a major version in the 2 weeks post GA if the images were built using the UI, but I think the tradeoff is worth it. The frontend will never need updating to switch to a new version.