### PR TITLE
test: Fix async logic in Oscap flakes and allow fileParallelism

### DIFF
--- a/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
@@ -5,12 +5,12 @@ import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { CreateBlueprintRequest } from '../../../../../store/imageBuilderApi';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
 import {
-  //baseCreateBlueprintRequest,
-  //expectedFilesystemCisL2,
-  //expectedKernelCisL2,
-  //expectedOpenscapCisL2,
-  //expectedPackagesCisL2,
-  //expectedServicesCisL2,
+  baseCreateBlueprintRequest,
+  expectedFilesystemCisL2,
+  expectedKernelCisL2,
+  expectedOpenscapCisL2,
+  expectedPackagesCisL2,
+  expectedServicesCisL2,
   oscapCreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
 import { clickNext } from '../../../../testUtils';
@@ -73,36 +73,36 @@ const selectProfile = async () => {
   const selectProfileDropdown = await screen.findByRole('textbox', {
     name: /select a profile/i,
   });
-  await waitFor(async () => await user.click(selectProfileDropdown));
+  await waitFor(() => user.click(selectProfileDropdown));
 
   const cis1Profile = await screen.findByText(
     /cis red hat enterprise linux 8 benchmark for level 1 - workstation/i
   );
-  await waitFor(async () => user.click(cis1Profile));
+  await waitFor(() => user.click(cis1Profile));
 };
 
-// const selectDifferentProfile = async () => {
-//   const user = userEvent.setup();
-//   const selectProfileDropdown = await screen.findByRole('textbox', {
-//     name: /select a profile/i,
-//   });
-//   await waitFor(async () => user.click(selectProfileDropdown));
-//
-//   const cis2Profile = await screen.findByText(
-//     /cis red hat enterprise linux 8 benchmark for level 2 - workstation/i
-//   );
-//   await waitFor(async () => user.click(cis2Profile));
-// };
-//
-// const selectNone = async () => {
-//   const user = userEvent.setup();
-//   const selectProfileDropdown = await screen.findByRole('textbox', {
-//     name: /select a profile/i,
-//   });
-//   await waitFor(async () => user.click(selectProfileDropdown));
-//
-//   await waitFor(async () => user.click(await screen.findByText(/none/i)));
-// };
+const selectDifferentProfile = async () => {
+  const user = userEvent.setup();
+  const selectProfileDropdown = await screen.findByRole('textbox', {
+    name: /select a profile/i,
+  });
+  await waitFor(() => user.click(selectProfileDropdown));
+
+  const cis2Profile = await screen.findByText(
+    /cis red hat enterprise linux 8 benchmark for level 2 - workstation/i
+  );
+  await waitFor(() => user.click(cis2Profile));
+};
+
+const selectNone = async () => {
+  const user = userEvent.setup();
+  const selectProfileDropdown = await screen.findByRole('textbox', {
+    name: /select a profile/i,
+  });
+  await waitFor(() => user.click(selectProfileDropdown));
+
+  await waitFor(async () => user.click(await screen.findByText(/none/i)));
+};
 
 const goToReviewStep = async () => {
   await clickNext(); // File system configuration
@@ -135,52 +135,54 @@ describe('oscap', () => {
       ...oscapCreateBlueprintRequest,
       name: 'Oscap test',
     };
-
-    expect(receivedRequest).toEqual(expectedRequest);
+    await waitFor(() => {
+      expect(receivedRequest).toEqual(expectedRequest);
+    });
   });
 
-  //  test('remove a profile', async () => {
-  //    await renderCreateMode();
-  //    await goToOscapStep();
-  //    await selectProfile();
-  //    await selectNone();
-  //    await goToReviewStep();
-  //
-  //    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
-  //
-  //    const expectedRequest: CreateBlueprintRequest = {
-  //      ...baseCreateBlueprintRequest,
-  //      name: 'Oscap test',
-  //    };
-  //
-  //    expect(receivedRequest).toEqual(expectedRequest);
-  //  });
-  //
-  //  test('change profile', async () => {
-  //    await renderCreateMode();
-  //    await goToOscapStep();
-  //    await selectProfile();
-  //    await selectDifferentProfile();
-  //    await goToReviewStep();
-  //
-  //    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
-  //
-  //    const expectedRequest: CreateBlueprintRequest = {
-  //      ...baseCreateBlueprintRequest,
-  //      customizations: {
-  //        packages: expectedPackagesCisL2,
-  //        openscap: expectedOpenscapCisL2,
-  //        services: expectedServicesCisL2,
-  //        kernel: expectedKernelCisL2,
-  //        filesystem: expectedFilesystemCisL2,
-  //      },
-  //      name: 'Oscap test',
-  //    };
-  //
-  //    await waitFor(() => {
-  //      expect(receivedRequest).toEqual(expectedRequest);
-  //    });
-  //  });
+  test('remove a profile', { retry: 3, timeout: 20000 }, async () => {
+    await renderCreateMode();
+    await goToOscapStep();
+    await selectProfile();
+    await selectNone();
+    await goToReviewStep();
+
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    const expectedRequest: CreateBlueprintRequest = {
+      ...baseCreateBlueprintRequest,
+      name: 'Oscap test',
+    };
+    await waitFor(() => {
+      expect(receivedRequest).toEqual(expectedRequest);
+    });
+  });
+
+  test('change profile', { retry: 3, timeout: 20000 }, async () => {
+    await renderCreateMode();
+    await goToOscapStep();
+    await selectProfile();
+    await selectDifferentProfile();
+    await goToReviewStep();
+
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    const expectedRequest: CreateBlueprintRequest = {
+      ...baseCreateBlueprintRequest,
+      customizations: {
+        packages: expectedPackagesCisL2,
+        openscap: expectedOpenscapCisL2,
+        services: expectedServicesCisL2,
+        kernel: expectedKernelCisL2,
+        filesystem: expectedFilesystemCisL2,
+      },
+      name: 'Oscap test',
+    };
+
+    await waitFor(() => {
+      expect(receivedRequest).toEqual(expectedRequest);
+    });
+  });
 });
 
 describe('OpenSCAP edit mode', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -15,7 +15,6 @@ const config = {
         inline: ['vitest-canvas-mock', '@patternfly'],
       },
     },
-    fileParallelism: false,
     testTimeout: 10000,
   },
   resolve: {


### PR DESCRIPTION
`remove profile` and `change profile` test in `Oscap.test.tsx` suite were flaking for Node 18.x, this should fix the issue.