### PR TITLE
Wizard: Confirm Image builder is using origin for contentList call

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
@@ -24,6 +24,7 @@ import { useDispatch } from 'react-redux';
 import PackageRecommendationDescription from './components/PackageRecommendationDescription';
 import { RedHatRepository } from './Packages';
 
+import { ContentOrigin } from '../../../../constants';
 import { useListRepositoriesQuery } from '../../../../store/contentSourcesApi';
 import { useAppSelector } from '../../../../store/hooks';
 import { useRecommendPackageMutation } from '../../../../store/imageBuilderApi';
@@ -54,7 +55,7 @@ const PackageRecommendations = () => {
       availableForArch: arch,
       availableForVersion: version,
       contentType: 'rpm',
-      origin: 'red_hat',
+      origin: ContentOrigin.REDHAT,
       limit: 100,
       offset: 0,
     });

--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -44,6 +44,7 @@ import PackageInfoNotAvailablePopover from './components/PackageInfoNotAvailable
 
 import {
   CONTENT_URL,
+  ContentOrigin,
   EPEL_8_REPO_DEFINITION,
   EPEL_9_REPO_DEFINITION,
   RH_ICON_SIZE,
@@ -135,6 +136,7 @@ const Packages = () => {
   const { data: epelRepo, isSuccess: isSuccessEpelRepo } =
     useListRepositoriesQuery({
       url: epelRepoUrlByDistribution,
+      origin: ContentOrigin.EXTERNAL,
     });
 
   const [isRepoModalOpen, setIsRepoModalOpen] = useState(false);

--- a/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
@@ -30,6 +30,7 @@ import {
 import RepositoriesStatus from './RepositoriesStatus';
 import RepositoryUnavailable from './RepositoryUnavailable';
 
+import { ContentOrigin } from '../../../../constants';
 import {
   ApiRepositoryResponseRead,
   useListRepositoriesQuery,
@@ -100,8 +101,8 @@ const Repositories = () => {
     {
       availableForArch: arch,
       availableForVersion: version,
-      origin: 'external',
-      limit: 999,
+      origin: ContentOrigin.EXTERNAL,
+      limit: 999, // O.O Oh dear, if possible this whole call should be removed
       offset: 0,
       url: [...initialSelectedState].join(','),
     },
@@ -125,7 +126,7 @@ const Repositories = () => {
       availableForArch: arch,
       availableForVersion: version,
       contentType: 'rpm',
-      origin: 'external',
+      origin: ContentOrigin.EXTERNAL,
       limit: perPage,
       offset: perPage * (page - 1),
       search: debouncedFilterValue,

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
@@ -11,6 +11,7 @@ import {
 } from '@patternfly/react-core';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
+import { ContentOrigin } from '../../../../constants';
 import {
   ApiSnapshotForDate,
   useListRepositoriesQuery,
@@ -36,7 +37,7 @@ const RepoName = ({ repoUrl }: repoPropType) => {
       // @ts-ignore if repoUrl is undefined the query is going to get skipped, so it's safe to ignore the linter here
       url: repoUrl,
       contentType: 'rpm',
-      origin: 'external',
+      origin: ContentOrigin.EXTERNAL,
     },
     { skip: !repoUrl }
   );
@@ -128,7 +129,7 @@ export const SnapshotTable = ({
 }) => {
   const { data, isSuccess, isLoading, isError } = useListRepositoriesQuery({
     uuid: snapshotForDate.map(({ repository_uuid }) => repository_uuid).join(),
-    origin: 'red_hat,external', // Make sure to show both redhat and custom
+    origin: ContentOrigin.REDHAT + ',' + ContentOrigin.EXTERNAL, // Make sure to show both redhat and external
   });
 
   const isAfterSet = new Set(

--- a/src/Components/CreateImageWizard/utilities/checkRepositoriesAvailability.ts
+++ b/src/Components/CreateImageWizard/utilities/checkRepositoriesAvailability.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
 
+import { ContentOrigin } from '../../../constants';
 import { useListRepositoriesQuery } from '../../../store/contentSourcesApi';
 import { useAppSelector } from '../../../store/hooks';
 import {
@@ -26,7 +27,7 @@ export const useCheckRepositoriesAvailability = () => {
     availableForArch: arch,
     availableForVersion: version,
     contentType: 'rpm',
-    origin: 'external',
+    origin: ContentOrigin.EXTERNAL,
   });
 
   const skip =
@@ -39,7 +40,7 @@ export const useCheckRepositoriesAvailability = () => {
       availableForArch: arch,
       availableForVersion: version,
       contentType: 'rpm',
-      origin: 'external',
+      origin: ContentOrigin.EXTERNAL,
       limit: firstRequest?.data?.meta?.count,
       offset: 0,
     },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -218,3 +218,12 @@ export const FIRST_BOOT_SERVICE_DATA =
   'W1VuaXRdCkRlc2NyaXB0aW9uPVJ1biBmaXJzdCBib290IHNjcmlwdApDb25kaXRpb25QYXRoRXhpc3RzPS91c3IvbG9jYWwvc2Jpbi9jdXN0b20tZmlyc3QtYm9vdApXYW50cz1uZXR3b3JrLW9ubGluZS50YXJnZXQKQWZ0ZXI9bmV0d29yay1vbmxpbmUudGFyZ2V0CkFmdGVyPW9zYnVpbGQtZmlyc3QtYm9vdC5zZXJ2aWNlCgpbU2VydmljZV0KVHlwZT1vbmVzaG90CkV4ZWNTdGFydD0vdXNyL2xvY2FsL3NiaW4vY3VzdG9tLWZpcnN0LWJvb3QKRXhlY1N0YXJ0UG9zdD1tdiAvdXNyL2xvY2FsL3NiaW4vY3VzdG9tLWZpcnN0LWJvb3QgL3Vzci9sb2NhbC9zYmluL2N1c3RvbS1maXJzdC1ib290LmRvbmUKCltJbnN0YWxsXQpXYW50ZWRCeT1tdWx0aS11c2VyLnRhcmdldAo=';
 
 export const FIRST_BOOT_SERVICE = 'custom-first-boot';
+
+// For use when calling content API (now required)
+export enum ContentOrigin {
+  'REDHAT' = 'red_hat',
+  'EXTERNAL' = 'external', // custom only
+  'UPLOAD' = 'upload', // custom upload repo
+  'CUSTOM' = 'external,upload',
+  'ALL' = 'red_hat,external,upload',
+}


### PR DESCRIPTION
- This ticket just adds a new enum and ensures that Origin is being set in the useListRepositoriesQuery.
Related ticket in HMS [here](https://issues.redhat.com/browse/HMS-4426)

Other changes: 
Added one comment to remind myself to address a performance issue at some point. 
Will address in another ticket at a later time.


- [x] Confirm that we only want External and not Custom for the majority of image-builders usage with @jlsherrill 