### PR TITLE
Wizard: Fix "button in a button" warning

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -111,7 +111,7 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
             component={TextListItemVariants.dt}
             className="pf-u-min-width pf-v5-u-text-align-left"
           >
-            <Button variant="link" isInline>
+            <Button variant="link" component="span" isInline>
               {label}
             </Button>
           </TextListItem>


### PR DESCRIPTION
This adds a component prop to the expandable button, solving the `Warning: validateDOMNesting(...): <button> cannot appear as a descendant of <button>.` warning that was repeatedly printed to the test output.