### PR TITLE
vitest: Disable `fileParallelism`

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,7 @@ const config = {
       },
     },
     testTimeout: 10000,
+    fileParallelism: false,
   },
   resolve: {
     mainFields: ['module'],


### PR DESCRIPTION
This re-disables `fileParallelism` again as it's still proving too flaky.