### PR TITLE
HMS-4667: Blueprints: Allow importing without subscription

### DIFF
--- a/src/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -121,6 +121,33 @@ const INVALID_JSON = `{
   "name": "Blueprint test"
 }`;
 
+const EMPTY_SUBSCRIPTION_VALID = `{
+  "customizations": {
+    "packages": [],
+    "subscription": {}
+  },
+  "description": "short subscription",
+  "distribution": "rhel-8",
+  "metadata": {
+    "exported_at": "2024-07-29 17:26:51.666952376 +0000 UTC",
+    "parent_id": "b3385e6d-ecc4-485c-b33c-f65131c46f52"
+  },
+  "name": "Blueprint can have empty subscription"
+}`;
+
+const NO_SUBSCRIPTION_VALID = `{
+  "customizations": {
+    "packages": []
+  },
+  "description": "shortsubscription",
+  "distribution": "rhel-8",
+  "metadata": {
+    "exported_at": "2024-07-29 17:26:51.666952376 +0000 UTC",
+    "parent_id": "b3385e6d-ecc4-485c-b33c-f65131c46f52"
+  },
+  "name": "Blueprint can have no subscription"
+}`;
+
 const uploadFile = async (filename: string, content: string): Promise<void> => {
   const user = userEvent.setup();
   const fileInput: HTMLElement | null =
@@ -197,6 +224,34 @@ describe('Import modal', () => {
   test('should enable button on correct blueprint and go to wizard', async () => {
     await setUp();
     await uploadFile(`blueprints.json`, BLUEPRINT_JSON);
+    const reviewButton = screen.getByTestId('import-blueprint-finish');
+    await waitFor(() => expect(reviewButton).not.toHaveClass('pf-m-disabled'));
+    user.click(reviewButton);
+
+    await waitFor(async () =>
+      expect(
+        await screen.findByText('Image output', { selector: 'h1' })
+      ).toBeInTheDocument()
+    );
+  });
+
+  test('should enable button on correct blueprint with no subscription and go to wizard', async () => {
+    await setUp();
+    await uploadFile(`blueprints.json`, NO_SUBSCRIPTION_VALID);
+    const reviewButton = screen.getByTestId('import-blueprint-finish');
+    await waitFor(() => expect(reviewButton).not.toHaveClass('pf-m-disabled'));
+    user.click(reviewButton);
+
+    await waitFor(async () =>
+      expect(
+        await screen.findByText('Image output', { selector: 'h1' })
+      ).toBeInTheDocument()
+    );
+  });
+
+  test('should enable button on correct blueprint with empty subscription and go to wizard', async () => {
+    await setUp();
+    await uploadFile(`blueprints.json`, EMPTY_SUBSCRIPTION_VALID);
     const reviewButton = screen.getByTestId('import-blueprint-finish');
     await waitFor(() => expect(reviewButton).not.toHaveClass('pf-m-disabled'));
     user.click(reviewButton);

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -69,16 +69,20 @@ export const ImportBlueprintModal: React.FunctionComponent<
   const handleDataChange = (_: DropEvent, value: string) => {
     try {
       const blueprintFromFile = JSON.parse(value);
+      const customizations = blueprintFromFile.customizations;
       const blueprintExportedResponse: BlueprintExportResponse = {
         name: blueprintFromFile.name,
         description: blueprintFromFile.description,
         distribution: blueprintFromFile.distribution,
-        customizations: blueprintFromFile.customizations,
+        customizations: customizations,
         metadata: blueprintFromFile.metadata,
       };
+      const isSubscriptionPresent =
+        customizations && 'subscription' in customizations;
       const importBlueprintState = mapExportRequestToState(
         blueprintExportedResponse,
-        blueprintFromFile.image_requests || []
+        blueprintFromFile.image_requests || [],
+        isSubscriptionPresent
       );
       setImportedBlueprint(importBlueprintState);
       setJsonContent(value);


### PR DESCRIPTION
This requires a small change on our backend - on export endpoint, we would need to export "subscription: {}" in the customizations field, so that we can detect that a subscription was there, when we import the blueprint back. :)
Let's not merge before we merge the backend change.

All information is in [the ticket](https://issues.redhat.com/browse/HMS-4667). But TLDR; we omit subscription now, and because of that, we can not detect if the blueprint was subscribed or not.