### PR TITLE
Wizard: Fix disable Next on Registration step

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -328,7 +328,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
             footer={
               <CustomWizardFooter
                 disableNext={
-                  registrationType === 'register-now' && !activationKey
+                  registrationType.startsWith('register-now') && !activationKey
                 }
               />
             }


### PR DESCRIPTION
When the option to register with rhc and insights was added back the disableNext condition wasn't updated, allowing user to continue with registration even without selecting activation key.