### PR TITLE
WizardV2: add 'some' word to image table toolbar title

### DIFF
--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -137,7 +137,7 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
                 '0 var(--pf-v5-c-toolbar__content--PaddingRight) 0 var(--pf-v5-c-toolbar__content--PaddingLeft)',
             }}
             isInline
-            title={`The selected blueprint is at version ${selectedBlueprintVersion}, images are at version ${latestImageVersion}. Build images to synchronize with the latest version.`}
+            title={`The selected blueprint is at version ${selectedBlueprintVersion}, the latest images are at version ${latestImageVersion}. Build images to synchronize with the latest version.`}
             ouiaId="blueprint-out-of-sync-alert"
           />
         )}

--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -109,13 +109,13 @@ describe('Blueprints', () => {
 
     await selectBlueprintById(blueprintIdOutOfSync);
     await screen.findByText(
-      'The selected blueprint is at version 2, images are at version 1. Build images to synchronize with the latest version.'
+      'The selected blueprint is at version 2, the latest images are at version 1. Build images to synchronize with the latest version.'
     );
 
     await selectBlueprintById(blueprintIdWithComposes);
     expect(
       screen.queryByText(
-        'The selected blueprint is at version 2, images are at version 1. Build images to synchronize with the latest version.'
+        'The selected blueprint is at version 2, the latest images are at version 1. Build images to synchronize with the latest version.'
       )
     ).not.toBeInTheDocument();
   });


### PR DESCRIPTION
this commit add the word 'some' to the toolbar title
<img width="525" alt="Screenshot 2024-05-21 at 12 34 38" src="https://github.com/osbuild/image-builder-frontend/assets/73419853/fea17455-b13e-4860-ace3-79b0b071fdac">
