### PR TITLE
wizard/compliance: re-enable stig profiles (HMS-4018)

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Oscap/Oscap.tsx
@@ -208,26 +208,15 @@ const ProfileSelector = () => {
         onFilter={(_event, value) => {
           if (profiles) {
             return [<OScapNoneOption key="oscap-none-option" />].concat(
-              profiles
-                // stig and stig_gui don't boot at the moment,
-                // so we should filter them out
-                .filter((profile_id) => {
-                  const brokenProfiles = [
-                    'xccdf_org.ssgproject.content_profile_stig',
-                    'xccdf_org.ssgproject.content_profile_stig_gui',
-                  ];
-
-                  return !brokenProfiles.includes(profile_id);
-                })
-                .map((profile_id, index) => {
-                  return (
-                    <OScapSelectOption
-                      key={index}
-                      profile_id={profile_id}
-                      filter={value}
-                    />
-                  );
-                })
+              profiles.map((profile_id, index) => {
+                return (
+                  <OScapSelectOption
+                    key={index}
+                    profile_id={profile_id}
+                    filter={value}
+                  />
+                );
+              })
             );
           }
         }}


### PR DESCRIPTION
The stig profiles have been fixed downstream, so we can re-enable these.