### PR TITLE
test: Move util function to wizardTestUtils

### DIFF
--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
@@ -4,6 +4,8 @@ import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { selectCustomRepo } from './wizardTestUtils';
+
 import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
 import {
   clickBack,
@@ -102,17 +104,6 @@ const checkRecommendationsEmptyState = async () => {
   });
 
   await screen.findByText('Select packages to generate recommendations.');
-};
-
-export const selectCustomRepo = async () => {
-  const user = userEvent.setup();
-  await clickBack();
-  const customRepoCheckbox = await screen.findByRole('checkbox', {
-    name: /select row 0/i,
-  });
-
-  user.click(customRepoCheckbox);
-  await clickNext();
 };
 
 describe('Step Packages', () => {

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -12,7 +12,7 @@ import {
   packagesCreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
 import { clickNext } from '../../../../testUtils';
-import { selectCustomRepo } from '../../CreateImageWizard.content.test';
+import { selectCustomRepo } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
@@ -10,7 +10,11 @@ import {
   ImageRequest,
 } from '../../../store/imageBuilderApi';
 import { server } from '../../mocks/server';
-import { clickNext, renderCustomRoutesWithReduxRouter } from '../../testUtils';
+import {
+  clickBack,
+  clickNext,
+  renderCustomRoutesWithReduxRouter,
+} from '../../testUtils';
 
 type RequestTypes = 'GET' | 'PUT' | 'POST' | 'DELETE';
 
@@ -104,6 +108,17 @@ export const clickRegisterLater = async () => {
     name: 'Register later',
   });
   await waitFor(() => user.click(radioButton));
+};
+
+export const selectCustomRepo = async () => {
+  const user = userEvent.setup();
+  await clickBack();
+  const customRepoCheckbox = await screen.findByRole('checkbox', {
+    name: /select row 0/i,
+  });
+
+  user.click(customRepoCheckbox);
+  await clickNext();
 };
 
 export const enterBlueprintName = async (name: string = 'Red Velvet') => {


### PR DESCRIPTION
This moves `selectCustomRepo` to `wizardTestUtils.tsx`

Since the function was originally imported into `Packages.test.tsx` from `CreateImageWizard.content.test.tsx` the entire content suite was re-run under Packages suite each time. This solves the issue.