### PR TITLE
Wizard: Unify snapshot date format

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -64,11 +64,7 @@ import {
   selectPartitions,
   selectFirstBootScript,
 } from '../../../../store/wizardSlice';
-import {
-  convertMMDDYYYYToYYYYMMDD,
-  toMonthAndYear,
-  yyyyMMddFormat,
-} from '../../../../Utilities/time';
+import { toMonthAndYear, yyyyMMddFormat } from '../../../../Utilities/time';
 import {
   Partition,
   getConversionFactor,
@@ -449,9 +445,7 @@ export const ContentList = ({
     listSnapshotsByDate({
       apiListSnapshotByDateRequest: {
         repository_uuids: customAndRecommendedRepositoryUUIDS,
-        date: useLatest
-          ? yyyyMMddFormat(new Date())
-          : convertMMDDYYYYToYYYYMMDD(snapshotDate),
+        date: useLatest ? yyyyMMddFormat(new Date()) : snapshotDate,
       },
     });
   }, [

--- a/src/Components/CreateImageWizard/steps/Snapshot/Snapshot.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/Snapshot.tsx
@@ -19,8 +19,8 @@ import {
   changeSnapshotDate,
 } from '../../../../store/wizardSlice';
 import {
-  dateToMMDDYYYY,
-  parseMMDDYYYYtoDate,
+  parseYYYYMMDDToDate,
+  yyyyMMddFormat,
 } from '../../../../Utilities/time';
 import { isSnapshotDateValid } from '../../validators';
 
@@ -78,9 +78,9 @@ export default function Snapshot() {
                 value={snapshotDate}
                 required
                 requiredDateOptions={{ isRequired: true }}
-                placeholder="MM/DD/YYYY"
-                dateParse={parseMMDDYYYYtoDate}
-                dateFormat={dateToMMDDYYYY}
+                placeholder="YYYY-MM-DD"
+                dateParse={parseYYYYMMDDToDate}
+                dateFormat={yyyyMMddFormat}
                 validators={[
                   (date: Date) => {
                     if (!isSnapshotDateValid(date)) {

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -68,10 +68,6 @@ import {
   selectMetadata,
   initialState,
 } from '../../../store/wizardSlice';
-import {
-  convertMMDDYYYYToYYYYMMDD,
-  convertYYYYMMDDTOMMDDYYYY,
-} from '../../../Utilities/time';
 import { FileSystemConfigurationType } from '../steps/FileSystem';
 import {
   getConversionFactor,
@@ -154,10 +150,9 @@ function commonRequestToState(
     (image) => image.image_type === 'azure'
   );
 
-  const snapshot_date = convertYYYYMMDDTOMMDDYYYY(
+  const snapshot_date =
     request.image_requests.find((image) => !!image.snapshot_date)
-      ?.snapshot_date || ''
-  );
+      ?.snapshot_date || '';
 
   const awsUploadOptions = aws?.upload_request
     .options as AwsUploadRequestOptions;
@@ -330,7 +325,7 @@ const getFirstBootScript = (files?: File[]): string => {
 
 const getImageRequests = (state: RootState): ImageRequest[] => {
   const imageTypes = selectImageTypes(state);
-  const snapshotDate = convertMMDDYYYYToYYYYMMDD(selectSnapshotDate(state));
+  const snapshotDate = selectSnapshotDate(state);
   const useLatest = selectUseLatest(state);
   return imageTypes.map((type) => ({
     architecture: selectArchitecture(state),

--- a/src/Utilities/time.ts
+++ b/src/Utilities/time.ts
@@ -1,9 +1,3 @@
-export const parseMMDDYYYYtoDate = (val: string) => {
-  const [mm, dd, yyyy] = val.split('/');
-  const newVal = `${yyyy}-${mm}-${dd}`;
-  return mm && dd && yyyy ? new Date(`${newVal}T00:00:00`) : new Date('');
-};
-
 export const parseYYYYMMDDToDate = (val: string) =>
   val ? new Date(`${val}T00:00:00`) : new Date('');
 
@@ -11,24 +5,6 @@ export const yyyyMMddFormat = (date: Date) =>
   `${date.getFullYear()}-${(date.getMonth() + 1)
     .toString()
     .padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')}`;
-
-export const convertMMDDYYYYToYYYYMMDD = (dateStr: string) => {
-  if (!dateStr) return '';
-  const date = parseMMDDYYYYtoDate(dateStr);
-  return yyyyMMddFormat(date);
-};
-
-export const dateToMMDDYYYY = (date: Date) =>
-  `${(date.getMonth() + 1).toString().padStart(2, '0')}/${date
-    .getDate()
-    .toString()
-    .padStart(2, '0')}/${date.getFullYear()}`;
-
-export const convertYYYYMMDDTOMMDDYYYY = (dateStr: string) => {
-  if (!dateStr) return '';
-  const date = parseYYYYMMDDToDate(dateStr);
-  return dateToMMDDYYYY(date);
-};
 
 export const toMonthAndYear = (dateString: string) => {
   const options: Intl.DateTimeFormatOptions = {

--- a/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
@@ -117,7 +117,7 @@ describe('repository snapshot tab - ', () => {
     await renderCreateMode();
     await goToSnapshotStep();
     await selectUseSnapshot();
-    await updateDatePickerWithValue('00/00/2024');
+    await updateDatePickerWithValue('2024-00-00');
     expect(
       await screen.findByRole('button', { name: /Review and finish/ })
     ).toBeDisabled();
@@ -127,7 +127,7 @@ describe('repository snapshot tab - ', () => {
     await renderCreateMode();
     await goToSnapshotStep();
     await selectUseSnapshot();
-    await updateDatePickerWithValue('04/22/2024');
+    await updateDatePickerWithValue('2024-04-22');
     await clickNext(); // To repositories step
     await selectFirstRepository();
     await goToReviewStep();
@@ -135,7 +135,7 @@ describe('repository snapshot tab - ', () => {
 
     const snapshotMethodElement = await getSnapshotMethodElement();
     // Check date was recorded correctly
-    expect(snapshotMethodElement).toHaveTextContent('State as of 04/22/2024');
+    expect(snapshotMethodElement).toHaveTextContent('State as of 2024-04-22');
     // Check that the button is clickable (has 1 repo selected)
     expect(snapshotMethodElement).toHaveAttribute('aria-disabled', 'false');
 
@@ -162,7 +162,7 @@ describe('repository snapshot tab - ', () => {
     await renderCreateMode();
     await goToSnapshotStep();
     await selectUseSnapshot();
-    await updateDatePickerWithValue('04/22/2024');
+    await updateDatePickerWithValue('2024-04-22');
     await clickNext(); // To repositories step
     await goToReviewStep();
     await clickContentDropdown();
@@ -180,7 +180,7 @@ describe('repository snapshot tab - ', () => {
     await renderCreateMode();
     await goToSnapshotStep();
     await selectUseSnapshot();
-    await updateDatePickerWithValue('04/22/2024');
+    await updateDatePickerWithValue('2024-04-22');
     await clickNext(); // To repositories step
     await searchForRepository('nosnapshot');
 
@@ -200,7 +200,7 @@ describe('repository snapshot tab - ', () => {
     await renderCreateMode();
     await goToSnapshotStep();
     await selectUseSnapshot();
-    await updateDatePickerWithValue('04/22/2024');
+    await updateDatePickerWithValue('2024-04-22');
     await clickNext(); // To repositories step
     await searchForRepository('01-test-valid-repo');
 
@@ -233,7 +233,7 @@ describe('repository snapshot tab - ', () => {
     await renderCreateMode();
     await goToSnapshotStep();
     await selectUseSnapshot();
-    await updateDatePickerWithValue('04/22/2024');
+    await updateDatePickerWithValue('2024-04-22');
     await clickNext();
     await goToReviewStep();
     await clickRevisitButton();


### PR DESCRIPTION
Currently the accepted date format in the UI date-picker is `MM/DD/YYYY`, and the API accepts `YYYY-MM-DD` as the date format.
This PR unifies the date formats (to `YYYY-MM-DD`) and removes unnecessary time conversion functions. 😅 
\
Related Ticket: [🔗HMS-4492](https://issues.redhat.com/browse/HMS-4492)