### PR TITLE
V2Wizard: Move targets to a constant

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStep.tsx
@@ -27,6 +27,7 @@ import {
 } from './ReviewStepTextLists';
 
 import isRhel from '../../../../../src/Utilities/isRhel';
+import { targetOptions } from '../../../../constants';
 import { useAppSelector } from '../../../../store/hooks';
 import {
   selectBlueprintDescription,
@@ -143,20 +144,24 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
         {environments.includes('oci') && <TargetEnvOciList />}
         {environments.includes('vsphere') && (
           <TextContent>
-            <Text component={TextVariants.h3}>VMware vSphere (.vmdk)</Text>
+            <Text component={TextVariants.h3}>
+              {targetOptions.vsphere} (.vmdk)
+            </Text>
             <TargetEnvOtherList />
           </TextContent>
         )}
         {environments.includes('vsphere-ova') && (
           <TextContent>
-            <Text component={TextVariants.h3}>VMware vSphere (.ova)</Text>
+            <Text component={TextVariants.h3}>
+              {targetOptions['vsphere-ova']} (.ova)
+            </Text>
             <TargetEnvOtherList />
           </TextContent>
         )}
         {environments.includes('guest-image') && (
           <TextContent>
             <Text component={TextVariants.h3}>
-              Virtualization - Guest image (.qcow2)
+              {targetOptions['guest-image']} (.qcow2)
             </Text>
             <TargetEnvOtherList />
           </TextContent>
@@ -164,7 +169,7 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
         {environments.includes('image-installer') && (
           <TextContent>
             <Text component={TextVariants.h3}>
-              Bare metal - Installer (.iso)
+              {targetOptions['image-installer']} (.iso)
             </Text>
             <TargetEnvOtherList />
           </TextContent>
@@ -172,7 +177,7 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
         {environments.includes('wsl') && (
           <TextContent>
             <Text component={TextVariants.h3}>
-              WSL - Windows Subsystem for Linux (.tar.gz)
+              WSL - {targetOptions.wsl} (.tar.gz)
             </Text>
             <TargetEnvOtherList />
           </TextContent>

--- a/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Review/ReviewStepTextLists.tsx
@@ -29,6 +29,7 @@ import {
   RHEL_8_FULL_SUPPORT,
   RHEL_8_MAINTENANCE_SUPPORT,
   RHEL_9,
+  targetOptions,
   UNIT_GIB,
 } from '../../../../constants';
 import { useListSnapshotsByDateMutation } from '../../../../store/contentSourcesApi';
@@ -221,7 +222,7 @@ export const TargetEnvAWSList = () => {
 
   return (
     <TextContent>
-      <Text component={TextVariants.h3}>AWS</Text>
+      <Text component={TextVariants.h3}>{targetOptions.aws}</Text>
       <TextList component={TextListVariants.dl}>
         <TextListItem
           component={TextListItemVariants.dt}
@@ -263,7 +264,7 @@ export const TargetEnvGCPList = () => {
   const email = useAppSelector(selectGcpEmail);
   return (
     <TextContent>
-      <Text component={TextVariants.h3}>GCP</Text>
+      <Text component={TextVariants.h3}>{targetOptions.gcp}</Text>
       <TextList component={TextListVariants.dl}>
         <TextListItem
           component={TextListItemVariants.dt}
@@ -326,7 +327,7 @@ export const TargetEnvAzureList = () => {
 
   return (
     <TextContent>
-      <Text component={TextVariants.h3}>Microsoft Azure</Text>
+      <Text component={TextVariants.h3}>{targetOptions.azure}</Text>
       <TextList component={TextListVariants.dl}>
         <TextListItem
           component={TextListItemVariants.dt}
@@ -383,7 +384,7 @@ export const TargetEnvAzureList = () => {
 export const TargetEnvOciList = () => {
   return (
     <TextContent>
-      <Text component={TextVariants.h3}>Oracle Cloud Infrastructure</Text>
+      <Text component={TextVariants.h3}>{targetOptions.oci}</Text>
       <TextList component={TextListVariants.dl}>
         <TextListItem
           component={TextListItemVariants.dt}

--- a/src/Components/ImagesTable/Target.tsx
+++ b/src/Components/ImagesTable/Target.tsx
@@ -2,29 +2,9 @@ import React from 'react';
 
 import { Skeleton } from '@patternfly/react-core';
 
-import {
-  ImageTypes,
-  useGetComposeClonesQuery,
-} from '../../store/imageBuilderApi';
+import { targetOptions } from '../../constants';
+import { useGetComposeClonesQuery } from '../../store/imageBuilderApi';
 import { ComposesResponseItem } from '../../store/imageBuilderApi';
-
-const targetOptions: { [key in ImageTypes]: string } = {
-  aws: 'Amazon Web Services',
-  azure: 'Microsoft Azure',
-  'edge-commit': 'Edge Commit',
-  'edge-installer': 'Edge Installer',
-  gcp: 'Google Cloud Platform',
-  'guest-image': 'Virtualization - Guest image',
-  'image-installer': 'Bare metal - Installer',
-  vsphere: 'VMware vSphere',
-  'vsphere-ova': 'VMware vSphere',
-  wsl: 'Windows Subsystem for Linux',
-  ami: 'Amazon Web Services',
-  'rhel-edge-commit': 'RHEL Edge Commit',
-  'rhel-edge-installer': 'RHEL Edge Installer',
-  vhd: '',
-  oci: 'Oracle Cloud Infrastructure',
-};
 
 type TargetPropTypes = {
   compose: ComposesResponseItem;
@@ -47,6 +27,6 @@ export const AwsTarget = ({ compose }: AwsTargetPropTypes) => {
     return <Skeleton />;
   }
 
-  const text = `Amazon Web Services (${data.data.length + 1})`;
+  const text = `${targetOptions.aws} (${data.data.length + 1})`;
   return <>{text}</>;
 };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,3 +1,5 @@
+import { ImageTypes } from './store/imageBuilderApi';
+
 export const IMAGE_BUILDER_API = '/api/image-builder/v1';
 export const RHSM_API = '/api/rhsm/v2';
 export const EDGE_API = '/api/edge/v1';
@@ -45,6 +47,24 @@ export const RHEL_9 = 'rhel-9';
 export const CENTOS_9 = 'centos-9';
 export const X86_64 = 'x86_64';
 export const AARCH64 = 'aarch64';
+
+export const targetOptions: { [key in ImageTypes]: string } = {
+  aws: 'Amazon Web Services',
+  azure: 'Microsoft Azure',
+  'edge-commit': 'Edge Commit',
+  'edge-installer': 'Edge Installer',
+  gcp: 'Google Cloud Platform',
+  'guest-image': 'Virtualization - Guest image',
+  'image-installer': 'Bare metal - Installer',
+  vsphere: 'VMware vSphere',
+  'vsphere-ova': 'VMware vSphere',
+  wsl: 'Windows Subsystem for Linux',
+  ami: 'Amazon Web Services',
+  'rhel-edge-commit': 'RHEL Edge Commit',
+  'rhel-edge-installer': 'RHEL Edge Installer',
+  vhd: '',
+  oci: 'Oracle Cloud Infrastructure',
+};
 
 export const UNIT_KIB = 1024 ** 1;
 export const UNIT_MIB = 1024 ** 2;

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -1086,47 +1086,39 @@ describe('Step Review', () => {
 
   test('has Registration expandable section for rhel', async () => {
     await setUp();
-    const targetExpandable = screen.getByText(/target environments/i);
-    const registrationExpandable = screen.getByTestId(
-      'registration-expandable'
+
+    const targetExpandable = await screen.findByTestId(
+      'target-environments-expandable'
     );
-
     const contentExpandable = await screen.findByTestId('content-expandable');
-    const fscExpandable = screen.getByTestId(
-      'file-system-configuration-expandable'
-    );
-
-    await user.click(targetExpandable);
-    await screen.findByText('AWS');
-
-    await user.click(registrationExpandable);
-    await user.click(contentExpandable);
-
-    await within(contentExpandable).findByText('Custom repositories');
-    await within(contentExpandable).findByText('Additional packages');
-    await user.click(fscExpandable);
-    await screen.findByText('Configuration type');
-  });
-  test('has no Registration expandable for centos', async () => {
-    await setUpCentOS();
-    const targetExpandable = screen.getByText(/target environments/i);
-    const contentExpandable = await screen.findByTestId('content-expandable');
-
     const fscExpandable = await screen.findByTestId(
       'file-system-configuration-expandable'
     );
+
+    await within(targetExpandable).findByText('Amazon Web Services');
+    await within(contentExpandable).findByText('Custom repositories');
+    await within(contentExpandable).findByText('Additional packages');
+    await within(fscExpandable).findByText('Configuration type');
+  });
+  test('has no Registration expandable for centos', async () => {
+    await setUpCentOS();
+
+    const targetExpandable = await screen.findByTestId(
+      'target-environments-expandable'
+    );
+    const contentExpandable = await screen.findByTestId('content-expandable');
+    const fscExpandable = await screen.findByTestId(
+      'file-system-configuration-expandable'
+    );
+
     expect(
       screen.queryByTestId('registration-expandable')
     ).not.toBeInTheDocument();
-    await user.click(targetExpandable);
-    await screen.findByText('AWS');
 
-    await user.click(contentExpandable);
+    await within(targetExpandable).findByText('Amazon Web Services');
     await within(contentExpandable).findByText('Custom repositories');
     await within(contentExpandable).findByText('Additional packages');
-
-    await user.click(fscExpandable);
-    await screen.findByText('Configuration type');
+    await within(fscExpandable).findByText('Configuration type');
   });
 });
 


### PR DESCRIPTION
This moves mapping between target short and full names to the const to make it reusable.