### PR TITLE
FileSystemConfiguration: enable mouse selection in TextInput fields

### DIFF
--- a/src/Components/CreateImageWizardV2/ValidatedTextInput.tsx
+++ b/src/Components/CreateImageWizardV2/ValidatedTextInput.tsx
@@ -130,6 +130,11 @@ export const ValidatedTextInput = ({
     return validator(value) ? 'success' : 'error';
   };
 
+  const dontDragMe: TextInputProps['onDragStart'] = (evt) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+  };
+
   return (
     <>
       <TextInput
@@ -142,6 +147,8 @@ export const ValidatedTextInput = ({
         aria-label={ariaLabel}
         onBlur={handleBlur}
         placeholder={placeholder}
+        draggable="true"
+        onDragStart={dontDragMe}
       />
       {!isPristine && !validator(value) && (
         <HelperText>

--- a/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FileSystem/FileSystemConfiguration.tsx
@@ -11,6 +11,7 @@ import {
   WizardFooterWrapper,
 } from '@patternfly/react-core';
 import { Select, SelectOption } from '@patternfly/react-core/deprecated';
+import { TextInputProps } from '@patternfly/react-core/src/components/TextInput/TextInput';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Td, Tr } from '@patternfly/react-table';
@@ -314,6 +315,11 @@ const MountpointSuffix = ({ partition }: MountpointSuffixPropTypes) => {
   const prefix = getPrefix(partition.mountpoint);
   const suffix = getSuffix(partition.mountpoint);
 
+  const dontDragMe: TextInputProps['onDragStart'] = (evt) => {
+    evt.preventDefault();
+    evt.stopPropagation();
+  };
+
   return (
     <TextInput
       value={suffix}
@@ -329,6 +335,8 @@ const MountpointSuffix = ({ partition }: MountpointSuffixPropTypes) => {
       }}
       aria-label="mountpoint suffix"
       ouiaId="mount-suffix"
+      draggable="true"
+      onDragStart={dontDragMe}
     />
   );
 };


### PR DESCRIPTION
explicitly overriding the drag functionality of the parent TR/TD to enable mouse selection

![Screenshot_20240513_125539](https://github.com/osbuild/image-builder-frontend/assets/8057963/72dc54fb-6283-4d89-867b-8898b4da1153)


Do you think this is useful? Is there a simpler solution in react?