### PR TITLE
change the value of SE_NODE_SESSION_TIMEOUT from number to string

### DIFF
--- a/deploy/iqe-trigger-integration.yml
+++ b/deploy/iqe-trigger-integration.yml
@@ -180,4 +180,4 @@ parameters:
 - name: IQE_PARALLEL_ENABLED
   value: "false"
 - name: SE_NODE_SESSION_TIMEOUT
-  value: 600
+  value: "600"


### PR DESCRIPTION
this commit change the value of SE_NODE_SESSION_TIMEOUT 
from number to string becuase it is blocking auto-promotion test