### PR TITLE
V2Wizard: Fix pagination on Packages step (useMemo)

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -830,6 +830,8 @@ const Packages = () => {
     // Would need significant rewrite to fix this
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
+    page,
+    perPage,
     debouncedSearchTerm,
     debouncedSearchTermLengthOf1,
     isLoadingCustomPackages,


### PR DESCRIPTION
Fixes https://github.com/osbuild/image-builder-frontend/issues/2084

Forget to add the page/perPage.

Using the useMemo prevents quite a bit of repeated logic/rerendering