### PR TITLE
V2Wizard: Hide package recommendations for CentOS

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/index.tsx
@@ -6,11 +6,15 @@ import { useFlag } from '@unleash/proxy-client-react';
 import PackageRecommendations from './PackageRecommendations';
 import Packages from './Packages';
 
+import { CENTOS_9 } from '../../../../constants';
+import { useAppSelector } from '../../../../store/hooks';
+import { selectDistribution } from '../../../../store/wizardSlice';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
 
 const PackagesStep = () => {
   const { isBeta } = useGetEnvironment();
   const packageRecommendationsFlag = useFlag('image-builder.pkgrecs.enabled');
+  const distribution = useAppSelector(selectDistribution);
   return (
     <Form>
       <Title headingLevel="h1" size="xl">
@@ -18,7 +22,9 @@ const PackagesStep = () => {
       </Title>
       <Text>Blueprints created with Images include all required packages.</Text>
       <Packages />
-      {isBeta() && packageRecommendationsFlag && <PackageRecommendations />}
+      {isBeta() && packageRecommendationsFlag && distribution !== CENTOS_9 && (
+        <PackageRecommendations />
+      )}
     </Form>
   );
 };


### PR DESCRIPTION
This hides the package recommendations expandable when CentOS is selected as a distribution.