### PR TITLE
Wizard: Add eslint-disable to useEffect

### DIFF
--- a/src/Components/CreateImageWizard/steps/Details/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/index.tsx
@@ -40,6 +40,9 @@ const DetailsStep = () => {
         )
       );
     }
+    // This useEffect hook should run *only* on mount and therefore has an empty
+    // dependency array. eslint's exhaustive-deps rule does not support this use.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
   const handleNameChange = (
     _event: React.FormEvent<HTMLInputElement>,

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -18,6 +18,9 @@ const OscapStep = () => {
   const release = useAppSelector(selectDistribution);
   useEffect(() => {
     prefetchOscapProfile({ distribution: release });
+    // This useEffect hook should run *only* on mount and therefore has an empty
+    // dependency array. eslint's exhaustive-deps rule does not support this use.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (


### PR DESCRIPTION
This disables `react-hooks/exhaustive-deps` rule for dependency arrays that should run only once on mount and therefore need to stay empty.