### PR TITLE
Wizard: Fix 400 when fetching packages

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -279,7 +279,7 @@ const Packages = () => {
         },
       });
     }
-    if (debouncedSearchTerm.length > 2) {
+    if (debouncedSearchTerm.length > 2 && customRepositories.length > 0) {
       if (toggleSourceRepos === RepoToggle.INCLUDED) {
         searchCustomRpms({
           apiContentUnitSearchRequest: {

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.content.test.tsx
@@ -116,6 +116,16 @@ const checkRecommendationsEmptyState = async () => {
   await screen.findByText('Select packages to generate recommendations.');
 };
 
+export const selectCustomRepo = async () => {
+  await clickBack();
+  const customRepoCheckbox = await screen.findByRole('checkbox', {
+    name: /select row 0/i,
+  });
+
+  await userEvent.click(customRepoCheckbox);
+  await clickNext();
+};
+
 describe('Step Packages', () => {
   const setUp = async () => {
     mockContentSourcesEnabled = false;
@@ -225,6 +235,7 @@ describe('Step Packages', () => {
   test('search results should be sorted with most relevant results first', async () => {
     await setUp();
 
+    await selectCustomRepo();
     await typeIntoSearchBox('test');
 
     const packagesTable = await screen.findByTestId('packages-table');
@@ -246,6 +257,7 @@ describe('Step Packages', () => {
   test('selected packages are sorted the same way as available packages', async () => {
     await setUp();
 
+    await selectCustomRepo();
     await typeIntoSearchBox('test');
 
     const checkboxes = await getAllCheckboxes();
@@ -323,6 +335,7 @@ describe('Step Packages', () => {
   test('should display relevant results in selected first', async () => {
     await setUp();
 
+    await selectCustomRepo();
     await typeIntoSearchBox('test');
 
     const checkboxes = await getAllCheckboxes();

--- a/src/test/Components/CreateImageWizardV2/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/steps/Packages/Packages.test.tsx
@@ -12,6 +12,7 @@ import {
   packagesCreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
 import { clickNext } from '../../../../testUtils';
+import { selectCustomRepo } from '../../CreateImageWizard.content.test';
 import {
   blueprintRequest,
   clickRegisterLater,
@@ -281,6 +282,7 @@ describe('pagination on packages step', () => {
   test('itemcount correct after search', async () => {
     await renderCreateMode();
     await goToPackagesStep();
+    await selectCustomRepo();
     await searchForPackage();
     await selectFirstPackage();
     // the pagination in the top right


### PR DESCRIPTION
Fixes #2219

The request for package search in custom repositories was sent even when no custom repositories were selected, ending in 400. This fixes the problem.