### PR TITLE
test: Move clicking helper functions to `wizardTestUtils`

### DIFF
--- a/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.azure.test.tsx
@@ -5,17 +5,18 @@ import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 
-import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
-import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
-import { PROVISIONING_API } from '../../../constants';
-import { server } from '../../mocks/server';
 import {
   clickBack,
   clickNext,
   getNextButton,
-  renderCustomRoutesWithReduxRouter,
   verifyCancelButton,
-} from '../../testUtils';
+} from './wizardTestUtils';
+
+import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
+import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
+import { PROVISIONING_API } from '../../../constants';
+import { server } from '../../mocks/server';
+import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
 const routes = [
   {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.compliance.test.tsx
@@ -3,9 +3,11 @@ import React from 'react';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { clickNext } from './wizardTestUtils';
+
 import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
 import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
-import { clickNext, renderCustomRoutesWithReduxRouter } from '../../testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
 const routes = [
   {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
@@ -5,14 +5,10 @@ import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { selectCustomRepo } from './wizardTestUtils';
+import { clickBack, clickNext, verifyCancelButton } from './wizardTestUtils';
 
 import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
-import {
-  clickBack,
-  clickNext,
-  renderCustomRoutesWithReduxRouter,
-  verifyCancelButton,
-} from '../../testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
 const routes = [
   {

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
@@ -9,18 +9,18 @@ import {
   enterBlueprintName,
   openAndDismissSaveAndBuildModal,
 } from './wizardTestUtils';
+import {
+  clickBack,
+  clickNext,
+  getNextButton,
+  verifyCancelButton,
+} from './wizardTestUtils';
 
 import CreateImageWizard from '../../../Components/CreateImageWizard/CreateImageWizard';
 import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
 import { PROVISIONING_API } from '../../../constants';
 import { server } from '../../mocks/server';
-import {
-  clickBack,
-  clickNext,
-  getNextButton,
-  renderCustomRoutesWithReduxRouter,
-  verifyCancelButton,
-} from '../../testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
 const routes = [
   {

--- a/src/test/Components/CreateImageWizard/steps/Details/Details.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Details/Details.test.tsx
@@ -4,7 +4,7 @@ import { userEvent } from '@testing-library/user-event';
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
 import { detailsCreateBlueprintRequest } from '../../../../fixtures/editMode';
-import { clickNext, getNextButton } from '../../../../testUtils';
+import { clickNext, getNextButton } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../../constants';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
 import { fscCreateBlueprintRequest } from '../../../../fixtures/editMode';
-import { clickNext } from '../../../../testUtils';
+import { clickNext } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
@@ -13,7 +13,7 @@ import {
   firstBootCreateBlueprintRequest,
   firstBootData,
 } from '../../../../fixtures/editMode';
-import { clickNext, getNextButton } from '../../../../testUtils';
+import { clickNext, getNextButton } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.test.tsx
@@ -26,10 +26,8 @@ import {
   rhel9CreateBlueprintRequest,
   x86_64CreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
-import {
-  clickNext,
-  renderCustomRoutesWithReduxRouter,
-} from '../../../../testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../../../testUtils';
+import { clickNext } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
@@ -13,7 +13,7 @@ import {
   expectedServicesCisL2,
   oscapCreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
-import { clickNext } from '../../../../testUtils';
+import { clickNext } from '../../wizardTestUtils';
 import {
   clickRegisterLater,
   enterBlueprintName,

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -11,7 +11,7 @@ import {
   expectedSinglePackageRecommendation,
   packagesCreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
-import { clickNext } from '../../../../testUtils';
+import { clickNext } from '../../wizardTestUtils';
 import { selectCustomRepo } from '../../wizardTestUtils';
 import {
   blueprintRequest,

--- a/src/test/Components/CreateImageWizard/steps/Registration/Registration.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Registration/Registration.test.tsx
@@ -24,12 +24,12 @@ import {
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
 import { registrationCreateBlueprintRequest } from '../../../../fixtures/editMode';
 import { server } from '../../../../mocks/server';
+import { renderCustomRoutesWithReduxRouter } from '../../../../testUtils';
 import {
   clickBack,
   clickNext,
-  renderCustomRoutesWithReduxRouter,
   verifyCancelButton,
-} from '../../../../testUtils';
+} from '../../wizardTestUtils';
 import {
   enterBlueprintName,
   renderCreateMode,

--- a/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
@@ -13,7 +13,7 @@ import {
   expectedPayloadRepositories,
   repositoriesCreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
-import { clickNext } from '../../../../testUtils';
+import { clickNext } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
@@ -9,7 +9,7 @@ import {
   expectedPayloadRepositories,
   snapshotCreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
-import { clickNext } from '../../../../testUtils';
+import { clickNext } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AwsTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AwsTarget.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../../../store/imageBuilderApi';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
 import { awsCreateBlueprintRequest } from '../../../../fixtures/editMode';
-import { clickBack, clickNext } from '../../../../testUtils';
+import { clickBack, clickNext } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
@@ -8,7 +8,7 @@ import {
 } from '../../../../../store/imageBuilderApi';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
 import { azureCreateBlueprintRequest } from '../../../../fixtures/editMode';
-import { clickBack, clickNext } from '../../../../testUtils';
+import { clickBack, clickNext } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../../../../store/imageBuilderApi';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
 import { gcpCreateBlueprintRequest } from '../../../../fixtures/editMode';
-import { clickBack, clickNext } from '../../../../testUtils';
+import { clickBack, clickNext } from '../../wizardTestUtils';
 import {
   blueprintRequest,
   clickRegisterLater,

--- a/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
@@ -10,11 +11,7 @@ import {
   ImageRequest,
 } from '../../../store/imageBuilderApi';
 import { server } from '../../mocks/server';
-import {
-  clickBack,
-  clickNext,
-  renderCustomRoutesWithReduxRouter,
-} from '../../testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
 type RequestTypes = 'GET' | 'PUT' | 'POST' | 'DELETE';
 
@@ -168,4 +165,34 @@ export const interceptEditBlueprintRequest = async (
   await waitFor(() => user.click(saveButton));
 
   return await receivedRequestPromise;
+};
+
+export const clickBack = async () => {
+  const user = userEvent.setup();
+  const backBtn = await screen.findByRole('button', { name: /Back/ });
+  await waitFor(() => user.click(backBtn));
+};
+
+export const clickNext = async () => {
+  const user = userEvent.setup();
+  const nextBtn = await screen.findByRole('button', { name: /Next/ });
+  await waitFor(() => user.click(nextBtn));
+};
+
+export const clickCancel = async () => {
+  const user = userEvent.setup();
+  const cancelBtn = await screen.findByRole('button', { name: /Cancel/ });
+  await waitFor(() => user.click(cancelBtn));
+};
+
+export const getNextButton = async () => {
+  const next = await screen.findByRole('button', { name: /Next/ });
+  return next;
+};
+
+export const verifyCancelButton = async (router: RemixRouter | undefined) => {
+  await clickCancel();
+  if (router) {
+    expect(router.state.location.pathname).toBe('/insights/image-builder');
+  }
 };

--- a/src/test/testUtils.js
+++ b/src/test/testUtils.js
@@ -1,8 +1,7 @@
 import React from 'react';
 
 import { configureStore } from '@reduxjs/toolkit';
-import { screen, render, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createMemoryRouter, RouterProvider } from 'react-router-dom';
 
@@ -45,44 +44,4 @@ export const renderCustomRoutesWithReduxRouter = async (
   );
 
   return { router, store };
-};
-
-export const renderWithProvider = (
-  component,
-  container,
-  preloadedState = {}
-) => {
-  const store = configureStore({ reducer, middleware, preloadedState });
-
-  return render(<Provider store={store}>{component}</Provider>, {
-    container: container,
-  });
-};
-
-export const clickBack = async () => {
-  const user = userEvent.setup();
-  const backBtn = await screen.findByRole('button', { name: /Back/ });
-  await waitFor(() => user.click(backBtn));
-};
-
-export const clickNext = async () => {
-  const user = userEvent.setup();
-  const nextBtn = await screen.findByRole('button', { name: /Next/ });
-  await waitFor(() => user.click(nextBtn));
-};
-
-export const clickCancel = async () => {
-  const user = userEvent.setup();
-  const cancelBtn = await screen.findByRole('button', { name: /Cancel/ });
-  await waitFor(() => user.click(cancelBtn));
-};
-
-export const getNextButton = async () => {
-  const next = await screen.findByRole('button', { name: /Next/ });
-  return next;
-};
-
-export const verifyCancelButton = async (router) => {
-  await clickCancel();
-  expect(router.state.location.pathname).toBe('/insights/image-builder');
 };


### PR DESCRIPTION
As clicking helper functions are used only in the context of Wizard, this moves them to an appropriate place.