### PR TITLE
test: Test with Node 20 only

### DIFF
--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -5,19 +5,15 @@ on:
     branches: [ "main" ]
 
 jobs:
-  tests:
+  dev-check:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [18.x, 20.x]
 
     steps:
     - uses: actions/checkout@v4
-    - name: Use Node.js ${{ matrix.node-version }}
+    - name: Use Node.js 20
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 20
         cache: 'npm'
     - name: Install dependencies
       run: npm ci

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -10,7 +10,7 @@ export IMAGE="quay.io/cloudservices/image-builder-frontend"
 export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build's workspace
 export APP_ROOT=$(pwd)
 #16 is the default Node version. Change this to override it.
-export NODE_BUILD_VERSION=18
+export NODE_BUILD_VERSION=20
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------


### PR DESCRIPTION
This updates the test env to test with Node 20 only, pr_check is also updated to use Node 20.

The changes shouldn't affect users in any way, please let me know if you think it might.

There were common async flakes when using testing-library with Node 18, those often surfaced in gh actions / pr_check only and did not reproduce locally unless resources got limited (I can reproduce some flakes in Power Saver mode only, leading me to conclusion, that it's just async being mischievous). Switching to testing with Node 20 only should also allow us to re-enable some tests that got disabled specifically because them running with Node 18 ended up in a time out.