### PR TITLE
jest: Increase test timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "setupFilesAfterEnv": [
       "./src/test/jest.setup.js"
     ],
-    "testTimeout": 10000
+    "testTimeout": 20000
   },
   "devDependencies": {
     "@babel/core": "7.24.7",

--- a/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizardV2/CreateImageWizard.test.tsx
@@ -943,7 +943,7 @@ describe('Step Details', () => {
 
     expect(await getNextButton()).not.toHaveClass('pf-m-disabled');
     expect(await getNextButton()).toBeEnabled();
-  }, 20000);
+  }, 50000);
 });
 
 describe('Step Review', () => {


### PR DESCRIPTION
This increases default test timeout from 10000 to 20000 and timeout for "image name invalid for more than 100 chars and description for 250" to 50000.

This should eliminate test flakes caused by timing out, later it will be "reverted" when the Vitest migration gets merged.