### PR TITLE
Wizard: Migrate WSL from `isBeta()` to unleash flag (HMS-4513)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
@@ -12,6 +12,7 @@ import {
   Tile,
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
+import { useFlag } from '@unleash/proxy-client-react';
 
 import { useAppSelector, useAppDispatch } from '../../../../store/hooks';
 import {
@@ -29,12 +30,14 @@ import {
   selectDistribution,
   selectImageTypes,
 } from '../../../../store/wizardSlice';
-import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
 
 const TargetEnvironment = () => {
   const arch = useAppSelector(selectArchitecture);
   const environments = useAppSelector(selectImageTypes);
   const distribution = useAppSelector(selectDistribution);
+
+  const wslFlag = useFlag('image-builder.wsl.enabled');
+
   const { data } = useGetArchitecturesQuery({
     distribution: distribution,
   });
@@ -45,7 +48,6 @@ const TargetEnvironment = () => {
 
   const dispatch = useAppDispatch();
   const prefetchSources = provisioningApi.usePrefetch('getSourceList');
-  const { isBeta } = useGetEnvironment();
 
   const supportedEnvironments = data?.find(
     (elem) => elem.arch === arch
@@ -321,7 +323,7 @@ const TargetEnvironment = () => {
             data-testid="checkbox-image-installer"
           />
         )}
-        {supportedEnvironments?.includes('wsl') && isBeta() && (
+        {supportedEnvironments?.includes('wsl') && wslFlag && (
           <Checkbox
             label="WSL - Windows Subsystem for Linux (.tar.gz)"
             isChecked={environments.includes('wsl')}

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.tsx
@@ -43,7 +43,9 @@ vi.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 vi.mock('@unleash/proxy-client-react', () => ({
   useUnleashContext: () => vi.fn(),
-  useFlag: vi.fn(() => false),
+  useFlag: vi.fn((flag) =>
+    flag === 'image-builder.wsl.enabled' ? true : false
+  ),
 }));
 
 const selectRhel8 = async () => {

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -71,9 +71,16 @@ vi.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
 
 vi.mock('@unleash/proxy-client-react', () => ({
   useUnleashContext: () => vi.fn(),
-  useFlag: vi.fn((flag) =>
-    flag === 'image-builder.firstboot.enabled' ? true : false
-  ),
+  useFlag: vi.fn((flag) => {
+    switch (flag) {
+      case 'image-builder.firstboot.enabled':
+        return true;
+      case 'image-builder.wsl.enabled':
+        return true;
+      default:
+        return false;
+    }
+  }),
 }));
 
 const openReleaseMenu = async () => {


### PR DESCRIPTION
This gates WSL target behind an 'image-builder.wsl.enabled' unleash flag instead of `isBeta()`.