### PR TITLE
src: Move content urls to const

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -43,8 +43,7 @@ import CustomHelperText from './components/CustomHelperText';
 import PackageInfoNotAvailablePopover from './components/PackageInfoNotAvailablePopover';
 
 import {
-  CONTENT_BETA,
-  CONTENT_STABLE,
+  CONTENT_URL,
   EPEL_8_REPO_DEFINITION,
   EPEL_9_REPO_DEFINITION,
   RH_ICON_SIZE,
@@ -77,6 +76,7 @@ import {
 } from '../../../../store/wizardSlice';
 import useDebounce from '../../../../Utilities/useDebounce';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
+import { betaPath } from '../../utilities/betaPath';
 
 type PackageRepository = 'distro' | 'custom' | 'recommended' | '';
 
@@ -546,7 +546,7 @@ const Packages = () => {
                       target="_blank"
                       iconPosition="right"
                       icon={<ExternalLinkAltIcon />}
-                      href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
+                      href={betaPath(CONTENT_URL, isBeta())}
                     >
                       Manage your repositories and popular repositories
                     </Button>
@@ -576,7 +576,7 @@ const Packages = () => {
                     isInline
                     component="a"
                     target="_blank"
-                    href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
+                    href={betaPath(CONTENT_URL, isBeta())}
                   >
                     your repositories
                   </Button>{' '}
@@ -629,7 +629,7 @@ const Packages = () => {
           iconPosition="right"
           isInline
           icon={<ExternalLinkAltIcon />}
-          href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
+          href={betaPath(CONTENT_URL, isBeta())}
         >
           content services
         </Button>{' '}

--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -43,6 +43,8 @@ import CustomHelperText from './components/CustomHelperText';
 import PackageInfoNotAvailablePopover from './components/PackageInfoNotAvailablePopover';
 
 import {
+  CONTENT_BETA,
+  CONTENT_STABLE,
   EPEL_8_REPO_DEFINITION,
   EPEL_9_REPO_DEFINITION,
   RH_ICON_SIZE,
@@ -544,11 +546,7 @@ const Packages = () => {
                       target="_blank"
                       iconPosition="right"
                       icon={<ExternalLinkAltIcon />}
-                      href={
-                        isBeta()
-                          ? '/preview/insights/content'
-                          : '/insights/content'
-                      }
+                      href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
                     >
                       Manage your repositories and popular repositories
                     </Button>
@@ -578,11 +576,7 @@ const Packages = () => {
                     isInline
                     component="a"
                     target="_blank"
-                    href={
-                      isBeta()
-                        ? '/preview/insights/content'
-                        : '/insights/content'
-                    }
+                    href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
                   >
                     your repositories
                   </Button>{' '}
@@ -635,7 +629,7 @@ const Packages = () => {
           iconPosition="right"
           isInline
           icon={<ExternalLinkAltIcon />}
-          href={isBeta() ? '/preview/settings/content' : '/settings/content'}
+          href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
         >
           content services
         </Button>{' '}

--- a/src/Components/CreateImageWizardV2/steps/Repositories/RepositoriesStatus.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/RepositoriesStatus.tsx
@@ -17,6 +17,7 @@ import {
   InProgressIcon,
 } from '@patternfly/react-icons';
 
+import { CONTENT_BETA, CONTENT_STABLE } from '../../../../constants';
 import { ApiRepositoryResponse } from '../../../../store/contentSourcesApi';
 import {
   convertStringToDate,
@@ -118,9 +119,7 @@ const RepositoriesStatus = ({
                 iconPosition="right"
                 isInline
                 icon={<ExternalLinkAltIcon />}
-                href={
-                  isBeta() ? '/preview/settings/content' : '/settings/content'
-                }
+                href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
               >
                 Go to Repositories
               </Button>

--- a/src/Components/CreateImageWizardV2/steps/Repositories/RepositoriesStatus.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/RepositoriesStatus.tsx
@@ -17,13 +17,14 @@ import {
   InProgressIcon,
 } from '@patternfly/react-icons';
 
-import { CONTENT_BETA, CONTENT_STABLE } from '../../../../constants';
+import { CONTENT_URL } from '../../../../constants';
 import { ApiRepositoryResponse } from '../../../../store/contentSourcesApi';
 import {
   convertStringToDate,
   timestampToDisplayString,
 } from '../../../../Utilities/time';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
+import { betaPath } from '../../utilities/betaPath';
 
 const getLastIntrospection = (
   repoIntrospections: RepositoryStatusProps['repoIntrospections']
@@ -119,7 +120,7 @@ const RepositoriesStatus = ({
                 iconPosition="right"
                 isInline
                 icon={<ExternalLinkAltIcon />}
-                href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
+                href={betaPath(CONTENT_URL, isBeta())}
               >
                 Go to Repositories
               </Button>

--- a/src/Components/CreateImageWizardV2/steps/Repositories/RepositoryUnavailable.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/RepositoryUnavailable.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
-import { CONTENT_BETA, CONTENT_STABLE } from '../../../../constants';
+import { CONTENT_URL } from '../../../../constants';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
+import { betaPath } from '../../utilities/betaPath';
 
 const RepositoryUnavailable = ({ quantity }: { quantity: number }) => {
   const { isBeta } = useGetEnvironment();
-
   return (
     <Alert
       variant="warning"
@@ -29,7 +29,7 @@ const RepositoryUnavailable = ({ quantity }: { quantity: number }) => {
         iconPosition="right"
         isInline
         icon={<ExternalLinkAltIcon />}
-        href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
+        href={betaPath(CONTENT_URL, isBeta())}
       >
         Go to Repositories
       </Button>

--- a/src/Components/CreateImageWizardV2/steps/Repositories/RepositoryUnavailable.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/RepositoryUnavailable.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Alert, Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
+import { CONTENT_BETA, CONTENT_STABLE } from '../../../../constants';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
 
 const RepositoryUnavailable = ({ quantity }: { quantity: number }) => {
@@ -28,7 +29,7 @@ const RepositoryUnavailable = ({ quantity }: { quantity: number }) => {
         iconPosition="right"
         isInline
         icon={<ExternalLinkAltIcon />}
-        href={isBeta() ? '/preview/settings/content' : '/settings/content'}
+        href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
       >
         Go to Repositories
       </Button>

--- a/src/Components/CreateImageWizardV2/steps/Repositories/components/Empty.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/components/Empty.tsx
@@ -11,8 +11,9 @@ import {
 } from '@patternfly/react-core';
 import { RepositoryIcon } from '@patternfly/react-icons';
 
-import { CONTENT_BETA, CONTENT_STABLE } from '../../../../../constants';
+import { CONTENT_URL } from '../../../../../constants';
 import { useGetEnvironment } from '../../../../../Utilities/useGetEnvironment';
+import { betaPath } from '../../../utilities/betaPath';
 
 type EmptyProps = {
   refetch: () => void;
@@ -43,7 +44,7 @@ export default function Empty({ hasFilterValue, refetch }: EmptyProps) {
           variant="primary"
           component="a"
           target="_blank"
-          href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
+          href={betaPath(CONTENT_URL, isBeta())}
           className="pf-u-mr-sm"
         >
           Go to repositories

--- a/src/Components/CreateImageWizardV2/steps/Repositories/components/Empty.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/components/Empty.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { RepositoryIcon } from '@patternfly/react-icons';
 
+import { CONTENT_BETA, CONTENT_STABLE } from '../../../../../constants';
 import { useGetEnvironment } from '../../../../../Utilities/useGetEnvironment';
 
 type EmptyProps = {
@@ -42,7 +43,7 @@ export default function Empty({ hasFilterValue, refetch }: EmptyProps) {
           variant="primary"
           component="a"
           target="_blank"
-          href={isBeta() ? '/preview/settings/content' : '/settings/content'}
+          href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
           className="pf-u-mr-sm"
         >
           Go to repositories

--- a/src/Components/CreateImageWizardV2/steps/Repositories/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/index.tsx
@@ -5,13 +5,14 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import Repositories from './Repositories';
 
-import { CONTENT_BETA, CONTENT_STABLE } from '../../../../constants';
+import { CONTENT_URL } from '../../../../constants';
 import { useAppSelector } from '../../../../store/hooks';
 import {
   selectPackages,
   selectRecommendedRepositories,
 } from '../../../../store/wizardSlice';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
+import { betaPath } from '../../utilities/betaPath';
 
 const ManageRepositoriesButton = () => {
   const { isBeta } = useGetEnvironment();
@@ -23,7 +24,7 @@ const ManageRepositoriesButton = () => {
       iconPosition="right"
       isInline
       icon={<ExternalLinkAltIcon />}
-      href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
+      href={betaPath(CONTENT_URL, isBeta())}
     >
       Create and manage repositories here
     </Button>

--- a/src/Components/CreateImageWizardV2/steps/Repositories/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Repositories/index.tsx
@@ -5,6 +5,7 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import Repositories from './Repositories';
 
+import { CONTENT_BETA, CONTENT_STABLE } from '../../../../constants';
 import { useAppSelector } from '../../../../store/hooks';
 import {
   selectPackages,
@@ -22,7 +23,7 @@ const ManageRepositoriesButton = () => {
       iconPosition="right"
       isInline
       icon={<ExternalLinkAltIcon />}
-      href={isBeta() ? '/preview/settings/content' : '/settings/content'}
+      href={isBeta() ? CONTENT_BETA : CONTENT_STABLE}
     >
       Create and manage repositories here
     </Button>

--- a/src/Components/CreateImageWizardV2/steps/Snapshot/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Snapshot/index.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 
 import { Alert, Button, Form, Grid, Text, Title } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { useHref } from 'react-router-dom';
 
 import Snapshot from './Snapshot';
 
+import { CONTENT_URL } from '../../../../constants';
+import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
+import { betaPath } from '../../utilities/betaPath';
+
 export default function SnapshotStep() {
-  const path = useHref('image-builder');
-  const pathname = path.split('image-builder')[0] + 'content';
+  const { isBeta } = useGetEnvironment();
   return (
     <Form>
       <Title headingLevel="h1" size="xl">
@@ -34,7 +36,7 @@ export default function SnapshotStep() {
           iconPosition="right"
           isInline
           icon={<ExternalLinkAltIcon />}
-          href={pathname + '/repositories'}
+          href={betaPath(CONTENT_URL, isBeta())}
         >
           Create and manage repositories here
         </Button>

--- a/src/Components/CreateImageWizardV2/utilities/betaPath.ts
+++ b/src/Components/CreateImageWizardV2/utilities/betaPath.ts
@@ -1,0 +1,3 @@
+export const betaPath = (path: string, beta: boolean) => {
+  return beta ? `/preview${path}` : path;
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,6 +10,8 @@ export const EDIT_BLUEPRINT = `${IMAGE_BUILDER_API}/blueprints`;
 
 export const CDN_PROD_URL = 'https://cdn.redhat.com/';
 export const CDN_STAGE_URL = 'https://cdn.stage.redhat.com/';
+export const CONTENT_BETA = '/preview/insights/content';
+export const CONTENT_STABLE = '/insights/content';
 export const DEVELOPERS_URL = 'https://developers.redhat.com/about';
 export const FILE_SYSTEM_CUSTOMIZATION_URL =
   'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_images_by_using_insights_image_builder/customizing-file-systems-during-the-image-creation';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -10,8 +10,7 @@ export const EDIT_BLUEPRINT = `${IMAGE_BUILDER_API}/blueprints`;
 
 export const CDN_PROD_URL = 'https://cdn.redhat.com/';
 export const CDN_STAGE_URL = 'https://cdn.stage.redhat.com/';
-export const CONTENT_BETA = '/preview/insights/content';
-export const CONTENT_STABLE = '/insights/content';
+export const CONTENT_URL = '/insights/content/repositories';
 export const DEVELOPERS_URL = 'https://developers.redhat.com/about';
 export const FILE_SYSTEM_CUSTOMIZATION_URL =
   'https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/creating_customized_images_by_using_insights_image_builder/customizing-file-systems-during-the-image-creation';


### PR DESCRIPTION
This moves both preview and stable links to content to the `constants.ts` file.