### PR TITLE
Wizard: fix blueprint unique name validation in Edit mode

### DIFF
--- a/src/Components/CreateImageWizardV2/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizardV2/utilities/requestMapper.ts
@@ -182,6 +182,7 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
   }
   return {
     wizardMode,
+    blueprintId: request.id,
     details: {
       blueprintName: request.name,
       blueprintDescription: request.description,

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -45,6 +45,7 @@ export type wizardState = {
     serverUrl: string;
     baseUrl: string;
   };
+  blueprintId?: string;
   wizardMode: WizardModeOptions;
   architecture: ImageRequest['architecture'];
   distribution: Distributions;
@@ -159,6 +160,10 @@ export const selectServerUrl = (state: RootState) => {
 
 export const selectWizardMode = (state: RootState) => {
   return state.wizard.wizardMode;
+};
+
+export const selectBlueprintId = (state: RootState) => {
+  return state.wizard.blueprintId;
 };
 
 export const selectBaseUrl = (state: RootState) => {

--- a/src/test/fixtures/editMode.ts
+++ b/src/test/fixtures/editMode.ts
@@ -248,8 +248,8 @@ export const awsCreateBlueprintRequest: CreateBlueprintRequest = {
 
 export const awsBlueprintResponse: BlueprintResponse = {
   ...awsCreateBlueprintRequest,
-  id: mockBlueprintIds['registration'],
-  description: mockBlueprintDescriptions['registration'],
+  id: mockBlueprintIds['aws'],
+  description: mockBlueprintDescriptions['aws'],
 };
 
 export const gcpImageRequest: ImageRequest = {


### PR DESCRIPTION
Fixes #2220

In cases there is already a state in the wizardSlice, there might have been cases of flicker, when unique request could be started for edit mode, because wizards loads before requestMapper maps the new state of edited blueprints.

In such case, name is not empty (leftover from previous BP create/edit), but wizardMode was not yet set, so defaults to create.

This addresses it by just making sure the validation works as expected in Edit mode.
Now when the name is changed in Edit mode, we run the validation.
We now have the blueprintID in the state, which is empty on create state (might be just easier to recognize mode by id in the future :) )