### PR TITLE
V2Wizard: add alert on snapshot step

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Snapshot/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Snapshot/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Button, Form, Grid, Text, Title } from '@patternfly/react-core';
+import { Alert, Button, Form, Grid, Text, Title } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useHref } from 'react-router-dom';
 
@@ -14,6 +14,14 @@ export default function SnapshotStep() {
       <Title headingLevel="h1" size="xl">
         Repository snapshot
       </Title>
+      <Alert
+        variant="info"
+        isInline
+        title="The snapshot date only applies to RHEL content."
+      >
+        Third party, custom repositories will always use the newest repository
+        state available.
+      </Alert>
       <Grid>
         <Text>
           Control the consistency of the packages in the repository used to


### PR DESCRIPTION
Inform users that the snapshots only apply to RHEL content for now.

---

![image](https://github.com/osbuild/image-builder-frontend/assets/11140201/bcc89296-a544-413b-b9ed-e532cb77bc61)
