### PR TITLE
WizardV2: fix google account typo

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Gcp/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/TargetEnvironment/Gcp/index.tsx
@@ -42,7 +42,7 @@ const Gcp = () => {
         <Radio
           id="share-with-google"
           data-testid="share-with-google"
-          label="Share image with a Google acount"
+          label="Share image with a Google account"
           name="radio-1"
           description={
             <Text>

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -459,7 +459,7 @@ describe('Step Upload to Google', () => {
     await setUp();
 
     const shareRadioButton = await screen.findByText(
-      /share image with a google acount/i
+      /share image with a google account/i
     );
     await user.click(shareRadioButton);
 
@@ -1176,7 +1176,7 @@ describe('Keyboard accessibility', () => {
     // Target environment google
     expect(
       await screen.findByRole('radio', {
-        name: /share image with a google acount/i,
+        name: /share image with a google account/i,
       })
     ).toHaveFocus();
     await user.type(


### PR DESCRIPTION
This fixes following typo "Google acount" -> "Google account"