### PR TITLE
Wizard: Rename `FileSystemPartitionMode` to `FileSystemConfigurationType`

### DIFF
--- a/src/Components/CreateImageWizard/steps/FileSystem/FileSystemPartition.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/FileSystemPartition.tsx
@@ -4,14 +4,16 @@ import { FormGroup, Label, Radio } from '@patternfly/react-core';
 
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
-  changeFileSystemPartitionMode,
-  selectFileSystemPartitionMode,
+  changeFileSystemConfigurationType,
+  selectFileSystemConfigurationType,
   selectProfile,
 } from '../../../../store/wizardSlice';
 
 const FileSystemPartition = () => {
   const dispatch = useAppDispatch();
-  const fileSystemPartitionMode = useAppSelector(selectFileSystemPartitionMode);
+  const fileSystemConfigurationType = useAppSelector(
+    selectFileSystemConfigurationType
+  );
   const hasOscapProfile = useAppSelector(selectProfile);
 
   if (hasOscapProfile) {
@@ -33,9 +35,9 @@ const FileSystemPartition = () => {
         }
         name="sc-radio-automatic"
         description="Automatically partition your image to what is best, depending on the target environment(s)"
-        isChecked={fileSystemPartitionMode === 'automatic'}
+        isChecked={fileSystemConfigurationType === 'automatic'}
         onChange={() => {
-          dispatch(changeFileSystemPartitionMode('automatic'));
+          dispatch(changeFileSystemConfigurationType('automatic'));
         }}
       />
       <Radio
@@ -44,9 +46,9 @@ const FileSystemPartition = () => {
         label="Manually configure partitions"
         name="fsc-radio-manual"
         description="Manually configure the file system of your image by adding, removing, and editing partitions"
-        isChecked={fileSystemPartitionMode === 'manual'}
+        isChecked={fileSystemConfigurationType === 'manual'}
         onChange={() => {
-          dispatch(changeFileSystemPartitionMode('manual'));
+          dispatch(changeFileSystemConfigurationType('manual'));
         }}
       />
     </FormGroup>

--- a/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/index.tsx
@@ -7,14 +7,16 @@ import FileSystemConfiguration from './FileSystemConfiguration';
 import FileSystemPartition from './FileSystemPartition';
 
 import { useAppSelector } from '../../../../store/hooks';
-import { selectFileSystemPartitionMode } from '../../../../store/wizardSlice';
+import { selectFileSystemConfigurationType } from '../../../../store/wizardSlice';
 import { useHasSpecificTargetOnly } from '../../utilities/hasSpecificTargetOnly';
-export type FileSystemPartitionMode = 'automatic' | 'manual';
+export type FileSystemConfigurationType = 'automatic' | 'manual';
 
 export const FileSystemContext = React.createContext<boolean>(true);
 
 const FileSystemStep = () => {
-  const fileSystemPartitionMode = useAppSelector(selectFileSystemPartitionMode);
+  const fileSystemConfigurationType = useAppSelector(
+    selectFileSystemConfigurationType
+  );
   const hasIsoTargetOnly = useHasSpecificTargetOnly('image-installer');
 
   return (
@@ -25,18 +27,18 @@ const FileSystemStep = () => {
       <Text>Define the partitioning of the image</Text>
       {hasIsoTargetOnly ? (
         <FileSystemAutomaticPartition />
-      ) : fileSystemPartitionMode === 'automatic' ? (
+      ) : fileSystemConfigurationType === 'automatic' ? (
         <>
           <FileSystemPartition />
           <FileSystemAutomaticPartition />
         </>
-      ) : fileSystemPartitionMode === 'manual' ? (
+      ) : fileSystemConfigurationType === 'manual' ? (
         <>
           <FileSystemPartition />
           <FileSystemConfiguration />
         </>
       ) : (
-        fileSystemPartitionMode === 'oscap' && <FileSystemConfiguration />
+        fileSystemConfigurationType === 'oscap' && <FileSystemConfiguration />
       )}
     </Form>
   );

--- a/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
@@ -36,7 +36,7 @@ import {
   selectProfile,
   addPackage,
   addPartition,
-  changeFileSystemPartitionMode,
+  changeFileSystemConfigurationType,
   removePackage,
   clearPartitions,
   selectImageTypes,
@@ -76,7 +76,7 @@ const ProfileSelector = () => {
   const handleClear = () => {
     dispatch(changeOscapProfile(undefined));
     clearOscapPackages(oscapData.packages || []);
-    dispatch(changeFileSystemPartitionMode('automatic'));
+    dispatch(changeFileSystemConfigurationType('automatic'));
   };
 
   const handlePackages = (
@@ -117,7 +117,7 @@ const ProfileSelector = () => {
     });
 
     if (newPartitions) {
-      dispatch(changeFileSystemPartitionMode('manual'));
+      dispatch(changeFileSystemConfigurationType('manual'));
       for (const partition of newPartitions) {
         dispatch(addPartition(partition));
       }

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -57,7 +57,7 @@ import {
   selectPackages,
   selectGroups,
   selectRegistrationType,
-  selectFileSystemPartitionMode,
+  selectFileSystemConfigurationType,
   selectRecommendedRepositories,
   selectSnapshotDate,
   selectUseLatest,
@@ -125,7 +125,9 @@ export const ImageOutputList = () => {
   );
 };
 export const FSCList = () => {
-  const fileSystemPartitionMode = useAppSelector(selectFileSystemPartitionMode);
+  const fileSystemConfigurationType = useAppSelector(
+    selectFileSystemConfigurationType
+  );
   const partitions = useAppSelector(selectPartitions);
 
   return (
@@ -141,8 +143,8 @@ export const FSCList = () => {
           component={TextListItemVariants.dd}
           data-testid="partitioning-auto-manual"
         >
-          {fileSystemPartitionMode === 'manual' ? 'Manual' : 'Automatic'}
-          {fileSystemPartitionMode === 'manual' && (
+          {fileSystemConfigurationType === 'manual' ? 'Manual' : 'Automatic'}
+          {fileSystemConfigurationType === 'manual' && (
             <>
               {' '}
               <Popover
@@ -165,7 +167,7 @@ export const FSCList = () => {
             </>
           )}
         </TextListItem>
-        {fileSystemPartitionMode === 'manual' && (
+        {fileSystemConfigurationType === 'manual' && (
           <>
             <TextListItem component={TextListItemVariants.dt}>
               Image size (minimum) <MinimumSizePopover />

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -57,7 +57,7 @@ import {
   selectRegistrationType,
   selectServerUrl,
   wizardState,
-  selectFileSystemPartitionMode,
+  selectFileSystemConfigurationType,
   selectPartitions,
   selectSnapshotDate,
   selectUseLatest,
@@ -67,7 +67,7 @@ import {
   convertMMDDYYYYToYYYYMMDD,
   convertYYYYMMDDTOMMDDYYYY,
 } from '../../../Utilities/time';
-import { FileSystemPartitionMode } from '../steps/FileSystem';
+import { FileSystemConfigurationType } from '../steps/FileSystem';
 import {
   getConversionFactor,
   Partition,
@@ -170,13 +170,13 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
 
   const fileSystem = request.customizations.filesystem
     ? {
-        mode: 'manual' as FileSystemPartitionMode,
+        mode: 'manual' as FileSystemConfigurationType,
         partitions: request.customizations.filesystem.map((fs) =>
           convertFilesystemToPartition(fs)
         ),
       }
     : {
-        mode: 'automatic' as FileSystemPartitionMode,
+        mode: 'automatic' as FileSystemConfigurationType,
         partitions: [],
       };
 
@@ -456,7 +456,7 @@ const getOpenscapProfile = (state: RootState): OpenScap | undefined => {
 };
 
 const getFileSystem = (state: RootState): Filesystem[] | undefined => {
-  const mode = selectFileSystemPartitionMode(state);
+  const mode = selectFileSystemConfigurationType(state);
 
   const convertToBytes = (minSize: string, conversionFactor: number) => {
     return minSize.length > 0 ? parseInt(minSize) * conversionFactor : 0;

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -9,7 +9,7 @@ import {
   selectBlueprintId,
   selectBlueprintName,
   selectBlueprintDescription,
-  selectFileSystemPartitionMode,
+  selectFileSystemConfigurationType,
   selectFirstBootScript,
   selectPartitions,
 } from '../../../store/wizardSlice';
@@ -37,7 +37,7 @@ export function useIsBlueprintValid(): boolean {
 }
 
 export function useFilesystemValidation(): StepValidation {
-  const mode = useAppSelector(selectFileSystemPartitionMode);
+  const mode = useAppSelector(selectFileSystemConfigurationType);
   const partitions = useAppSelector(selectPartitions);
   let disabledNext = false;
 

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -12,7 +12,7 @@ import {
 } from './imageBuilderApi';
 import { ActivationKeys } from './rhsmApi';
 
-import { FileSystemPartitionMode } from '../Components/CreateImageWizard/steps/FileSystem';
+import { FileSystemConfigurationType } from '../Components/CreateImageWizard/steps/FileSystem';
 import {
   Partition,
   Units,
@@ -76,7 +76,7 @@ export type wizardState = {
     profile: DistributionProfileItem | undefined;
   };
   fileSystem: {
-    mode: FileSystemPartitionMode;
+    mode: FileSystemConfigurationType;
     partitions: Partition[];
   };
   snapshotting: {
@@ -238,7 +238,7 @@ export const selectProfile = (state: RootState) => {
   return state.wizard.openScap.profile;
 };
 
-export const selectFileSystemPartitionMode = (state: RootState) => {
+export const selectFileSystemConfigurationType = (state: RootState) => {
   return state.wizard.fileSystem.mode;
 };
 
@@ -408,9 +408,9 @@ export const wizardSlice = createSlice({
     ) => {
       state.fileSystem.partitions = action.payload;
     },
-    changeFileSystemPartitionMode: (
+    changeFileSystemConfigurationType: (
       state,
-      action: PayloadAction<FileSystemPartitionMode>
+      action: PayloadAction<FileSystemConfigurationType>
     ) => {
       const currentMode = state.fileSystem.mode;
 
@@ -626,7 +626,7 @@ export const {
   changeActivationKey,
   changeOscapProfile,
   changeFileSystemConfiguration,
-  changeFileSystemPartitionMode,
+  changeFileSystemConfigurationType,
   clearPartitions,
   addPartition,
   removePartition,


### PR DESCRIPTION
This renames `FileSystemPartitionMode` to `FileSystemConfigurationType` in preparation to expose raw/lvm partitioning in the UI: https://github.com/osbuild/image-builder-frontend/pull/2342