### PR TITLE
Wizard: Fix information rendered in package recommendations

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
@@ -164,7 +164,7 @@ const PackageRecommendations = () => {
                 again by changing your selected packages.
               </Alert>
             )}
-            {isSuccess && !data?.packages?.length && (
+            {isSuccess && !data?.packages?.length && packages.length > 0 && (
               <>No recommendations found for the set of selected packages</>
             )}
             {isSuccess && data && data?.packages && (


### PR DESCRIPTION
When a package got selected and deselected again, landing on 0 for selected packages, the information shown in the package recommendations was "Select packages to generate recommendations.No recommendations found for the set of selected packages", this updates the logic to separate the messages.