### PR TITLE
test: Remove deprecated flags from mocking

### DIFF
--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -24,9 +24,7 @@ vi.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 vi.mock('@unleash/proxy-client-react', () => ({
   useUnleashContext: () => vi.fn(),
-  useFlag: vi.fn((flag) =>
-    flag === 'image-builder.new-wizard.enabled' ? true : false
-  ),
+  useFlag: vi.fn(() => false),
 }));
 
 const selectBlueprintById = async (bpId: string) => {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.tsx
@@ -43,9 +43,7 @@ vi.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 vi.mock('@unleash/proxy-client-react', () => ({
   useUnleashContext: () => vi.fn(),
-  useFlag: vi.fn((flag) =>
-    flag === 'image-builder.wizard.oscap.enabled' ? true : false
-  ),
+  useFlag: vi.fn(() => false),
 }));
 
 const selectRhel8 = async () => {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
@@ -45,20 +45,11 @@ vi.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   }),
 }));
 
-let mockContentSourcesEnabled: boolean;
-
 vi.mock('@unleash/proxy-client-react', () => ({
   useUnleashContext: () => vi.fn(),
-  useFlag: vi.fn((flag) => {
-    switch (flag) {
-      case 'image-builder.enable-content-sources':
-        return mockContentSourcesEnabled;
-      case 'image-builder.pkgrecs.enabled':
-        return true;
-      default:
-        return false;
-    }
-  }),
+  useFlag: vi.fn((flag) =>
+    flag === 'image-builder.pkgrecs.enabled' ? true : false
+  ),
 }));
 
 const typeIntoSearchBox = async (searchTerm: string) => {
@@ -120,13 +111,10 @@ export const selectCustomRepo = async () => {
 describe('Step Packages', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockContentSourcesEnabled = true;
   });
 
   const user = userEvent.setup();
   const setUp = async () => {
-    mockContentSourcesEnabled = false;
-
     ({ router } = await renderCustomRoutesWithReduxRouter(
       'imagewizard',
       {},
@@ -418,7 +406,6 @@ describe('Step Packages', () => {
 describe('Step Custom repositories', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockContentSourcesEnabled = true;
   });
 
   const user = userEvent.setup();


### PR DESCRIPTION
`image-builder.new-wizard.enabled`, `image-builder.wizard.oscap.enabled` and `image-builder.enable-content-sources` are no longer used in the code base and thus don't need to be mocked in tests.