### PR TITLE
Wizard: Fix repositories recommendations

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizardV2/steps/Packages/Packages.tsx
@@ -279,8 +279,11 @@ const Packages = () => {
         },
       });
     }
-    if (debouncedSearchTerm.length > 2 && customRepositories.length > 0) {
-      if (toggleSourceRepos === RepoToggle.INCLUDED) {
+    if (debouncedSearchTerm.length > 2) {
+      if (
+        toggleSourceRepos === RepoToggle.INCLUDED &&
+        customRepositories.length > 0
+      ) {
         searchCustomRpms({
           apiContentUnitSearchRequest: {
             search: debouncedSearchTerm,


### PR DESCRIPTION
Repositories were not getting recommended after https://github.com/osbuild/image-builder-frontend/pull/2226 got merged. This fixes the problem.