### PR TITLE
LandingPage / ImagesTable: Set max width for the ImagesTable

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -180,66 +180,64 @@ const ImagesTable = () => {
 
   return (
     <>
-      <>
-        <ImagesTableToolbar
-          itemCount={itemCount}
-          perPage={perPage}
-          page={page}
-          setPage={setPage}
-          onPerPageSelect={onPerPageSelect}
-        />
-        <Table variant="compact" data-testid="images-table">
-          <Thead>
+      <ImagesTableToolbar
+        itemCount={itemCount}
+        perPage={perPage}
+        page={page}
+        setPage={setPage}
+        onPerPageSelect={onPerPageSelect}
+      />
+      <Table variant="compact" data-testid="images-table">
+        <Thead>
+          <Tr>
+            <Th style={{ minWidth: itemCount === 0 ? '30px' : 'auto' }} />
+            <Th>Name</Th>
+            <Th>Updated</Th>
+            <Th>OS</Th>
+            <Th>Target</Th>
+            {experimentalFlag && <Th>Version</Th>}
+            <Th>Status</Th>
+            <Th>Instance</Th>
+            <Th />
+          </Tr>
+        </Thead>
+        {itemCount === 0 && (
+          <Tbody>
             <Tr>
-              <Th style={{ minWidth: itemCount === 0 ? '30px' : 'auto' }} />
-              <Th>Name</Th>
-              <Th>Updated</Th>
-              <Th>OS</Th>
-              <Th>Target</Th>
-              {experimentalFlag && <Th>Version</Th>}
-              <Th>Status</Th>
-              <Th>Instance</Th>
-              <Th />
+              <Td colSpan={12}>
+                <ImagesEmptyState selectedBlueprint={selectedBlueprintId} />
+              </Td>
             </Tr>
-          </Thead>
-          {itemCount === 0 && (
-            <Tbody>
-              <Tr>
-                <Td colSpan={12}>
-                  <ImagesEmptyState selectedBlueprint={selectedBlueprintId} />
-                </Td>
-              </Tr>
-            </Tbody>
-          )}
+          </Tbody>
+        )}
 
-          {composes?.map((compose, rowIndex) => {
-            return (
-              <ImagesTableRow
-                compose={compose}
-                rowIndex={rowIndex}
-                key={compose.id}
-              />
-            );
-          })}
-        </Table>
-        <Toolbar className="pf-u-mb-xl">
-          <ToolbarContent>
-            <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
-              <Pagination
-                variant={PaginationVariant.bottom}
-                itemCount={itemCount}
-                perPage={perPage}
-                page={page}
-                onSetPage={onSetPage}
-                onPerPageSelect={onPerPageSelect}
-                widgetId="compose-pagination-bottom"
-                data-testid="images-pagination-bottom"
-                isCompact
-              />
-            </ToolbarItem>
-          </ToolbarContent>
-        </Toolbar>
-      </>
+        {composes?.map((compose, rowIndex) => {
+          return (
+            <ImagesTableRow
+              compose={compose}
+              rowIndex={rowIndex}
+              key={compose.id}
+            />
+          );
+        })}
+      </Table>
+      <Toolbar className="pf-u-mb-xl">
+        <ToolbarContent>
+          <ToolbarItem variant="pagination" align={{ default: 'alignRight' }}>
+            <Pagination
+              variant={PaginationVariant.bottom}
+              itemCount={itemCount}
+              perPage={perPage}
+              page={page}
+              onSetPage={onSetPage}
+              onPerPageSelect={onPerPageSelect}
+              widgetId="compose-pagination-bottom"
+              data-testid="images-pagination-bottom"
+              isCompact
+            />
+          </ToolbarItem>
+        </ToolbarContent>
+      </Toolbar>
     </>
   );
 };

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -73,7 +73,7 @@ export const LandingPage = () => {
 
   const experimentalImageList = (
     <>
-      <PageSection>
+      <PageSection isWidthLimited>
         {showAlert && <NewAlert setShowAlert={setShowAlert} />}
         <Sidebar hasBorder className="pf-v5-u-background-color-100">
           <SidebarPanel


### PR DESCRIPTION
Fixes #933

This applies `isWidthLimited` to the section containing ImagesTable, ensuring the table doesn't get stretched out too much.

The were also two sets of empty tags around ImagesTable return, this removes one of them.

before:
![Screenshot from 2024-05-07 10-13-01](https://github.com/osbuild/image-builder-frontend/assets/49452678/1d58d5b1-5724-4efe-ac39-fd8a7f03ecce)

after:
![Screenshot from 2024-05-07 10-13-19](https://github.com/osbuild/image-builder-frontend/assets/49452678/4ba01115-0da5-4bb1-aacd-f4ddf0f986c5)
