### PR TITLE
testUtils: Merge `renderCustomRoutesWithReduxRouter` and `renderWithReduxRouter`

### DIFF
--- a/src/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -1,7 +1,7 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { renderWithReduxRouter } from '../../test/testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../test/testUtils';
 
 const BLUEPRINT_JSON = `{
     "customizations": {
@@ -174,13 +174,13 @@ describe('Import model', () => {
   const user = userEvent.setup();
 
   test('renders import component', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
     const importButton = await screen.findByTestId('import-blueprint-button');
     await waitFor(() => expect(importButton).toBeInTheDocument());
   });
 
   const setUp = async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
     const importBlueprintBtn = await screen.findByTestId(
       'import-blueprint-button'
     );

--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -9,10 +9,7 @@ import LandingPage from '../../../Components/LandingPage/LandingPage';
 import { IMAGE_BUILDER_API } from '../../../constants';
 import { emptyGetBlueprints } from '../../fixtures/blueprints';
 import { server } from '../../mocks/server';
-import {
-  renderCustomRoutesWithReduxRouter,
-  renderWithReduxRouter,
-} from '../../testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
 const selectBlueprintById = async (bpId: string) => {
   const user = userEvent.setup();
@@ -36,7 +33,7 @@ describe('Blueprints', () => {
   const blueprintIdCentos8 = 'b1f10309-a250-4db8-ab64-c110176e3eb7';
 
   test('renders blueprints page', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
     await screen.findByText(blueprintNameWithComposes);
     await screen.findByText(blueprintNameEmptyComposes);
   });
@@ -47,7 +44,7 @@ describe('Blueprints', () => {
       })
     );
 
-    const { router } = await renderWithReduxRouter('', {});
+    const { router } = await renderCustomRoutesWithReduxRouter();
     await screen.findByText('No blueprints yet');
     const emptyStateAction = screen.getByRole('link', {
       name: /Add blueprint/i,
@@ -62,7 +59,7 @@ describe('Blueprints', () => {
     );
   });
   test('renders blueprint composes', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
 
     await selectBlueprintById(blueprintIdWithComposes);
     const table = await screen.findByTestId('images-table');
@@ -71,7 +68,7 @@ describe('Blueprints', () => {
     expect(images).toHaveLength(2);
   });
   test('renders blueprint composes empty state', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
 
     await selectBlueprintById(blueprintIdEmptyComposes);
     const table = await screen.findByTestId('images-table');
@@ -80,7 +77,7 @@ describe('Blueprints', () => {
   });
 
   test('click build images button', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
 
     await selectBlueprintById(blueprintIdWithComposes);
     const buildImageBtn = await screen.findByRole('button', {
@@ -90,7 +87,7 @@ describe('Blueprints', () => {
   });
 
   test('uncheck Target option and check that build images button is Disable', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
 
     await selectBlueprintById(blueprintIdWithComposes);
     const buildImageBtn = await screen.findByRole('button', {
@@ -115,7 +112,7 @@ describe('Blueprints', () => {
   });
 
   test('uncheck one Target option and check that you can build an image', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
 
     await selectBlueprintById(blueprintIdWithMultipleTargets);
     const buildImageBtn = await screen.findByRole('button', {
@@ -139,7 +136,7 @@ describe('Blueprints', () => {
   });
 
   test('blueprint is out of sync', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
 
     await selectBlueprintById(blueprintIdOutOfSync);
     await screen.findByText(
@@ -155,7 +152,7 @@ describe('Blueprints', () => {
   });
 
   test('CentOS 8 Stream renders', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
 
     await selectBlueprintById(blueprintIdCentos8);
     await screen.findByText(
@@ -220,7 +217,7 @@ describe('Blueprints', () => {
     });
 
     test('filter blueprints', async () => {
-      renderWithReduxRouter('', {});
+      renderCustomRoutesWithReduxRouter();
 
       const searchInput = await screen.findByPlaceholderText(
         'Search by name or description'
@@ -248,7 +245,7 @@ describe('Blueprints', () => {
     });
 
     test('paging of blueprints', async () => {
-      renderWithReduxRouter('', {});
+      renderCustomRoutesWithReduxRouter();
 
       expect(await screen.findAllByRole('checkbox')).toHaveLength(10);
 
@@ -285,7 +282,7 @@ describe('Blueprints', () => {
     });
 
     test('filter composes by blueprint version', async () => {
-      renderWithReduxRouter('', {});
+      renderCustomRoutesWithReduxRouter();
 
       await selectBlueprintById(blueprintIdWithComposes);
 

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.content.test.tsx
@@ -572,13 +572,13 @@ describe('Step Custom repositories', () => {
 // describe('On Recreate', () => {
 //   const user = userEvent.setup();
 //   const setUp = async () => {
-//     ({ router } = renderWithReduxRouter(
+//     ({ router } = renderCustomRoutesWithReduxRouter(
 //       'imagewizard/hyk93673-8dcc-4a61-ac30-e9f4940d8346'
 //     ));
 //   };
 //
 //   const setUpUnavailableRepo = async () => {
-//     ({ router } = renderWithReduxRouter(
+//     ({ router } = renderCustomRoutesWithReduxRouter(
 //       'imagewizard/b7193673-8dcc-4a5f-ac30-e9f4940d8346'
 //     ));
 //   };

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -6,7 +6,7 @@ import {
   mockClones,
   mockCloneStatus,
 } from '../../fixtures/composes';
-import { renderWithReduxRouter } from '../../testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
 describe('Images Table', () => {
   beforeEach(() => {
@@ -15,7 +15,7 @@ describe('Images Table', () => {
 
   const user = userEvent.setup();
   test('render ImagesTable', async () => {
-    await renderWithReduxRouter('', {});
+    await renderCustomRoutesWithReduxRouter();
 
     const table = await screen.findByTestId('images-table');
 
@@ -55,7 +55,7 @@ describe('Images Table', () => {
   });
 
   test('check download compose request action', async () => {
-    await renderWithReduxRouter('', {});
+    await renderCustomRoutesWithReduxRouter();
 
     // get rows
     const table = await screen.findByTestId('images-table');
@@ -96,7 +96,7 @@ describe('Images Table', () => {
   });
 
   test('check expandable row toggle', async () => {
-    await renderWithReduxRouter('', {});
+    await renderCustomRoutesWithReduxRouter();
 
     const table = await screen.findByTestId('images-table');
     const { findAllByRole } = within(table);
@@ -114,7 +114,7 @@ describe('Images Table', () => {
   });
 
   test('check error details', { retry: 3 }, async () => {
-    await renderWithReduxRouter('', {});
+    await renderCustomRoutesWithReduxRouter();
 
     let table = await screen.findByTestId('images-table');
     let rows = await within(table).findAllByRole('row');
@@ -203,7 +203,7 @@ describe('Images Table Toolbar', () => {
   });
 
   test('render toolbar', async () => {
-    await renderWithReduxRouter('', {});
+    await renderCustomRoutesWithReduxRouter();
     await screen.findByTestId('images-table');
 
     // check pagination renders
@@ -219,7 +219,7 @@ describe('Clones table', () => {
 
   const user = userEvent.setup();
   test('renders clones table', async () => {
-    await renderWithReduxRouter('', {});
+    await renderCustomRoutesWithReduxRouter();
 
     const table = await screen.findByTestId('images-table');
 

--- a/src/test/Components/LandingPage/LandingPage.test.tsx
+++ b/src/test/Components/LandingPage/LandingPage.test.tsx
@@ -4,7 +4,7 @@ import { http, HttpResponse } from 'msw';
 import { IMAGE_BUILDER_API } from '../../../constants';
 import { mockComposesEmpty } from '../../fixtures/composes';
 import { server } from '../../mocks/server';
-import { renderWithReduxRouter } from '../../testUtils';
+import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
 
 describe('Landing Page', () => {
   beforeEach(() => {
@@ -12,7 +12,7 @@ describe('Landing Page', () => {
   });
 
   test('renders page heading', async () => {
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
 
     // check heading
     const heading = await screen.findByText('Images');
@@ -26,7 +26,7 @@ describe('Landing Page', () => {
       })
     );
 
-    renderWithReduxRouter('', {});
+    renderCustomRoutesWithReduxRouter();
     // check table loads
     await screen.findByTestId('empty-state');
   });

--- a/src/test/testUtils.js
+++ b/src/test/testUtils.js
@@ -12,46 +12,27 @@ import ShareImageModal from '../Components/ShareImageModal/ShareImageModal';
 import { middleware, reducer } from '../store';
 import { resolveRelPath } from '../Utilities/path';
 
+const defaultRoutes = [
+  {
+    path: 'insights/image-builder/*',
+    element: <LandingPage />,
+  },
+  {
+    path: 'insights/image-builder/imagewizard/import',
+    element: <ImportImageWizard />,
+  },
+  {
+    path: 'insights/image-builder/share/:composeId',
+    element: <ShareImageModal />,
+  },
+];
+
 export const renderCustomRoutesWithReduxRouter = async (
   route = '/',
   preloadedState = {},
-  routes
+  routes = defaultRoutes
 ) => {
   const store = configureStore({ reducer, middleware, preloadedState });
-
-  const router = createMemoryRouter(routes, {
-    initialEntries: [resolveRelPath(route)],
-  });
-
-  render(
-    <Provider store={store}>
-      <RouterProvider router={router} />
-    </Provider>
-  );
-
-  return { router, store };
-};
-
-export const renderWithReduxRouter = async (
-  route = '/',
-  preloadedState = {}
-) => {
-  const store = configureStore({ reducer, middleware, preloadedState });
-
-  const routes = [
-    {
-      path: 'insights/image-builder/*',
-      element: <LandingPage />,
-    },
-    {
-      path: 'insights/image-builder/imagewizard/import',
-      element: <ImportImageWizard />,
-    },
-    {
-      path: 'insights/image-builder/share/:composeId',
-      element: <ShareImageModal />,
-    },
-  ];
 
   const router = createMemoryRouter(routes, {
     initialEntries: [resolveRelPath(route)],


### PR DESCRIPTION
`renderCustomRoutesWithReduxRouter` and `renderWithReduxRouter`are functionally the same apart from routes they use to render components.

We could just use `renderCustomRoutesWithReduxRouter` and use the routes from `renderWithReduxRouter` as a default value for an optional parameter `routes`.