### PR TITLE
createImage: change resolution to be able to see buttons in create image wizard (HMS-4485)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -2,9 +2,6 @@
     padding-right: 0px;
 }
 
-.pf-v5-c-wizard__nav {
-    overflow-y: unset;
-}
 
 .pf-c-popover[data-popper-reference-hidden="true"] {
     font-weight: initial;
@@ -88,7 +85,6 @@ div.pf-v5-c-alert.pf-m-inline.pf-m-plain.pf-m-warning {
     display: flex
 }
 
-// Fixes min height issues on the main wizard container
-.pf-v5-c-wizard__outer-wrap {
-    min-height: 602px;
+.pf-v5-c-wizard__main {
+    flex: 1 1 0
 }

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -8,6 +8,7 @@ import {
   WizardStep,
   WizardStepType,
   useWizardContext,
+  PageSection,
 } from '@patternfly/react-core';
 import { useFlag } from '@unleash/proxy-client-react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
@@ -229,7 +230,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   return (
     <>
       <ImageBuilderHeader inWizard />
-      <section className="pf-l-page__main-section pf-c-page__main-section">
+      <PageSection isWidthLimited>
         <Wizard
           startIndex={startIndex}
           onClose={() => navigate(resolveRelPath(''))}
@@ -433,7 +434,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
             <ReviewStep snapshottingEnabled={snapshottingEnabled} />
           </WizardStep>
         </Wizard>
-      </section>
+      </PageSection>
     </>
   );
 };


### PR DESCRIPTION
this commit change the resoluiton of wizard__outer-wrap to solve
the problem that user should scroll to see the next, backl and cancel buttons

https://github.com/user-attachments/assets/f54826fb-bf1a-4b2b-81db-516b1793d2c0

