### PR TITLE
dependabot: Decrease open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 3
     rebase-strategy: "auto"


### PR DESCRIPTION
The backlog of stuck dependencies is shrinking, meaning we can go back to previous limit of three open dependabot pull requests.