### PR TITLE
Search against content sources for distro packages  (HMS-4094)

### DIFF
--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.js
@@ -1219,7 +1219,7 @@ describe('Click through all steps', () => {
     await searchForAvailablePackages(searchbox, 'test');
     await user.click(
       await screen.findByRole('option', {
-        name: /test-sources summary for test package/,
+        name: /test summary for test package/,
       })
     );
     await user.click(
@@ -1360,7 +1360,7 @@ describe('Click through all steps', () => {
       ],
       custom_repositories: custom_repos,
       payload_repositories: payload_repos,
-      packages: ['test-sources'],
+      packages: ['test'],
       subscription: {
         'activation-key': 'name0',
         insights: true,

--- a/src/test/fixtures/packages.ts
+++ b/src/test/fixtures/packages.ts
@@ -2,65 +2,19 @@ import {
   ApiRepositoryRpm,
   ApiSearchRpmResponse,
 } from '../../store/contentSourcesApi';
-import {
-  PackagesResponse,
-  RecommendPackageApiResponse,
-} from '../../store/imageBuilderApi';
-
-export const mockPackagesResults = (search: string): PackagesResponse => {
-  if (search === 'te' || search === 'testPkg-123') {
-    return mockPkgResultAll;
-  } else if (search === 'test') {
-    return {
-      data: [
-        {
-          name: 'testPkg',
-          summary: 'test package summary',
-        },
-        {
-          name: 'lib-test',
-          summary: 'lib-test package summary',
-        },
-        {
-          name: 'test',
-          summary: 'summary for test package',
-        },
-      ],
-      links: { first: '', last: '' },
-      meta: {
-        count: 3,
-      },
-    };
-  } else if (search === 'mock') {
-    return {
-      data: [
-        {
-          name: 'mockPkg',
-          summary: 'test package summary',
-        },
-        {
-          name: 'lib-mock',
-          summary: 'lib-test package summary',
-        },
-        {
-          name: 'mock',
-          summary: 'summary for test package',
-        },
-      ],
-      links: { first: '', last: '' },
-      meta: {
-        count: 3,
-      },
-    };
-  } else {
-    return { data: [], links: { first: '', last: '' }, meta: { count: 0 } };
-  }
-};
+import { RecommendPackageApiResponse } from '../../store/imageBuilderApi';
 
 export const mockSourcesPackagesResults = (
-  search: string
+  search: string,
+  urls: string[]
 ): ApiSearchRpmResponse[] => {
-  if (search === 'test') {
+  const isDistroPkgSearch =
+    urls.filter((u) => u.includes('cdn.redhat.com')).length > 0;
+  if (search === 'te' || search === 'testPkg-123') {
+    return mockPkgResultAll;
+  }
+
+  if (!isDistroPkgSearch) {
     return [
       {
         package_name: 'testPkg-sources',
@@ -75,28 +29,41 @@ export const mockSourcesPackagesResults = (
         summary: 'summary for test package',
       },
     ];
-  } else {
-    return [];
   }
-};
 
-export const mockPkgResultAlpha: PackagesResponse = {
-  meta: { count: 3 },
-  links: { first: '', last: '' },
-  data: [
-    {
-      name: 'lib-test',
-      summary: 'lib-test package summary',
-    },
-    {
-      name: 'Z-test',
-      summary: 'Z-test package summary',
-    },
-    {
-      name: 'test',
-      summary: 'summary for test package',
-    },
-  ],
+  if (search === 'test') {
+    return [
+      {
+        package_name: 'testPkg',
+        summary: 'test package summary',
+      },
+      {
+        package_name: 'lib-test',
+        summary: 'lib-test package summary',
+      },
+      {
+        package_name: 'test',
+        summary: 'summary for test package',
+      },
+    ];
+  }
+  if (search === 'mock' && isDistroPkgSearch) {
+    return [
+      {
+        package_name: 'mockPkg',
+        summary: 'test package summary',
+      },
+      {
+        package_name: 'lib-mock',
+        summary: 'lib-test package summary',
+      },
+      {
+        package_name: 'mock',
+        summary: 'summary for test package',
+      },
+    ];
+  }
+  return [];
 };
 
 export const mockPkgResultAlphaContentSources: ApiRepositoryRpm[] = [
@@ -117,29 +84,23 @@ export const mockPkgResultAlphaContentSources: ApiRepositoryRpm[] = [
   },
 ];
 
-export const mockPkgResultPartial: PackagesResponse = {
-  meta: { count: 132 },
-  links: { first: '', last: '' },
-  data: new Array(100).fill(undefined).map((_, i) => {
+export const mockPkgResultPartial: ApiSearchRpmResponse[] = new Array(100)
+  .fill(undefined)
+  .map((_, i) => {
     return {
-      name: 'testPkg-' + i,
+      package_name: 'testPkg-' + i,
       summary: 'test package summary',
-      version: '1.0',
     };
-  }),
-};
+  });
 
-export const mockPkgResultAll: PackagesResponse = {
-  meta: { count: 132 },
-  links: { first: '', last: '' },
-  data: new Array(132).fill(undefined).map((_, i) => {
+export const mockPkgResultAll: ApiSearchRpmResponse[] = new Array(132)
+  .fill(undefined)
+  .map((_, i) => {
     return {
-      name: 'testPkg-' + i,
+      package_name: 'testPkg-' + i,
       summary: 'test package summary',
-      version: '1.0',
     };
-  }),
-};
+  });
 
 export const mockPkgRecommendations: RecommendPackageApiResponse = {
   packages: [

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -58,8 +58,11 @@ export const handlers = [
     }
   ),
   rest.post(`${CONTENT_SOURCES_API}/rpms/names`, async (req, res, ctx) => {
-    const { search } = await req.json();
-    return res(ctx.status(200), ctx.json(mockSourcesPackagesResults(search)));
+    const { search, urls } = await req.json();
+    return res(
+      ctx.status(200),
+      ctx.json(mockSourcesPackagesResults(search, urls))
+    );
   }),
   rest.get(`${CONTENT_SOURCES_API}/features/`, async (req, res, ctx) => {
     return res(ctx.status(200), ctx.json(mockedFeatureResponse));


### PR DESCRIPTION
Switches over to content sources entirely. For package groups we'll need to use content sources as well, so I think it makes sense. This keeps the custom and distro packages query separated, because we do some heuristics there. 

I also noticed that distro packages are search when there's 2 characters, and custom/recommends when there's 3 or more. Could change this to be consistent.

I removed the v1 wizard test without concent sources entirely.