### PR TITLE
Firstboot: Add testid to empty state buttons

### DIFF
--- a/src/Components/CreateImageWizardV2/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizardV2/steps/FirstBoot/index.tsx
@@ -64,6 +64,10 @@ const FirstBootStep = () => {
         onCodeChange={(code) => dispatch(setFirstBootScript(code))}
         code={selectedScript}
         height="35vh"
+        emptyStateButton={<span data-testid="firstboot_browse">Browse</span>}
+        emptyStateLink={
+          <span data-testid="firstboot_write_manual">Start from scratch</span>
+        }
       />
     </Form>
   );


### PR DESCRIPTION
Add testid to Firstboot buttons.
The code editor [component does not exposes the ouids](https://github.com/patternfly/patternfly-react/blob/c16c6f4a6c64f1d70523f25a5195435971326dde/packages/react-code-editor/src/components/CodeEditor/CodeEditor.tsx#L535) of the buttons, so we are adding inner spans with ids.

```html
<div class="pf-v5-c-empty-state__actions">
  <button aria-disabled="false" class="pf-v5-c-button pf-m-primary" type="button" data-ouia-component-type="PF5/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-primary-3">
    <span data-testid="firstboot_browse">Browse</span>
  </button>
</div>
<div class="pf-v5-c-empty-state__actions">
  <button aria-disabled="false" class="pf-v5-c-button pf-m-link" type="button" data-ouia-component-type="PF5/Button" data-ouia-safe="true" data-ouia-component-id="OUIA-Generated-Button-link-12">
    <span data-testid="firstboot_write_manual">Start from scratch</span>
  </button>
</div>
```