### PR TITLE
src: Fix "Table headers must have an accessible name" warning

### DIFF
--- a/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
+++ b/src/Components/CreateImageWizard/formComponents/FileSystemConfiguration.js
@@ -379,7 +379,7 @@ const FileSystemConfiguration = ({ ...props }) => {
           >
             <Thead>
               <Tr>
-                <Th />
+                <Th aria-label="Drag mount point" />
                 <Th>Mount point</Th>
                 <Th>Type</Th>
                 <Th>
@@ -405,7 +405,7 @@ const FileSystemConfiguration = ({ ...props }) => {
                     </Button>
                   </Popover>
                 </Th>
-                <Th />
+                <Th aria-label="Remove mount point" />
               </Tr>
             </Thead>
             <Tbody

--- a/src/Components/CreateImageWizard/formComponents/Repositories.js
+++ b/src/Components/CreateImageWizard/formComponents/Repositories.js
@@ -440,7 +440,7 @@ const Repositories = (props) => {
                 <Table variant="compact" data-testid="repositories-table">
                   <Thead>
                     <Tr>
-                      <Th />
+                      <Th aria-label="Selected" />
                       <Th width={45}>Name</Th>
                       <Th width={15}>Architecture</Th>
                       <Th>Version</Th>

--- a/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemTable.tsx
@@ -190,15 +190,15 @@ const FileSystemTable = () => {
     >
       <Thead>
         <Tr>
-          <Th />
+          <Th aria-label="Drag mount point" />
           <Th>Mount point</Th>
-          <Th></Th>
+          <Th aria-label="Suffix"></Th>
           <Th>Type</Th>
           <Th>
             Minimum size <MinimumSizePopover />
           </Th>
-          <Th />
-          <Th />
+          <Th aria-label="Unit" />
+          <Th aria-label="Remove mount point" />
         </Tr>
       </Thead>
 

--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -960,7 +960,7 @@ const Packages = () => {
       <Table variant="compact" data-testid="packages-table">
         <Thead>
           <Tr>
-            <Th />
+            <Th aria-label="Selected" />
             <Th width={20}>Package name</Th>
             <Th width={35}>
               Description

--- a/src/Components/CreateImageWizardV2/steps/Repositories/Repositories.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/Repositories.tsx
@@ -535,7 +535,7 @@ const Repositories = () => {
                 <Table variant="compact" data-testid="repositories-table">
                   <Thead>
                     <Tr>
-                      <Th />
+                      <Th aria-label="Selected" />
                       <Th width={45}>Name</Th>
                       <Th width={15}>Architecture</Th>
                       <Th>Version</Th>

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -190,7 +190,10 @@ const ImagesTable = () => {
       <Table variant="compact" data-testid="images-table">
         <Thead>
           <Tr>
-            <Th style={{ minWidth: itemCount === 0 ? '30px' : 'auto' }} />
+            <Th
+              style={{ minWidth: itemCount === 0 ? '30px' : 'auto' }}
+              aria-label="Details expandable"
+            />
             <Th>Name</Th>
             <Th>Updated</Th>
             <Th>OS</Th>
@@ -198,7 +201,7 @@ const ImagesTable = () => {
             {experimentalFlag && <Th>Version</Th>}
             <Th>Status</Th>
             <Th>Instance</Th>
-            <Th />
+            <Th aria-label="Actions menu" />
           </Tr>
         </Thead>
         {itemCount === 0 && (


### PR DESCRIPTION
The tests output contained following warning:

```
console.warn
    Th: Table headers must have an accessible name. If the Th is intended to be visually empty,
pass in screenReaderText. If the Th contains only non-text, interactive content such as a checkbox
or expand toggle, pass in an aria-label.
```

This fixes the warning by adding an accesible `screenReaderText` text to every empty table heading cell. The text doesn't get rendered, but is available as an information for screen readers.