### PR TITLE
Wizard: add partitioning modes into file system config

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/FileSystemConfiguration.tsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import {
   Alert,
   Button,
+  FormGroup,
+  Radio,
   Text,
   TextContent,
   TextInput,
@@ -31,6 +33,8 @@ import {
   removePartition,
   selectPartitions,
   changePartitionUnit,
+  selectFileSystemPartitioningMode,
+  changeFileSystemPartitioningMode,
 } from '../../../../store/wizardSlice';
 import UsrSubDirectoriesDisabled from '../../UsrSubDirectoriesDisabled';
 import { useFilesystemValidation } from '../../utilities/useValidation';
@@ -48,6 +52,7 @@ export type Partition = {
 const FileSystemConfiguration = () => {
   const partitions = useAppSelector(selectPartitions);
   const environments = useAppSelector(selectImageTypes);
+  const partitioningMode = useAppSelector(selectFileSystemPartitioningMode);
 
   const dispatch = useAppDispatch();
 
@@ -74,9 +79,34 @@ const FileSystemConfiguration = () => {
       <TextContent>
         <Text>
           Create partitions for your image by defining mount points and minimum
-          sizes. Image builder creates partitions with a logical volume (LVM)
-          device type.
+          sizes.
         </Text>
+        <FormGroup>
+          <Radio
+            id="raw partitioning radio"
+            ouiaId="raw-partitioning-radio"
+            label="Use raw partitioning"
+            name="fsc-radio-raw"
+            description="Filesystems will be created directly on top of physical partitions"
+          isChecked={partitioningMode === 'raw'}
+          onChange={() => {
+            dispatch(changeFileSystemPartitioningMode('raw'));
+          }}
+          />
+          <Radio
+            id="lvm partitioning radio"
+            ouiaId="lvm-partitioning-radio"
+            label="Use LVM partitioning"
+            name="fsc-radio-lvm"
+            description="Image builder will allocate a single volume group and create logical volumes for each partition, except for /boot and /boot/efi"
+          isChecked={partitioningMode === 'lvm'}
+          onChange={() => {
+            dispatch(changeFileSystemPartitioningMode('lvm'));
+          }}
+          />
+        </FormGroup>
+      </TextContent>
+      <TextContent>
         <Text>
           The order of partitions may change when the image is installed in
           order to conform to best practices and ensure functionality.
@@ -176,8 +206,8 @@ export const Row = ({
         )}
       </Td>
       {partition.mountpoint !== '/' &&
-      !partition.mountpoint.startsWith('/boot') &&
-      !partition.mountpoint.startsWith('/usr') ? (
+        !partition.mountpoint.startsWith('/boot') &&
+        !partition.mountpoint.startsWith('/usr') ? (
         <Td width={20}>
           <MountpointSuffix partition={partition} />
         </Td>

--- a/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
@@ -10,6 +10,7 @@ import { useAppSelector } from '../../../../store/hooks';
 import { selectFileSystemPartitionMode } from '../../../../store/wizardSlice';
 import { useHasSpecificTargetOnly } from '../../utilities/hasSpecificTargetOnly';
 export type FileSystemPartitionMode = 'automatic' | 'manual';
+export type FileSystemPartitioningMode = 'raw' | 'lvm';
 
 export const FileSystemContext = React.createContext<boolean>(true);
 

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -12,7 +12,7 @@ import {
 } from './imageBuilderApi';
 import { ActivationKeys } from './rhsmApi';
 
-import { FileSystemPartitionMode } from '../Components/CreateImageWizard/steps/FileSystem';
+import { FileSystemPartitionMode, FileSystemPartitioningMode } from '../Components/CreateImageWizard/steps/FileSystem';
 import {
   Partition,
   Units,
@@ -77,6 +77,7 @@ export type wizardState = {
   };
   fileSystem: {
     mode: FileSystemPartitionMode;
+    partitioningMode: FileSystemPartitioningMode;
     partitions: Partition[];
   };
   snapshotting: {
@@ -134,6 +135,7 @@ const initialState: wizardState = {
   },
   fileSystem: {
     mode: 'automatic',
+    partitioningMode: 'raw',
     partitions: [],
   },
   snapshotting: {
@@ -240,6 +242,10 @@ export const selectProfile = (state: RootState) => {
 
 export const selectFileSystemPartitionMode = (state: RootState) => {
   return state.wizard.fileSystem.mode;
+};
+
+export const selectFileSystemPartitioningMode = (state: RootState) => {
+  return state.wizard.fileSystem.partitioningMode;
 };
 
 export const selectPartitions = (state: RootState) => {
@@ -432,6 +438,12 @@ export const wizardSlice = createSlice({
             ];
         }
       }
+    },
+    changeFileSystemPartitioningMode: (
+      state,
+      action: PayloadAction<FileSystemPartitioningMode>
+    ) => {
+      state.fileSystem.partitioningMode = action.payload;
     },
     clearPartitions: (state) => {
       const currentMode = state.fileSystem.mode;
@@ -627,6 +639,7 @@ export const {
   changeOscapProfile,
   changeFileSystemConfiguration,
   changeFileSystemPartitionMode,
+  changeFileSystemPartitioningMode,
   clearPartitions,
   addPartition,
   removePartition,


### PR DESCRIPTION
The image builder API supports partitioning modes for a while. Currently, the frontend doesn't specify one, which makes the backend default to "auto-lvm". This partitions the image as lvm if the request contains an extra mountpoint that isn't specified in the base partition table. Otherwise, it's raw-partitioned. In other words, it's confusing.

This commit gives users an option to specify the mode explicitly: either to lvm, or raw. This should reduce confusion and give users more power.

The partitioning mode is now enforced by the frontend. This means that old blueprints are "converted" when edited: A simple heurestic is in charge of that: if there's a custom mountpoint in the original blueprint, the mode is set to lvm. Otherwise, it defaults to raw.

TODO:

- [ ] Discuss this with the UX folks.
- [ ] Add some tests (I will need help with this part :sweat_smile: ).


There's also one extra unfortunate thing: There's already a property called `FileSystemPartitionMode` in the code used to control whether the partitioning is manual, or automatic. Unfortunately, the API property for lvm/raw is called a partitioning mode, so this creates a lot of confusion. I guess we should rename the original "partition mode" to prevent this clash. Suggestions are welcome!

![image](https://github.com/user-attachments/assets/37efb196-800c-4613-a9f1-7611de44bc93)
