### PR TITLE
Wizard: Unique default key name

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
@@ -37,6 +37,7 @@ import {
   selectRegistrationType,
 } from '../../../../store/wizardSlice';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
+import { generateRandomId } from '../../utilities/generateRandomId';
 
 export const PopoverActivation = () => {
   const [orgId, setOrgId] = useState<string | undefined>(undefined);
@@ -106,7 +107,7 @@ const ActivationKeysList = () => {
   const activationKey = useAppSelector(selectActivationKey);
   const registrationType = useAppSelector(selectRegistrationType);
 
-  const defaultActivationKeyName = 'activation-key-default';
+  const defaultActivationKeyName = `activation-key-default-${generateRandomId()}`;
 
   const { isProd } = useGetEnvironment();
   const [isOpen, setIsOpen] = useState(false);

--- a/src/Components/CreateImageWizard/utilities/generateRandomId.ts
+++ b/src/Components/CreateImageWizard/utilities/generateRandomId.ts
@@ -1,0 +1,8 @@
+export const generateRandomId = () => {
+  let id = '';
+  const characterSet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  while (id.length < 6) {
+    id += characterSet.charAt(Math.floor(Math.random() * characterSet.length));
+  }
+  return id;
+};


### PR DESCRIPTION
Fixes #2353

This adds a random suffix to the default activation key name, making it less predictable.