### PR TITLE
src/store: Remove server store hooks

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
@@ -15,7 +15,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { CreateSaveAndBuildBtn, CreateSaveButton } from './CreateDropdown';
 import { EditSaveAndBuildBtn, EditSaveButton } from './EditDropdown';
 
-import { useServerStore } from '../../../../../store/hooks';
 import {
   useCreateBlueprintMutation,
   useUpdateBlueprintMutation,
@@ -30,7 +29,6 @@ const ReviewWizardFooter = () => {
     useCreateBlueprintMutation({ fixedCacheKey: 'createBlueprintKey' });
 
   // initialize the server store with the data from RTK query
-  const serverStore = useServerStore();
   const [, { isSuccess: isUpdateSuccess, reset: resetUpdate }] =
     useUpdateBlueprintMutation({ fixedCacheKey: 'updateBlueprintKey' });
   const { auth } = useChrome();
@@ -54,7 +52,7 @@ const ReviewWizardFooter = () => {
   const getBlueprintPayload = async () => {
     const userData = await auth?.getUser();
     const orgId = userData?.identity?.internal?.org_id;
-    const requestBody = orgId && mapRequestFromState(store, orgId, serverStore);
+    const requestBody = orgId && mapRequestFromState(store, orgId);
     return requestBody;
   };
 

--- a/src/store/hooks.ts
+++ b/src/store/hooks.ts
@@ -1,41 +1,7 @@
 import { useDispatch, useSelector } from 'react-redux';
 
-import { useGetOscapCustomizationsQuery } from './imageBuilderApi';
-import { selectDistribution, selectProfile } from './wizardSlice';
-
 import type { RootState, AppDispatch } from './index';
 
 // Use throughout your app instead of plain `useDispatch` and `useSelector`
 export const useAppDispatch = useDispatch.withTypes<AppDispatch>();
 export const useAppSelector = useSelector.withTypes<RootState>();
-
-// common hooks
-export const useOscapData = () => {
-  const release = useAppSelector(selectDistribution);
-  const openScapProfile = useAppSelector(selectProfile);
-  const { data } = useGetOscapCustomizationsQuery(
-    {
-      distribution: release,
-      // @ts-ignore if openScapProfile is undefined the query is going to get skipped
-      profile: openScapProfile,
-    },
-    { skip: !openScapProfile }
-  );
-  if (!openScapProfile) return undefined;
-  return {
-    kernel: { append: data?.kernel?.append },
-    services: {
-      enabled: data?.services?.enabled,
-      disabled: data?.services?.disabled,
-      masked: data?.services?.masked,
-    },
-    packages: data?.packages,
-    filesystem: data?.filesystem,
-    profileName: data?.openscap?.profile_name,
-  };
-};
-
-export const useServerStore = () => {
-  const oscap = useOscapData();
-  return { ...oscap };
-};

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -93,6 +93,14 @@ export type wizardState = {
   };
   packages: IBPackageWithRepositoryInfo[];
   groups: GroupWithRepositoryInfo[];
+  services: {
+    enabled: string[];
+    masked: string[];
+    disabled: string[];
+  };
+  kernel: {
+    append: string;
+  };
   details: {
     blueprintName: string;
     blueprintDescription: string;
@@ -151,6 +159,14 @@ export const initialState: wizardState = {
   },
   packages: [],
   groups: [],
+  services: {
+    enabled: [],
+    masked: [],
+    disabled: [],
+  },
+  kernel: {
+    append: '',
+  },
   details: {
     blueprintName: '',
     blueprintDescription: '',
@@ -275,6 +291,14 @@ export const selectPackages = (state: RootState) => {
 
 export const selectGroups = (state: RootState) => {
   return state.wizard.groups;
+};
+
+export const selectServices = (state: RootState) => {
+  return state.wizard.services;
+};
+
+export const selectKernel = (state: RootState) => {
+  return state.wizard.kernel;
 };
 
 export const selectBlueprintName = (state: RootState) => {
@@ -604,6 +628,18 @@ export const wizardSlice = createSlice({
     setFirstBootScript: (state, action: PayloadAction<string>) => {
       state.firstBoot.script = action.payload;
     },
+    changeEnabledServices: (state, action: PayloadAction<string[]>) => {
+      state.services.enabled = action.payload;
+    },
+    changeMaskedServices: (state, action: PayloadAction<string[]>) => {
+      state.services.masked = action.payload;
+    },
+    changeDisabledServices: (state, action: PayloadAction<string[]>) => {
+      state.services.disabled = action.payload;
+    },
+    changeKernelAppend: (state, action: PayloadAction<string>) => {
+      state.kernel.append = action.payload;
+    },
   },
 });
 
@@ -657,5 +693,9 @@ export const {
   changeBlueprintDescription,
   loadWizardState,
   setFirstBootScript,
+  changeEnabledServices,
+  changeMaskedServices,
+  changeDisabledServices,
+  changeKernelAppend,
 } = wizardSlice.actions;
 export default wizardSlice.reducer;


### PR DESCRIPTION
Removing the server store makes the way we handle data going in and out of the wizard state more consistent. Each customisation is mapped into the wizard state and pulled out when generating the blueprint payload.

When the services and kernel customisations are implemented, this information will need to be stored inside of the wizard state anyway.

Lastly this will make implementing a compliance step easier for edit mode, removing the need to write to the wizard state from within the server store when only a compliance policy id is available (on the review page), which would be used to fetch the profile ref id, which would in turn be used to fetch the customisations not stored in the wizard state.