### PR TITLE
V2Wizard: Make e-mail validation case insensitive

### DIFF
--- a/src/Components/CreateImageWizardV2/validators.ts
+++ b/src/Components/CreateImageWizardV2/validators.ts
@@ -27,7 +27,7 @@ export const isAzureResourceGroupValid = (azureResourceGroup: string) => {
 export const isGcpEmailValid = (gcpShareWithAccount: string | undefined) => {
   return (
     gcpShareWithAccount !== undefined &&
-    /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,12}$/.test(gcpShareWithAccount) &&
+    /^[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,12}$/i.test(gcpShareWithAccount) &&
     gcpShareWithAccount.length <= 253
   );
 };


### PR DESCRIPTION
Fixes #1554

Case validation for the e-mail field was previously case sensitive, disallowing uppercase letters. This updates the validation to accept both lower and upper case letters.

before:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/6032fa4b-0a7f-43b8-a2c7-48c5538f6735)

after:
![image](https://github.com/osbuild/image-builder-frontend/assets/49452678/c7c194c0-19fc-4f24-b021-a63f77c03f59)
