### PR TITLE
devDeps: Manual bump msw from 2.4.1 to 2.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "identity-obj-proxy": "3.0.0",
         "jsdom": "25.0.0",
         "moment": "2.30.1",
-        "msw": "2.4.1",
+        "msw": "2.4.4",
         "npm-run-all": "4.1.5",
         "postcss-scss": "4.0.9",
         "react-chartjs-2": "5.2.0",
@@ -1523,16 +1523,17 @@
       }
     },
     "node_modules/@mswjs/interceptors": {
-      "version": "0.29.1",
-      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.29.1.tgz",
-      "integrity": "sha512-3rDakgJZ77+RiQUuSK69t1F0m8BQKA8Vh5DCS5V0DWvNY67zob2JhhQrhCO0AKLGINTRSFd1tBaHcJTkhefoSw==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.35.0.tgz",
+      "integrity": "sha512-f5cHyIvm4m4g1I5x9EH1etGx0puaU0OaX2szqGRVBVgUC6aMASlOI5hbpe7tJ9l4/VWjCUu5OMraCazLZGI24A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@open-draft/deferred-promise": "^2.2.0",
         "@open-draft/logger": "^0.3.0",
         "@open-draft/until": "^2.0.0",
         "is-node-process": "^1.2.0",
-        "outvariant": "^1.2.1",
+        "outvariant": "^1.4.3",
         "strict-event-emitter": "^0.5.1"
       },
       "engines": {
@@ -1587,13 +1588,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
       "integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@open-draft/logger": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
       "integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "is-node-process": "^1.2.0",
         "outvariant": "^1.4.0"
@@ -1603,7 +1606,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@openshift/dynamic-plugin-sdk": {
       "version": "5.0.1",
@@ -8857,8 +8861,6 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.9.0.tgz",
       "integrity": "sha512-GGTKBX4SD7Wdb8mqeDLni2oaRGYQWjWHGKPQ24ZMnUtKfcsVoiv4uX8+LJr1K6U5VW2Lu1BwJnj7uiori0YtRw==",
       "dev": true,
-      "optional": true,
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -10050,7 +10052,8 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
       "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -11613,9 +11616,9 @@
       "dev": true
     },
     "node_modules/msw": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.4.1.tgz",
-      "integrity": "sha512-HXcoQPzYTwEmVk+BGIcRa0vLabBT+J20SSSeYh/QfajaK5ceA6dlD4ZZjfz2dqGEq4vRNCPLP6eXsB94KllPFg==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.4.4.tgz",
+      "integrity": "sha512-iuM0qGs4YmgYCLH+xqb07w2e/e4fYmsx3+WHVlIOUA34TW1sw+wRpNmOlXnLDkw/T7233Jnm6t+aNf4v2E3e2Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -11624,11 +11627,12 @@
         "@bundled-es-modules/statuses": "^1.0.1",
         "@bundled-es-modules/tough-cookie": "^0.1.6",
         "@inquirer/confirm": "^3.0.0",
-        "@mswjs/interceptors": "^0.29.0",
+        "@mswjs/interceptors": "^0.35.0",
         "@open-draft/until": "^2.1.0",
         "@types/cookie": "^0.6.0",
         "@types/statuses": "^2.0.4",
         "chalk": "^4.1.2",
+        "graphql": "^16.8.1",
         "headers-polyfill": "^4.0.2",
         "is-node-process": "^1.2.0",
         "outvariant": "^1.4.2",
@@ -11647,13 +11651,9 @@
         "url": "https://github.com/sponsors/mswjs"
       },
       "peerDependencies": {
-        "graphql": ">= 16.8.x",
-        "typescript": ">= 4.7.x"
+        "typescript": ">= 4.8.x"
       },
       "peerDependenciesMeta": {
-        "graphql": {
-          "optional": true
-        },
         "typescript": {
           "optional": true
         }
@@ -12517,7 +12517,8 @@
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
       "integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/p-all": {
       "version": "5.0.0",
@@ -14899,7 +14900,8 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
       "integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "identity-obj-proxy": "3.0.0",
     "jsdom": "25.0.0",
     "moment": "2.30.1",
-    "msw": "2.4.1",
+    "msw": "2.4.4",
     "npm-run-all": "4.1.5",
     "postcss-scss": "4.0.9",
     "react-chartjs-2": "5.2.0",

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.4.1'
+const PACKAGE_VERSION = '2.4.4'
 const INTEGRITY_CHECKSUM = '26357c79639bfa20d64c0efca2a87423'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()


### PR DESCRIPTION
Dependabot doesn't touch the `mockServiceWorker.js` file that gets automatically updated by `npm install` which causes problem with "manual changes". We'll need to bump this manually at least for the time being.