### PR TITLE
test: Move `@testing-library/jest-dom` import to test setup file

### DIFF
--- a/src/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import '@testing-library/jest-dom';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import '@testing-library/jest-dom';
 
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor } from '@testing-library/react';

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import '@testing-library/jest-dom';
-
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import '@testing-library/jest-dom';
-
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 
-import '@testing-library/jest-dom';
-
 import type { Router as RemixRouter } from '@remix-run/router';
 import {
   screen,

--- a/src/test/Components/CreateImageWizard/EditImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/EditImageWizard.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { screen, within } from '@testing-library/react';
 
 import { renderEditMode } from './wizardTestUtils';

--- a/src/test/Components/CreateImageWizard/steps/Details/Details.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Details/Details.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';

--- a/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import '@testing-library/jest-dom';
 
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { screen, waitFor, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/test/Components/LandingPage/LandingPage.test.tsx
+++ b/src/test/Components/LandingPage/LandingPage.test.tsx
@@ -1,4 +1,3 @@
-import '@testing-library/jest-dom';
 import { screen } from '@testing-library/react';
 import { http, HttpResponse } from 'msw';
 

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.tsx
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import '@testing-library/jest-dom';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 

--- a/src/test/Components/edge/EdgeImagesTable.test.tsx
+++ b/src/test/Components/edge/EdgeImagesTable.test.tsx
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { useFlag } from '@unleash/proxy-client-react';
 
 vi.mock('@unleash/proxy-client-react', () => ({

--- a/src/test/Components/edge/ImageDetails.test.tsx
+++ b/src/test/Components/edge/ImageDetails.test.tsx
@@ -1,5 +1,3 @@
-import '@testing-library/jest-dom';
-
 import { useFlag } from '@unleash/proxy-client-react';
 
 vi.mock('@unleash/proxy-client-react', () => ({

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,3 +1,4 @@
+import '@testing-library/jest-dom';
 import { configure } from '@testing-library/react';
 
 import { server } from './mocks/server';


### PR DESCRIPTION
This removes `@testing-library/jest-dom` from single test files and adds it to the shared setup.ts file.