### PR TITLE
devDeps: Fix one of `npm ci` warnings

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -10,7 +10,7 @@ module.exports = {
     // Put _extends helpers in their own file
         '@babel/plugin-transform-runtime',
         // Support for {...props} via Object.assign({}, props)
-        '@babel/plugin-proposal-object-rest-spread',
+        '@babel/plugin-transform-object-rest-spread',
         // Devs tend to write `import { someIcon } from '@patternfly/react-icons';`
         // This transforms the import to be specific which prevents having to parse 2k+ icons
         // Also prevents potential bundle size blowups with CJS

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
       "devDependencies": {
         "@babel/core": "7.24.9",
         "@babel/eslint-parser": "7.24.8",
-        "@babel/plugin-proposal-object-rest-spread": "7.20.7",
+        "@babel/plugin-transform-object-rest-spread": "7.24.7",
         "@babel/plugin-transform-runtime": "7.24.7",
         "@babel/preset-env": "7.24.8",
         "@babel/preset-react": "7.24.7",
@@ -681,26 +681,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
-    },
-    "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.20.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.20.7.tgz",
-      "integrity": "sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==",
-      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-object-rest-spread instead.",
-      "dev": true,
-      "dependencies": {
-        "@babel/compat-data": "^7.20.5",
-        "@babel/helper-compilation-targets": "^7.20.7",
-        "@babel/helper-plugin-utils": "^7.20.2",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-        "@babel/plugin-transform-parameters": "^7.20.7"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      },
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "devDependencies": {
     "@babel/core": "7.24.9",
     "@babel/eslint-parser": "7.24.8",
-    "@babel/plugin-proposal-object-rest-spread": "7.20.7",
+    "@babel/plugin-transform-object-rest-spread": "7.24.7",
     "@babel/plugin-transform-runtime": "7.24.7",
     "@babel/preset-env": "7.24.8",
     "@babel/preset-react": "7.24.7",


### PR DESCRIPTION
`@babel/plugin-proposal-object-rest-spread` was merged to the ECMAScript standard and is no longer maintained, this replaces it with `@babel/plugin-transform-object-rest-spread`.