### PR TITLE
Wizard: validate wizard with Redux Hook

### DIFF
--- a/src/Components/CreateImageWizardV2/ValidatedTextInput.tsx
+++ b/src/Components/CreateImageWizardV2/ValidatedTextInput.tsx
@@ -7,11 +7,7 @@ import {
   TextInputProps,
 } from '@patternfly/react-core';
 
-import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import {
-  setStepInputValidation,
-  selectInputValidation,
-} from '../../store/wizardSlice';
+import { StepValidation } from './utilities/useValidation';
 
 interface ValidatedTextInputPropTypes extends TextInputProps {
   dataTestId?: string | undefined;
@@ -23,63 +19,38 @@ interface ValidatedTextInputPropTypes extends TextInputProps {
   placeholder?: string;
 }
 
-interface StateValidatedTextInputPropTypes extends TextInputProps {
+interface HookValidatedTextInputPropTypes extends TextInputProps {
   dataTestId?: string | undefined;
   ouiaId?: string;
-  stepId: string;
-  inputId: string;
   ariaLabel: string | undefined;
   helperText: string | undefined;
-  validator: (value: string | undefined) => boolean;
   value: string;
   placeholder?: string;
+  stepValidation: StepValidation;
+  fieldName: string;
 }
 
-export const StateValidatedInput = ({
+export const HookValidatedInput = ({
   dataTestId,
   ouiaId,
-  stepId,
-  inputId,
   ariaLabel,
   helperText,
-  validator,
   value,
   placeholder,
   onChange,
-}: StateValidatedTextInputPropTypes) => {
-  const dispatch = useAppDispatch();
-  const validatedState = useAppSelector(selectInputValidation(stepId, inputId));
+  stepValidation,
+  fieldName,
+}: HookValidatedTextInputPropTypes) => {
   const [isPristine, setIsPristine] = useState(!value ? true : false);
   // Do not surface validation on pristine state components
-  const validated = isPristine ? 'default' : validatedState;
+  const validated = isPristine
+    ? 'default'
+    : stepValidation.errors[fieldName]
+    ? 'error'
+    : 'success';
 
   const handleBlur = () => {
     setIsPristine(false);
-    const isValid = validator(value);
-    dispatch(
-      setStepInputValidation({
-        stepId,
-        inputId,
-        isValid,
-        errorText: isValid ? helperText : undefined,
-      })
-    );
-  };
-
-  const wrappedOnChange = (
-    evt: React.FormEvent<HTMLInputElement>,
-    newVal: string
-  ) => {
-    if (onChange) onChange(evt, newVal);
-    const isValid = validator(newVal);
-    dispatch(
-      setStepInputValidation({
-        stepId,
-        inputId,
-        isValid,
-        errorText: isValid ? helperText : undefined,
-      })
-    );
   };
 
   return (
@@ -89,7 +60,7 @@ export const StateValidatedInput = ({
         data-testid={dataTestId}
         ouiaId={ouiaId}
         type="text"
-        onChange={wrappedOnChange}
+        onChange={onChange}
         validated={validated}
         aria-label={ariaLabel}
         onBlur={handleBlur}

--- a/src/Components/CreateImageWizardV2/steps/Details/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Details/index.tsx
@@ -17,11 +17,8 @@ import {
   selectBlueprintDescription,
   selectBlueprintName,
 } from '../../../../store/wizardSlice';
-import { StateValidatedInput } from '../../ValidatedTextInput';
-import {
-  isBlueprintDescriptionValid,
-  isBlueprintNameValid,
-} from '../../validators';
+import { useDetailsValidation } from '../../utilities/useValidation';
+import { HookValidatedInput } from '../../ValidatedTextInput';
 
 const DetailsStep = () => {
   const dispatch = useAppDispatch();
@@ -41,6 +38,8 @@ const DetailsStep = () => {
     dispatch(changeBlueprintDescription(description));
   };
 
+  const stepValidation = useDetailsValidation();
+
   return (
     <Form>
       <Title headingLevel="h1" size="xl">
@@ -52,16 +51,15 @@ const DetailsStep = () => {
         blueprint.
       </Text>
       <FormGroup isRequired label="Blueprint name" fieldId="blueprint-name">
-        <StateValidatedInput
+        <HookValidatedInput
           ariaLabel="blueprint name"
           dataTestId="blueprint"
-          stepId="details"
-          inputId="blueprint-name"
           value={blueprintName}
-          validator={isBlueprintNameValid}
           onChange={handleNameChange}
           helperText="Please enter a valid name"
           placeholder="Add blueprint name"
+          stepValidation={stepValidation}
+          fieldName="name"
         />
         <FormHelperText>
           <HelperText>
@@ -76,16 +74,15 @@ const DetailsStep = () => {
         label="Blueprint description"
         fieldId="blueprint-description-name"
       >
-        <StateValidatedInput
+        <HookValidatedInput
           ariaLabel="blueprint description"
           dataTestId="blueprint description"
-          stepId="details"
-          inputId="blueprint-description"
           value={blueprintDescription || ''}
-          validator={isBlueprintDescriptionValid}
           onChange={handleDescriptionChange}
           helperText="Please enter a valid description"
           placeholder="Add description"
+          stepValidation={stepValidation}
+          fieldName="description"
         />
       </FormGroup>
     </Form>

--- a/src/Components/CreateImageWizardV2/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FileSystem/index.tsx
@@ -11,6 +11,8 @@ import { selectFileSystemPartitionMode } from '../../../../store/wizardSlice';
 import { useHasSpecificTargetOnly } from '../../utilities/hasSpecificTargetOnly';
 export type FileSystemPartitionMode = 'automatic' | 'manual';
 
+export const FileSystemContext = React.createContext<boolean>(true);
+
 const FileSystemStep = () => {
   const fileSystemPartitionMode = useAppSelector(selectFileSystemPartitionMode);
   const hasIsoTargetOnly = useHasSpecificTargetOnly('image-installer');

--- a/src/Components/CreateImageWizardV2/steps/Review/Footer/Footer.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/Footer/Footer.tsx
@@ -15,14 +15,14 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { CreateSaveAndBuildBtn, CreateSaveButton } from './CreateDropdown';
 import { EditSaveAndBuildBtn, EditSaveButton } from './EditDropdown';
 
-import { useServerStore, useAppSelector } from '../../../../../store/hooks';
+import { useServerStore } from '../../../../../store/hooks';
 import {
   useCreateBlueprintMutation,
   useUpdateBlueprintMutation,
 } from '../../../../../store/imageBuilderApi';
-import { selectIsValid } from '../../../../../store/wizardSlice';
 import { resolveRelPath } from '../../../../../Utilities/path';
 import { mapRequestFromState } from '../../../utilities/requestMapper';
+import { useIsBlueprintValid } from '../../../utilities/useValidation';
 
 const ReviewWizardFooter = () => {
   const { goToPrevStep, close } = useWizardContext();
@@ -41,7 +41,7 @@ const ReviewWizardFooter = () => {
     setIsOpen(!isOpen);
   };
   const navigate = useNavigate();
-  const isValid = useAppSelector(selectIsValid);
+  const isValid = useIsBlueprintValid();
 
   useEffect(() => {
     if (isUpdateSuccess || isCreateSuccess) {

--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.ts
@@ -170,12 +170,10 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
         partitions: request.customizations.filesystem.map((fs) =>
           convertFilesystemToPartition(fs)
         ),
-        isNextButtonTouched: true,
       }
     : {
         mode: 'automatic' as FileSystemPartitionMode,
         partitions: [],
-        isNextButtonTouched: true,
       };
 
   const arch = request.image_requests[0].architecture;
@@ -259,7 +257,6 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
           repository: '',
           package_list: [],
         })) || [],
-    stepValidations: {},
   };
 };
 

--- a/src/Components/CreateImageWizardV2/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizardV2/utilities/useValidation.tsx
@@ -1,0 +1,65 @@
+import { useAppSelector } from '../../../store/hooks';
+import {
+  selectBlueprintName,
+  selectBlueprintDescription,
+  selectFileSystemPartitionMode,
+  selectPartitions,
+} from '../../../store/wizardSlice';
+import {
+  getDuplicateMountPoints,
+  isBlueprintNameValid,
+  isBlueprintDescriptionValid,
+  isMountpointMinSizeValid,
+} from '../validators';
+
+export type StepValidation = {
+  errors: {
+    [key: string]: string;
+  };
+  disabledNext: boolean;
+};
+
+export function useIsBlueprintValid(): boolean {
+  const filesystem = useFilesystemValidation();
+  const details = useDetailsValidation();
+  return !filesystem.disabledNext && !details.disabledNext;
+}
+
+export function useFilesystemValidation(): StepValidation {
+  const mode = useAppSelector(selectFileSystemPartitionMode);
+  const partitions = useAppSelector(selectPartitions);
+  let disabledNext = false;
+
+  const errors: { [key: string]: string } = {};
+  if (mode === 'automatic') {
+    return { errors, disabledNext: false };
+  }
+
+  const duplicates = getDuplicateMountPoints(partitions);
+  for (const partition of partitions) {
+    if (!isMountpointMinSizeValid(partition.min_size)) {
+      errors[`min-size-${partition.id}`] = 'Invalid size';
+      disabledNext = true;
+    }
+    if (duplicates.includes(partition.mountpoint)) {
+      errors[`mountpoint-${partition.id}`] = 'Duplicate mount points';
+      disabledNext = true;
+    }
+  }
+  return { errors, disabledNext };
+}
+
+export function useDetailsValidation(): StepValidation {
+  const name = useAppSelector(selectBlueprintName);
+  const description = useAppSelector(selectBlueprintDescription);
+
+  const nameValid = isBlueprintNameValid(name);
+  const descriptionValid = isBlueprintDescriptionValid(description);
+  return {
+    errors: {
+      name: nameValid ? '' : 'Invalid name',
+      description: descriptionValid ? '' : 'Invalid description',
+    },
+    disabledNext: !nameValid || !descriptionValid,
+  };
+}

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -817,7 +817,7 @@ describe('Step File system configuration', () => {
     await clickNext();
     expect(await getNextButton()).toBeDisabled();
     const mountPointAlerts = screen.getAllByRole('heading', {
-      name: /danger alert: duplicate mount point\./i,
+      name: /danger alert: duplicate mount point/i,
     });
     const tbody = await screen.findByTestId('file-system-configuration-tbody');
     const rows = within(tbody).getAllByRole('row');
@@ -910,7 +910,7 @@ describe('Step Details', () => {
     await clickNext();
   };
 
-  test('image name invalid for more than 63 chars', async () => {
+  test('image name invalid for more than 100 chars and description for 250', async () => {
     await setUp();
 
     // Enter image name


### PR DESCRIPTION
Use redux hook to validate the form.
This gives us single point of contact for "is the data valid?" while not requiring every redux action touching form data to perform validation.

It's not perfect and might be improved when using external library solving the problems we're having.

Imperfections:
* Pristine state needs to be handled manually
* maintaining the validations externally to the fields

Possible future libraries (reserach needed):
* Redux form - deprecated, but that's what we do currently
* [Final form](https://final-form.org/) considered one of the best, but mostly based on data not being in redux
  * IMO best fit and we should embrace not having our form data in redux :) 
* [React hook form](https://www.react-hook-form.com/) (uses mostly uncontrolled componente - not great fit