### PR TITLE
test: Fix act warnings 

### DIFF
--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
@@ -109,12 +109,13 @@ const checkRecommendationsEmptyState = async () => {
 };
 
 export const selectCustomRepo = async () => {
+  const user = userEvent.setup();
   await clickBack();
   const customRepoCheckbox = await screen.findByRole('checkbox', {
     name: /select row 0/i,
   });
 
-  await userEvent.click(customRepoCheckbox);
+  user.click(customRepoCheckbox);
   await clickNext();
 };
 


### PR DESCRIPTION
Rebased on https://github.com/osbuild/image-builder-frontend/pull/2238

This removes the `act()` warnings from the test output.