### PR TITLE
fix(HMS-4310): Disable editing of Blueprint file

### DIFF
--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -104,7 +104,7 @@ export const ImportBlueprintModal: React.FunctionComponent<
             onReadFinished={handleFileReadFinished}
             onClearClick={handleClear}
             isLoading={isLoading}
-            allowEditingUploadedText={false}
+            isReadOnly={true}
             browseButtonText="Upload"
             dropzoneProps={{
               accept: { 'text/json': ['.json'] },


### PR DESCRIPTION
Yeah, so before it was possible to insert the blueprint file inside the editor. I missed that someone might try to do that. Let's make the whole editor read-only as MVP.