### PR TITLE
test: Re-enable a test

### DIFF
--- a/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
@@ -180,7 +180,8 @@ describe('Repositories edit mode', () => {
     vi.clearAllMocks();
   });
 
-  //  const user = userEvent.setup();
+  const user = userEvent.setup();
+
   test('edit mode works', async () => {
     const id = mockBlueprintIds['repositories'];
     await renderEditMode(id);
@@ -192,45 +193,46 @@ describe('Repositories edit mode', () => {
     const expectedRequest = repositoriesCreateBlueprintRequest;
     await waitFor(() => expect(receivedRequest).toEqual(expectedRequest));
   });
-  //  test(
-  //    'modal pops up when deselecting previously used repository',
-  //    { retry: 3 },
-  //    async () => {
-  //      const id = mockBlueprintIds['repositories'];
-  //      await renderEditMode(id);
-  //
-  //      const customRepositories = await screen.findByRole('button', {
-  //        name: /Custom repositories/,
-  //      });
-  //
-  //      user.click(customRepositories);
-  //
-  //      await screen.findByText(
-  //        /Removing previously added repositories may lead to issues with selected packages/i
-  //      );
-  //
-  //      const selectedRepositories = await screen.findByRole('button', {
-  //        name: /Selected repositories/,
-  //      });
-  //      user.click(selectedRepositories);
-  //
-  //      const repoCheckbox = await screen.findByRole('checkbox', {
-  //        name: /select row 0/i,
-  //      });
-  //      await waitFor(() => expect(repoCheckbox).toBeChecked());
-  //
-  //      user.click(repoCheckbox);
-  //      await screen.findByText(/Are you sure?/);
-  //      const removeAnywayBtn = await screen.findByRole('button', {
-  //        name: /Remove anyway/,
-  //      });
-  //      user.click(removeAnywayBtn);
-  //
-  //      await waitFor(() =>
-  //        expect(screen.queryByText(/Are you sure?/)).not.toBeInTheDocument()
-  //      );
-  //
-  //      await waitFor(() => expect(repoCheckbox).not.toBeChecked());
-  //    }
-  //  );
+
+  test(
+    'modal pops up when deselecting previously used repository',
+    { retry: 3 },
+    async () => {
+      const id = mockBlueprintIds['repositories'];
+      await renderEditMode(id);
+
+      const customRepositories = await screen.findByRole('button', {
+        name: /Custom repositories/,
+      });
+
+      user.click(customRepositories);
+
+      await screen.findByText(
+        /Removing previously added repositories may lead to issues with selected packages/i
+      );
+
+      const selectedRepositories = await screen.findByRole('button', {
+        name: /Selected repositories/,
+      });
+      user.click(selectedRepositories);
+
+      const repoCheckbox = await screen.findByRole('checkbox', {
+        name: /select row 0/i,
+      });
+      await waitFor(() => expect(repoCheckbox).toBeChecked());
+
+      user.click(repoCheckbox);
+      await screen.findByText(/Are you sure?/);
+      const removeAnywayBtn = await screen.findByRole('button', {
+        name: /Remove anyway/,
+      });
+      user.click(removeAnywayBtn);
+
+      await waitFor(() =>
+        expect(screen.queryByText(/Are you sure?/)).not.toBeInTheDocument()
+      );
+
+      await waitFor(() => expect(repoCheckbox).not.toBeChecked());
+    }
+  );
 });


### PR DESCRIPTION
This re-enables "Repositories edit mode modal pops up when deselecting previously used repository" test.

This works reliably locally, not sure what will pr_check think.