### PR TITLE
Revert "pr_check: change --ref-env to insights-production"

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -26,7 +26,7 @@ export RESERVE_DURATION="2h"
 
 # bootstrap bonfire and it's config
 CICD_URL=https://raw.githubusercontent.com/RedHatInsights/bonfire/master/cicd
-curl -s "$CICD_URL"/bootstrap.sh >.cicd_bootstrap.sh && source .cicd_bootstrap.sh
+curl -s "$CICD_URL"/bootstrap.sh > .cicd_bootstrap.sh && source .cicd_bootstrap.sh
 
 # # source is preferred to | bash -s in this case to avoid a subshell
 source <(curl -sSL $COMMON_BUILDER/src/frontend-build.sh)
@@ -36,7 +36,7 @@ export DEPLOY_FRONTENDS="true"
 export EXTRA_DEPLOY_ARGS="provisioning sources rhsm-api-proxy --set-template-ref rhsm-api-proxy=master"
 export APP_NAME="image-builder-crc"
 export DEPLOY_TIMEOUT="1200"
-export REF_ENV="insights-production"
+export REF_ENV="insights-stage"
 
 source "$CICD_ROOT"/deploy_ephemeral_env.sh
 


### PR DESCRIPTION
This reverts commit e85789f58d6958a71ce217a4ca019a5e265aa39d. It actually makes more sense to use insights-stage