### PR TITLE
V2Wizard: Disable OpenSCAP for WSL (HMS-3945)

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FileSystem/index.tsx
@@ -8,12 +8,12 @@ import FileSystemPartition from './FileSystemPartition';
 
 import { useAppSelector } from '../../../../store/hooks';
 import { selectFileSystemPartitionMode } from '../../../../store/wizardSlice';
-import { useHasIsoTargetOnly } from '../../utilities/hasIsoTargetOnly';
+import { useHasSpecificTargetOnly } from '../../utilities/hasSpecificTargetOnly';
 export type FileSystemPartitionMode = 'automatic' | 'manual';
 
 const FileSystemStep = () => {
   const fileSystemPartitionMode = useAppSelector(selectFileSystemPartitionMode);
-  const hasIsoTargetOnly = useHasIsoTargetOnly();
+  const hasIsoTargetOnly = useHasSpecificTargetOnly('image-installer');
 
   return (
     <Form>

--- a/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
@@ -39,7 +39,9 @@ import {
   changeFileSystemPartitionMode,
   removePackage,
   clearPartitions,
+  selectImageTypes,
 } from '../../../../store/wizardSlice';
+import { useHasSpecificTargetOnly } from '../../utilities/hasSpecificTargetOnly';
 import { parseSizeUnit } from '../../utilities/parseSizeUnit';
 import { Partition, Units } from '../FileSystem/FileSystemConfiguration';
 
@@ -47,6 +49,7 @@ const ProfileSelector = () => {
   const oscapProfile = useAppSelector(selectProfile);
   const oscapData = useServerStore();
   const release = useAppSelector(selectDistribution);
+  const hasWslTargetOnly = useHasSpecificTargetOnly('wsl');
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
   const {
@@ -201,7 +204,7 @@ const ProfileSelector = () => {
         isOpen={isOpen}
         placeholderText="Select a profile"
         typeAheadAriaLabel="Select a profile"
-        isDisabled={!isSuccess}
+        isDisabled={!isSuccess || hasWslTargetOnly}
         onFilter={(_event, value) => {
           if (profiles) {
             return [<OScapNoneOption key="oscap-none-option" />].concat(
@@ -295,9 +298,17 @@ const OScapSelectOption = ({
 
 export const Oscap = () => {
   const oscapProfile = useAppSelector(selectProfile);
+  const environments = useAppSelector(selectImageTypes);
 
   return (
     <>
+      {environments.includes('wsl') && (
+        <Alert
+          variant="warning"
+          isInline
+          title="OpenSCAP profiles are not compatible with WSL images."
+        />
+      )}
       <ProfileSelector />
       <OscapProfileInformation />
       {oscapProfile && (

--- a/src/Components/CreateImageWizardV2/utilities/hasIsoTargetOnly.ts
+++ b/src/Components/CreateImageWizardV2/utilities/hasIsoTargetOnly.ts
@@ -1,7 +1,0 @@
-import { useAppSelector } from '../../../store/hooks';
-import { selectImageTypes } from '../../../store/wizardSlice';
-
-export const useHasIsoTargetOnly = () => {
-  const environments = useAppSelector(selectImageTypes);
-  return environments.length === 1 && environments.includes('image-installer');
-};

--- a/src/Components/CreateImageWizardV2/utilities/hasSpecificTargetOnly.ts
+++ b/src/Components/CreateImageWizardV2/utilities/hasSpecificTargetOnly.ts
@@ -1,0 +1,8 @@
+import { useAppSelector } from '../../../store/hooks';
+import { ImageTypes } from '../../../store/imageBuilderApi';
+import { selectImageTypes } from '../../../store/wizardSlice';
+
+export const useHasSpecificTargetOnly = (target: ImageTypes) => {
+  const environments = useAppSelector(selectImageTypes);
+  return environments.length === 1 && environments.includes(target);
+};


### PR DESCRIPTION
This adds an alert about OpenSCAP being incompatible with WSL when a WSL target is selected.

In a case of only WSL being selected as a target the OpenSCAP dropdown gets disabled.