### PR TITLE
Bug - V2 Wizard: trim searchterm to prevent illegal characters

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -125,7 +125,7 @@ const Packages = () => {
     },
   ] = useSearchRpmMutation();
 
-  const debouncedSearchTerm = useDebounce(searchTerm);
+  const debouncedSearchTerm = useDebounce(searchTerm.trim());
   const debouncedSearchTermLengthOf1 = debouncedSearchTerm.length === 1;
 
   const [


### PR DESCRIPTION
This was feedback from a user related to summit demos

- Removes extra lead/trailing whitespace for the api (not in the input)