### PR TITLE
Api: generate RTK Query for CloudAPI

### DIFF
--- a/api/codegen.sh
+++ b/api/codegen.sh
@@ -6,7 +6,7 @@ npx @rtk-query/codegen-openapi ./api/config/rhsm.ts &
 npx @rtk-query/codegen-openapi ./api/config/contentSources.ts &
 npx @rtk-query/codegen-openapi ./api/config/provisioning.ts &
 npx @rtk-query/codegen-openapi ./api/config/edge.ts &
-
+npx @rtk-query/codegen-openapi ./api/config/cloudapi.ts &
 # Wait for all background jobs to finish
 wait
 

--- a/api/config/cloudapi.ts
+++ b/api/config/cloudapi.ts
@@ -1,0 +1,21 @@
+import type { ConfigFile } from '@rtk-query/codegen-openapi';
+
+const config: ConfigFile = {
+  schemaFile: '../schema/cloudapi.yml',
+  apiFile: '../../src/store/emptyCloudApi.ts',
+  apiImport: 'emptyCloudApi',
+  outputFile: '../../src/store/cloudApi.ts',
+  exportName: 'cloudApi',
+  hooks: { queries: true, lazyQueries: true, mutations: true },
+  filterEndpoints: [
+    'getComposeStatus',
+    'getComposeMetadata',
+    'getComposeLogs',
+    'getComposeManifests',
+    'postCloneCompose',
+    'getCloneStatus',
+    'postCompose',
+  ],
+};
+
+export default config;

--- a/api/schema/cloudapi.yml
+++ b/api/schema/cloudapi.yml
@@ -1,0 +1,2129 @@
+---
+openapi: 3.0.1
+info:
+  version: '2'
+  title: OSBuild Composer cloud api
+  description: Service to build and install images.
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: https://api.openshift.com/api/image-builder-composer/v2
+    description: Main (production) server
+  - url: https://api.stage.openshift.com/api/image-builder-composer/v2
+    description: Staging server
+  - url: /api/image-builder-composer/v2
+    description: current domain
+
+paths:
+  /openapi:
+    get:
+      operationId: getOpenapi
+      summary: Get the openapi spec in json format
+      security:
+        - Bearer: []
+      responses:
+        '200':
+          description: openapi spec in json format
+          content:
+            application/json:
+              schema:
+                type: object
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /composes/{id}:
+    get:
+      operationId: getComposeStatus
+      summary: The status of a compose
+      security:
+        - Bearer: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: ID of compose status to get
+      description: |-
+        Get the status of a running or completed compose.
+        This includes whether or not the compose succeeded.
+      responses:
+        '200':
+          description: compose status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeStatus'
+        '400':
+          description: Invalid compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Unauthorized to perform operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Unknown compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /composes/{id}/metadata:
+    get:
+      operationId: getComposeMetadata
+      summary: Get the metadata for a compose.
+      security:
+        - Bearer: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: 123e4567-e89b-12d3-a456-426655440000
+          required: true
+          description: ID of compose status to get
+      description: |-
+        Get the metadata of a finished compose.
+        The exact information returned depends on the requested image type.
+      responses:
+        '200':
+          description: The metadata for the given compose.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeMetadata'
+        '400':
+          description: Invalid compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Unauthorized to perform operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Unknown compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+  '/composes/{id}/logs':
+    get:
+      operationId: getComposeLogs
+      summary: Get logs for a compose.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: 123e4567-e89b-12d3-a456-426655440000
+          required: true
+          description: ID of compose status to get
+      description: 'Get the status of a running or finished compose. This includes whether or not it succeeded, and also meta information about the result.'
+      responses:
+        '200':
+          description: The logs for the given compose, in no particular format (though valid JSON).
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeLogs'
+        '400':
+          description: Invalid compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Unknown compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+  '/composes/{id}/manifests':
+    get:
+      operationId: getComposeManifests
+      summary: Get the manifests for a compose.
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: 123e4567-e89b-12d3-a456-426655440000
+          required: true
+          description: ID of compose status to get
+      description: 'Get the manifests of a running or finished compose. Returns one manifest for each image in the request. Each manifest conforms to the format defined at https://www.osbuild.org/man/osbuild-manifest.5'
+      responses:
+        '200':
+          description: The manifest for the given compose.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeManifests'
+        '400':
+          description: Invalid compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Unknown compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /composes/{id}/clone:
+    post:
+      operationId: postCloneCompose
+      summary: Clone an existing compose
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: 123e4567-e89b-12d3-a456-426655440000
+          required: true
+          description: ID of the compose
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CloneComposeBody'
+      responses:
+        '201':
+          description: The new image is being created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloneComposeResponse'
+        '400':
+          description: Invalid compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+        '404':
+          description: Unknown compose id
+          content:
+            text/plain:
+              schema:
+                type: string
+
+  /clones/{id}:
+    get:
+      operationId: getCloneStatus
+      summary: The status of a cloned compose
+      security:
+        - Bearer: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            format: uuid
+            example: '123e4567-e89b-12d3-a456-426655440000'
+          required: true
+          description: ID of image status to get
+      description: |-
+        Get the status of a running or completed image from a compose.
+        This includes whether or not the image creation succeeded.
+      responses:
+        '200':
+          description: image status
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CloneStatus'
+        '400':
+          description: Invalid compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Unauthorized to perform operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Unknown compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /compose:
+    post:
+      operationId: postCompose
+      summary: Create compose
+      description: Create a new compose, potentially consisting of several images and upload each to their destinations.
+      security:
+        - Bearer: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ComposeRequest'
+      responses:
+        '201':
+          description: Compose has started
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ComposeId'
+        '400':
+          description: Invalid compose request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Unauthorized to perform operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Unknown compose id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /errors/{id}:
+    get:
+      operationId: getError
+      summary: Get error description
+      description: Get an instance of the error specified by id
+      security:
+        - Bearer: []
+      parameters:
+        - in: path
+          name: id
+          schema:
+            type: string
+            example: '13'
+          required: true
+          description: ID of the error
+      responses:
+        '200':
+          description: Error description
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '401':
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Unauthorized to perform operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Unknown error id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+  /errors:
+    get:
+      operationId: getErrorList
+      summary: Get a list of all possible errors
+      security:
+        - Bearer: []
+      parameters:
+        - $ref: '#/components/parameters/page'
+        - $ref: '#/components/parameters/size'
+      responses:
+        '200':
+          description: A list of errors
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorList'
+        '401':
+          description: Auth token is invalid
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Unauthorized to perform operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Unknown error id
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Unexpected error occurred
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
+components:
+  schemas:
+    ObjectReference:
+      type: object
+      required:
+        - id
+        - kind
+        - href
+      properties:
+        id:
+          type: string
+        kind:
+          type: string
+        href:
+          type: string
+
+    List:
+      type: object
+      properties:
+        kind:
+          type: string
+        page:
+          type: integer
+        size:
+          type: integer
+        total:
+          type: integer
+      required:
+        - kind
+        - page
+        - size
+        - total
+        - items
+
+    Error:
+      allOf:
+        - $ref: '#/components/schemas/ObjectReference'
+        - type: object
+          required:
+            - code
+            - reason
+            - operation_id
+          properties:
+            code:
+              type: string
+            reason:
+              type: string
+            operation_id:
+              type: string
+            details: {}
+
+    ErrorList:
+      allOf:
+        - $ref: '#/components/schemas/List'
+        - type: object
+          required:
+            - items
+          properties:
+            items:
+              type: array
+              items:
+                $ref: '#/components/schemas/Error'
+
+    ComposeStatus:
+      allOf:
+        - $ref: '#/components/schemas/ObjectReference'
+        - type: object
+          required:
+            - status
+            - image_status
+          properties:
+            status:
+              $ref: '#/components/schemas/ComposeStatusValue'
+            image_status:
+              $ref: '#/components/schemas/ImageStatus'
+            image_statuses:
+              type: array
+              items:
+                $ref: '#/components/schemas/ImageStatus'
+            koji_status:
+              $ref: '#/components/schemas/KojiStatus'
+    ComposeStatusValue:
+      type: string
+      enum:
+        - success
+        - failure
+        - pending
+      example: success
+    ComposeLogs:
+      allOf:
+        - $ref: '#/components/schemas/ObjectReference'
+        - type: object
+          required:
+            - image_builds
+          properties:
+            image_builds:
+              type: array
+              items:
+                type: object
+                x-go-type: interface{}
+            koji:
+              $ref: '#/components/schemas/KojiLogs'
+    KojiLogs:
+      type: object
+      required:
+        - init
+        - import
+      properties:
+        init: {}
+        import: {}
+    ComposeManifests:
+      allOf:
+        - $ref: '#/components/schemas/ObjectReference'
+        - type: object
+          required:
+            - manifests
+          properties:
+            manifests:
+              type: array
+              items:
+                type: object
+                x-go-type: interface{}
+    ImageStatus:
+      required:
+        - status
+      properties:
+        status:
+          $ref: '#/components/schemas/ImageStatusValue'
+        upload_status:
+          $ref: '#/components/schemas/UploadStatus'
+        upload_statuses:
+          type: array
+          items:
+            $ref: '#/components/schemas/UploadStatus'
+        error:
+          $ref: '#/components/schemas/ComposeStatusError'
+    ComposeStatusError:
+      required:
+        - id
+        - reason
+      properties:
+        id:
+          type: integer
+        reason:
+          type: string
+        details: {}
+    ImageStatusValue:
+      type: string
+      enum: ['success', 'failure', 'pending', 'building', 'uploading', 'registering']
+    UploadStatus:
+      required:
+        - status
+        - type
+        - options
+      properties:
+        status:
+          $ref: '#/components/schemas/UploadStatusValue'
+        type:
+          $ref: '#/components/schemas/UploadTypes'
+        options:
+          oneOf:
+            - $ref: '#/components/schemas/AWSEC2UploadStatus'
+            - $ref: '#/components/schemas/AWSS3UploadStatus'
+            - $ref: '#/components/schemas/GCPUploadStatus'
+            - $ref: '#/components/schemas/AzureUploadStatus'
+            - $ref: '#/components/schemas/ContainerUploadStatus'
+            - $ref: '#/components/schemas/OCIUploadStatus'
+            - $ref: '#/components/schemas/PulpOSTreeUploadStatus'
+    UploadStatusValue:
+      type: string
+      enum: ['success', 'failure', 'pending', 'running']
+    UploadTypes:
+      type: string
+      enum:
+        - aws
+        - aws.s3
+        - gcp
+        - azure
+        - container
+        - oci.objectstorage
+        - pulp.ostree
+        - local
+    AWSEC2UploadStatus:
+      type: object
+      required:
+        - ami
+        - region
+      properties:
+        ami:
+          type: string
+          example: 'ami-0c830793775595d4b'
+        region:
+          type: string
+          example: 'eu-west-1'
+    AWSS3UploadStatus:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+    GCPUploadStatus:
+      type: object
+      required:
+        - project_id
+        - image_name
+      properties:
+        project_id:
+          type: string
+          example: 'ascendant-braid-303513'
+        image_name:
+          type: string
+          example: 'my-image'
+    AzureUploadStatus:
+      type: object
+      required:
+        - image_name
+      properties:
+        image_name:
+          type: string
+          example: 'my-image'
+    KojiStatus:
+      type: object
+      properties:
+        build_id:
+          type: integer
+          example: 42
+    ContainerUploadStatus:
+      type: object
+      additionalProperties: false
+      required:
+        - url
+        - digest
+      properties:
+        url:
+          type: string
+          example: 'quay.io/myaccount/osbuild:latest'
+          description: |
+            FQDN of the uploaded image
+        digest:
+          type: string
+          description: |
+            Digest of the manifest of the uploaded container on the registry
+    OCIUploadStatus:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+    PulpOSTreeUploadStatus:
+      type: object
+      required:
+        - repo_url
+      properties:
+        repo_url:
+          type: string
+    ComposeMetadata:
+      allOf:
+        - $ref: '#/components/schemas/ObjectReference'
+        - type: object
+          properties:
+            packages:
+              type: array
+              items:
+                $ref: '#/components/schemas/PackageMetadata'
+              description: 'Package list including NEVRA'
+            ostree_commit:
+              type: string
+              description: 'ID (hash) of the built commit'
+    PackageMetadata:
+      required:
+        - type
+        - name
+        - version
+        - release
+        - arch
+        - sigmd5
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        release:
+          type: string
+        epoch:
+          type: string
+        arch:
+          type: string
+        sigmd5:
+          type: string
+        signature:
+          type: string
+
+    ComposeRequest:
+      additionalProperties: false
+      required:
+        - distribution
+      not: {required: ['customizations', 'blueprint']}
+      properties:
+        distribution:
+          type: string
+          example: 'rhel-8'
+        image_request:
+          $ref: '#/components/schemas/ImageRequest'
+        image_requests:
+          type: array
+          items:
+            $ref: '#/components/schemas/ImageRequest'
+        customizations:
+          $ref: '#/components/schemas/Customizations'
+        koji:
+          $ref: '#/components/schemas/Koji'
+        blueprint:
+          $ref: '#/components/schemas/Blueprint'
+    ImageRequest:
+      additionalProperties: false
+      required:
+        - architecture
+        - image_type
+        - repositories
+      properties:
+        architecture:
+          type: string
+          example: 'x86_64'
+        image_type:
+          $ref: '#/components/schemas/ImageTypes'
+        repositories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Repository'
+        ostree:
+          $ref: '#/components/schemas/OSTree'
+        upload_targets:
+          type: array
+          description: |
+            The type and options for multiple upload targets. Each item defines
+            a separate upload destination with its own options. Multiple
+            different targets as well as multiple targets of the same kind are
+            supported.
+          items:
+            $ref: '#/components/schemas/UploadTarget'
+        upload_options:
+          description: |
+            Top level upload options for a single upload target. If this is
+            defined, it is used with the default target type for the image type
+            and is combined with the targets defined in upload_targets.
+          $ref: '#/components/schemas/UploadOptions'
+        size:
+          x-go-type: uint64
+          default: 0
+          example: 4294967296
+          description: |
+            Size of image, in bytes. When set to 0 the image size is a minimum
+            defined by the image type.
+    ImageTypes:
+      type: string
+      enum:
+        - aws
+        - aws-ha-rhui
+        - aws-rhui
+        - aws-sap-rhui
+        - azure
+        - azure-eap7-rhui
+        - azure-rhui
+        - azure-sap-rhui
+        - edge-commit
+        - edge-container
+        - edge-installer
+        - gcp
+        - gcp-rhui
+        - guest-image
+        - image-installer
+        - iot-bootable-container
+        - iot-commit
+        - iot-container
+        - iot-installer
+        - iot-raw-image
+        - iot-simplified-installer
+        - live-installer
+        - minimal-raw
+        - oci
+        - vsphere
+        - vsphere-ova
+        - wsl
+    Repository:
+      type: object
+      description: |
+        Repository configuration.
+        At least one of the 'baseurl', 'mirrorlist', 'metalink' properties must
+        be specified. If more of them are specified, the order of precedence is
+        the same as listed above.
+      properties:
+        rhsm:
+          type: boolean
+          default: false
+          description: 'Determines whether a valid subscription is required to access this repository.'
+        baseurl:
+          type: string
+          format: uri
+          example: 'https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/'
+        mirrorlist:
+          type: string
+          format: uri
+          example: 'http://mirrorlist.centos.org/?release=8-stream&arch=aarch64&repo=BaseOS'
+        metalink:
+          type: string
+          format: uri
+          example: 'https://mirrors.fedoraproject.org/metalink?repo=fedora-32&arch=x86_64'
+        gpgkey:
+          type: string
+          example: "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGAcScoBEADLf8YHkezJ6adlMYw7aGGIlJalt8Jj2x/B2K+hIfIuxGtpVj7e\nLRgDU76jaT5pVD5mFMJ3pkeneR/cTmqqQkNyQshX2oQXwEzUSb1CNMCfCGgkX8Q2\nzZkrIcCrF0Q2wrKblaudhU+iVanADsm18YEqsb5AU37dtUrM3QYdWg9R+XiPfV8R\nKBjT03vVBOdMSsY39LaCn6Ip1Ovp8IEo/IeEVY1qmCOPAaK0bJH3ufg4Cueks+TS\nwQWTeCLxuZL6OMXoOPKwvMQfxbg1XD8vuZ0Ktj/cNH2xau0xmsAu9HJpekvOPRxl\nyqtjyZfroVieFypwZgvQwtnnM8/gSEu/JVTrY052mEUT7Ccb74kcHFTFfMklnkG/\n0fU4ARa504H3xj0ktbe3vKcPXoPOuKBVsHSv00UGYAyPeuy+87cU/YEhM7k3SVKj\n6eIZgyiMO0wl1YGDRKculwks9A+ulkg1oTb4s3zmZvP07GoTxW42jaK5WS+NhZee\n860XoVhbc1KpS+jfZojsrEtZ8PbUZ+YvF8RprdWArjHbJk2JpRKAxThxsQAsBhG1\n0Lux2WaMB0g2I5PcMdJ/cqjo08ccrjBXuixWri5iu9MXp8qT/fSzNmsdIgn8/qZK\ni8Qulfu77uqhW/wt2btnitgRsqjhxMujYU4Zb4hktF8hKU/XX742qhL5KwARAQAB\ntDFGZWRvcmEgKDM1KSA8ZmVkb3JhLTM1LXByaW1hcnlAZmVkb3JhcHJvamVjdC5v\ncmc+iQJOBBMBCAA4FiEEeH6mrhFH7uVsQLMM20Y5cZhnxY8FAmAcScoCGw8FCwkI\nBwIGFQoJCAsCBBYCAwECHgECF4AACgkQ20Y5cZhnxY+NYA/7BYpglySAZYHhjyKh\n/+f6zPfVvbH20Eq3kI7OFBN0nLX+BU1muvS+qTuS3WLrB3m3GultpKREJKLtm5ED\n1rGzXAoT1yp9YI8LADdMCCOyjAjsoWU87YUuC+/bnjrTeR2LROCfyPC76W985iOV\nm5S+bsQDw7C2LrldAM4MDuoyZ1SitGaZ4KQLVt+TEa14isYSGCjzo7PY8V3JOk50\ngqWg82N/bm2EzS7T83WEDb1lvj4IlvxgIqKeg11zXYxmrYSZJJCfvzf+lNS6uxgH\njx/J0ylZ2LibGr6GAAyO9UWrAZSwSM0EcjT8wECnxkSDuyqmWwVvNBXuEIV8Oe3Y\nMiU1fJN8sd7DpsFx5M+XdnMnQS+HrjTPKD3mWrlAdnEThdYV8jZkpWhDys3/99eO\nhk0rLny0jNwkauf/iU8Oc6XvMkjLRMJg5U9VKyJuWWtzwXnjMN5WRFBqK4sZomMM\nftbTH1+5ybRW/A3vBbaxRW2t7UzNjczekSZEiaLN9L/HcJCIR1QF8682DdAlEF9d\nk2gQiYSQAaaJ0JJAzHvRkRJLLgK2YQYiHNVy2t3JyFfsram5wSCWOfhPeIyLBTZJ\nvrpNlPbefsT957Tf2BNIugzZrC5VxDSKkZgRh1VGvSIQnCyzkQy6EU2qPpiW59G/\nhPIXZrKocK3KLS9/izJQTRltjMA=\n=PfT7\n-----END PGP PUBLIC KEY BLOCK-----\n"
+          description: 'GPG key used to sign packages in this repository.'
+        check_gpg:
+          type: boolean
+        check_repo_gpg:
+          type: boolean
+          default: false
+          description: |
+            Enables gpg verification of the repository metadata
+        ignore_ssl:
+          type: boolean
+        module_hotfixes:
+          type: boolean
+          default: false
+          description: |
+            Disables modularity filtering for this repository.
+        package_sets:
+          type: array
+          example: ["build", "os"]
+          items:
+            type: string
+          description: |
+            Naming package sets for a repository assigns it to a specific part
+            (pipeline) of the build process.
+    CustomRepository:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        filename:
+          type: string
+        baseurl:
+          type: array
+          items:
+            type: string
+            format: uri
+            example: 'https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/'
+        mirrorlist:
+          type: string
+          format: uri
+          example: 'http://mirrorlist.centos.org/?release=8-stream&arch=aarch64&repo=BaseOS'
+        metalink:
+          type: string
+          format: uri
+          example: 'https://mirrors.fedoraproject.org/metalink?repo=fedora-32&arch=x86_64'
+        enabled:
+          type: boolean
+        gpgkey:
+          type: array
+          items:
+            type: string
+        check_gpg:
+          type: boolean
+        check_repo_gpg:
+          type: boolean
+        ssl_verify:
+          type: boolean
+        priority:
+          type: integer
+        module_hotfixes:
+          type: boolean
+    BlueprintRepository:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        baseurls:
+          type: array
+          items:
+            type: string
+            format: uri
+            example: 'https://cdn.redhat.com/content/dist/rhel8/8/x86_64/baseos/os/'
+        gpgkeys:
+          type: array
+          items:
+            type: string
+        metalink:
+          type: string
+          format: uri
+          example: 'https://mirrors.fedoraproject.org/metalink?repo=fedora-32&arch=x86_64'
+        mirrorlist:
+          type: string
+          format: uri
+          example: 'http://mirrorlist.centos.org/?release=8-stream&arch=aarch64&repo=BaseOS'
+        name:
+          type: string
+        priority:
+          type: integer
+        enabled:
+          type: boolean
+        gpgcheck:
+          type: boolean
+        repo_gpgcheck:
+          type: boolean
+        sslverify:
+          type: boolean
+        filename:
+          type: string
+        module_hotfixes:
+          type: boolean
+          description: |
+            Disables modularity filtering for this repository.
+    OpenSCAP:
+      type: object
+      required:
+        - profile_id
+      properties:
+        policy_id:
+          type: string
+          format: uuid
+          description: |
+            Puts a specified policy ID in the RHSM facts, so that any instances registered to
+            insights will be automatically connected to the compliance policy in the console.
+        profile_id:
+          type: string
+        tailoring:
+          $ref: '#/components/schemas/OpenSCAPTailoring'
+        json_tailoring:
+          $ref: '#/components/schemas/OpenSCAPJSONTailoring'
+    BlueprintOpenSCAP:
+      type: object
+      required:
+        - profile_id
+      properties:
+        policy_id:
+          type: string
+          format: uuid
+          description: |
+            Puts a specified policy ID in the RHSM facts, so that any instances registered to
+            insights will be automatically connected to the compliance policy in the console.
+        profile_id:
+          type: string
+        datastream:
+          type: string
+        tailoring:
+          $ref: '#/components/schemas/OpenSCAPTailoring'
+        json_tailoring:
+          $ref: '#/components/schemas/OpenSCAPJSONTailoring'
+    OpenSCAPTailoring:
+      type: object
+      properties:
+        selected:
+          type: array
+          items:
+            type: string
+        unselected:
+          type: array
+          items:
+            type: string
+    OpenSCAPJSONTailoring:
+      type: object
+      required:
+        - profile_id
+        - filepath
+      properties:
+        profile_id:
+          type: string
+        filepath:
+          type: string
+    Installer:
+      type: object
+      properties:
+        unattended:
+          type: boolean
+        sudo-nopasswd:
+          type: array
+          items:
+            type: string
+    ImportKeys:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            type: string
+    RPMCustomization:
+      type: object
+      properties:
+        import_keys:
+          $ref: '#/components/schemas/ImportKeys'
+    DNFPluginConfig:
+      type: object
+      properties:
+        enabled:
+          type: boolean
+    SubManDNFPluginsConfig:
+      type: object
+      properties:
+        product_id:
+          $ref: '#/components/schemas/DNFPluginConfig'
+        subscription_manager:
+          $ref: '#/components/schemas/DNFPluginConfig'
+    SubManRHSMConfig:
+      type: object
+      properties:
+        manage_repos:
+          type: boolean
+    SubManRHSMCertdConfig:
+      type: object
+      properties:
+        auto_registration:
+          type: boolean
+    SubManConfig:
+      type: object
+      properties:
+        rhsm:
+          $ref: '#/components/schemas/SubManRHSMConfig'
+        rhsmcertd:
+          $ref: '#/components/schemas/SubManRHSMCertdConfig'
+    RHSMConfig:
+      type: object
+      properties:
+        dnf_plugins:
+          $ref: '#/components/schemas/SubManDNFPluginsConfig'
+        subscription_manager:
+          $ref: '#/components/schemas/SubManConfig'
+    RHSMCustomization:
+      type: object
+      properties:
+        config:
+          $ref: '#/components/schemas/RHSMConfig'
+    UploadTarget:
+      type: object
+      required:
+        - type
+        - upload_options
+      properties:
+        type:
+          $ref: '#/components/schemas/UploadTypes'
+          description: |
+            The name of the upload target that matches the upload_options.
+        upload_options:
+          $ref: '#/components/schemas/UploadOptions'
+    UploadOptions:
+      anyOf:
+        - $ref: '#/components/schemas/AWSEC2UploadOptions'
+        - $ref: '#/components/schemas/AWSS3UploadOptions'
+        - $ref: '#/components/schemas/GCPUploadOptions'
+        - $ref: '#/components/schemas/AzureUploadOptions'
+        - $ref: '#/components/schemas/ContainerUploadOptions'
+        - $ref: '#/components/schemas/LocalUploadOptions'
+        - $ref: '#/components/schemas/OCIUploadOptions'
+        - $ref: '#/components/schemas/PulpOSTreeUploadOptions'
+      description: |
+        Options for a given upload destination.
+        This should really be oneOf but AWSS3UploadOptions is a subset of
+        AWSEC2UploadOptions. This means that all AWSEC2UploadOptions objects
+        are also valid AWSS3UploadOptionas objects which violates the oneOf
+        rules. Therefore, we have to use anyOf here but be aware that it isn't
+        possible to mix and match more schemas together.
+    LocalUploadOptions:
+      type: object
+      additionalProperties: false
+      required:
+        - local_save
+      properties:
+        local_save:
+          type: boolean
+          default: false
+          description: |
+            This is used in combination with the OSBUILD_LOCALSAVE environmental
+            variable on the server to enable saving the compose locally. This
+            is for development use only, and is not available to users.
+    AWSEC2UploadOptions:
+      type: object
+      additionalProperties: false
+      required:
+        - region
+        - share_with_accounts
+      properties:
+        region:
+          type: string
+          example: 'eu-west-1'
+        snapshot_name:
+          type: string
+          example: 'my-snapshot'
+        share_with_accounts:
+          type: array
+          example: ['123456789012']
+          items:
+            type: string
+    AWSS3UploadOptions:
+      type: object
+      additionalProperties: false
+      required:
+        - region
+      properties:
+        region:
+          type: string
+          example: 'eu-west-1'
+        public:
+          type: boolean
+          default: false
+          description: |
+            If set to false (the default value), a long, obfuscated URL
+            is returned. Its expiration might be sooner than for other upload
+            targets.
+
+            If set to true, a shorter URL is returned and
+            its expiration is the same as for the other upload targets.
+    OCIUploadOptions:
+      type: object
+      additionalProperties: false
+    GCPUploadOptions:
+      type: object
+      additionalProperties: false
+      required:
+        - region
+      properties:
+        region:
+          type: string
+          example: 'eu'
+          description: |
+            The GCP region where the OS image will be imported to and shared from.
+            The value must be a valid GCP location. See https://cloud.google.com/storage/docs/locations.
+            If not specified, the multi-region location closest to the source
+            (source Storage Bucket location) is chosen automatically.
+        bucket:
+          type: string
+          example: 'my-example-bucket'
+          description: 'Name of an existing STANDARD Storage class Bucket.'
+        # don't expose the os type for now
+        #        os:
+        #          type: string
+        #          example: 'rhel-8-byol'
+        #          description: 'OS of the disk image being imported needed for installation of GCP guest tools.'
+        image_name:
+          type: string
+          example: 'my-image'
+          description: |
+            The name to use for the imported and shared Compute Engine image.
+            The image name must be unique within the GCP project, which is used
+            for the OS image upload and import. If not specified a random
+            'composer-api-<uuid>' string is used as the image name.
+        share_with_accounts:
+          type: array
+          example: [
+            'user:alice@example.com',
+            'serviceAccount:my-other-app@appspot.gserviceaccount.com',
+            'group:admins@example.com',
+            'domain:example.com'
+          ]
+          description: |
+            List of valid Google accounts to share the imported Compute Engine image with.
+            Each string must contain a specifier of the account type. Valid formats are:
+              - 'user:{emailid}': An email address that represents a specific
+                Google account. For example, 'alice@example.com'.
+              - 'serviceAccount:{emailid}': An email address that represents a
+                service account. For example, 'my-other-app@appspot.gserviceaccount.com'.
+              - 'group:{emailid}': An email address that represents a Google group.
+                For example, 'admins@example.com'.
+              - 'domain:{domain}': The G Suite domain (primary) that represents all
+                the users of that domain. For example, 'google.com' or 'example.com'.
+            If not specified, the imported Compute Engine image is not shared with any
+            account.
+          items:
+            type: string
+    AzureUploadOptions:
+      type: object
+      additionalProperties: false
+      required:
+        - tenant_id
+        - subscription_id
+        - resource_group
+      properties:
+        tenant_id:
+          type: string
+          example: '5c7ef5b6-1c3f-4da0-a622-0b060239d7d7'
+          description: |
+            ID of the tenant where the image should be uploaded.
+            How to find it in the Azure Portal:
+            https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant
+        subscription_id:
+          type: string
+          example: '4e5d8b2c-ab24-4413-90c5-612306e809e2'
+          description: |
+            ID of subscription where the image should be uploaded.
+        resource_group:
+          type: string
+          example: 'ToucanResourceGroup'
+          description: |
+            Name of the resource group where the image should be uploaded.
+        location:
+          type: string
+          example: 'westeurope'
+          description: |
+            Location of the provided resource_group, where the image should be uploaded and registered.
+            How to list all locations:
+            https://docs.microsoft.com/en-us/cli/azure/account?view=azure-cli-latest#az_account_list_locations'
+            If the location is not specified, it is deducted from the provided resource_group.
+        image_name:
+          type: string
+          example: 'my-image'
+          description: |
+            Name of the uploaded image. It must be unique in the given resource group.
+            If name is omitted from the request, a random one based on a UUID is
+            generated.
+    ContainerUploadOptions:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          example: 'osbuild'
+          description: |
+            Name for the created container image
+        tag:
+          type: string
+          example: 'latest'
+          description: |
+            Tag for the created container image
+    PulpOSTreeUploadOptions:
+      type: object
+      additionalProperties: false
+      required:
+        - basepath
+      properties:
+        basepath:
+          type: string
+          description: 'Basepath for distributing the repository'
+        repository:
+          type: string
+          description: 'Repository to import the ostree commit to'
+        server_address:
+          type: string
+          format: uri
+    Blueprint:
+      type: object
+      required:
+        - name
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        version:
+          type: string
+          example: '7.7.70'
+          description: A semver version number
+        distro:
+          type: string
+          example: 'fedora-39'
+          description: |
+            The distribution to use for the compose. If left empty the host
+            distro will be used.
+        packages:
+          type: array
+          description: Packages to be installed
+          items:
+            $ref: '#/components/schemas/Package'
+        modules:
+          type: array
+          description: |
+            An alias for packages, retained for backwards compatability
+          items:
+            $ref: '#/components/schemas/Package'
+        groups:
+          type: array
+          description: Package groups to be installed
+          items:
+            $ref: '#/components/schemas/PackageGroup'
+        containers:
+          type: array
+          description: Container images to embed into the final artfact
+          items:
+            $ref: '#/components/schemas/Container'
+        customizations:
+          $ref: '#/components/schemas/BlueprintCustomizations'
+    BlueprintCustomizations:
+      type: object
+      additionalProperties: false
+      properties:
+        hostname:
+          type: string
+          description: Configures the hostname
+        kernel:
+          $ref: '#/components/schemas/Kernel'
+        sshkey:
+          type: array
+          description: List of ssh keys
+          items:
+            $ref: '#/components/schemas/SSHKey'
+        user:
+          type: array
+          description: List of users to create
+          items:
+            $ref: '#/components/schemas/BlueprintUser'
+        group:
+          type: array
+          description: List of groups to create
+          items:
+            $ref: '#/components/schemas/Group'
+        timezone:
+          $ref: '#/components/schemas/Timezone'
+        locale:
+          $ref: '#/components/schemas/Locale'
+        firewall:
+          $ref: '#/components/schemas/BlueprintFirewall'
+        services:
+          $ref: '#/components/schemas/Services'
+        filesystem:
+          type: array
+          description: List of filesystem mountpoints to create
+          items:
+            $ref: '#/components/schemas/BlueprintFilesystem'
+        installation_device:
+          type: string
+          description: |
+            Name of the installation device, currently only useful for the edge-simplified-installer type
+          example: /dev/sda
+        partitioning_mode:
+          type: string
+          enum:
+            - raw
+            - lvm
+            - auto-lvm
+          default: auto-lvm
+          description: |
+            Select how the disk image will be partitioned. 'auto-lvm' will use raw unless
+            there are one or more mountpoints in which case it will use LVM. 'lvm' always
+            uses LVM, even when there are no extra mountpoints. 'raw' uses raw partitions
+            even when there are one or more mountpoints.
+        fdo:
+          $ref: '#/components/schemas/FDO'
+        openscap:
+          $ref: '#/components/schemas/BlueprintOpenSCAP'
+        ignition:
+          $ref: '#/components/schemas/Ignition'
+        directories:
+          type: array
+          description: Directories to create in the final artifact
+          items:
+            $ref: '#/components/schemas/Directory'
+        files:
+          type: array
+          description: Files to create in the final artifact
+          items:
+            $ref: '#/components/schemas/BlueprintFile'
+        repositories:
+          type: array
+          description: |
+            Repositories to write to /etc/yum.repos.d/ in the final image. Note
+            that these are not used at build time.
+          items:
+            $ref: '#/components/schemas/BlueprintRepository'
+        fips:
+          type: boolean
+          description: Enable FIPS mode
+        installer:
+          $ref: '#/components/schemas/Installer'
+        rpm:
+          $ref: '#/components/schemas/RPMCustomization'
+        rhsm:
+          $ref: '#/components/schemas/RHSMCustomization'
+    SSHKey:
+      type: object
+      additionalProperties: false
+      required:
+        - user
+        - key
+      properties:
+        user:
+          type: string
+          description: User to configure the ssh key for
+          example: admin
+        key:
+          type: string
+          description: Adds the key to the user's authorized_keys file
+          example: |
+            ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIASWitkOH4U874EdsBUnytb3bwvRggHlQlbYXl7n10v9
+    Package:
+      type: object
+      required:
+        - name
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          example: 'tmux'
+          description: |
+            Name of the package to install. File globbing is supported,
+            eg. 'openssh-*'
+        version:
+          type: string
+          example: '3.3a'
+          description: |
+            Optional version of the package to install. If left blank the
+            latest available version will be used. Wildcards are supported
+            eg. '4.11.*'
+    PackageGroup:
+      type: object
+      required:
+        - name
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          example: 'anaconda-tools'
+          description: Package group name
+    Customizations:
+      type: object
+      additionalProperties: false
+      properties:
+        containers:
+          type: array
+          items:
+            $ref: '#/components/schemas/Container'
+            description: Container images to embed into the final artfact
+        directories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Directory'
+            description: Directories to create in the final artifact
+        files:
+          type: array
+          items:
+            $ref: '#/components/schemas/File'
+            description: Files to create in the final artifact
+        subscription:
+          $ref: '#/components/schemas/Subscription'
+        packages:
+          type: array
+          example: ['postgres']
+          items:
+            type: string
+        users:
+          type: array
+          items:
+            $ref: '#/components/schemas/User'
+        payload_repositories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Repository'
+          description: |
+            Extra repositories for packages specified in customizations. These
+            repositories will only be used to depsolve and retrieve packages
+            for the OS itself (they will not be available for the build root or
+            any other part of the build process). The package_sets field for these
+            repositories is ignored.
+        custom_repositories:
+          type: array
+          items:
+            $ref: '#/components/schemas/CustomRepository'
+          description: |
+            Extra repositories for packages specified in customizations. These
+            repositories will be used to depsolve and retrieve packages. Additionally,
+            these packages will be saved and imported to the `/etc/yum.repos.d/` directory
+            on the image
+        openscap:
+          $ref: '#/components/schemas/OpenSCAP'
+        filesystem:
+          type: array
+          items:
+            $ref: '#/components/schemas/Filesystem'
+        services:
+          $ref: '#/components/schemas/Services'
+        hostname:
+          type: string
+          description: Configures the hostname
+          example: myhostname
+        kernel:
+          $ref: '#/components/schemas/Kernel'
+        groups:
+          type: array
+          description: List of groups to create
+          items:
+            $ref: '#/components/schemas/Group'
+        timezone:
+          $ref: '#/components/schemas/Timezone'
+        locale:
+          $ref: '#/components/schemas/Locale'
+        firewall:
+          $ref: '#/components/schemas/FirewallCustomization'
+        installation_device:
+          type: string
+          description: |
+            Name of the installation device, currently only useful for the edge-simplified-installer type
+          example: /dev/sda
+        fdo:
+          $ref: '#/components/schemas/FDO'
+        ignition:
+          $ref: '#/components/schemas/Ignition'
+        partitioning_mode:
+          type: string
+          enum:
+            - raw
+            - lvm
+            - auto-lvm
+          default: auto-lvm
+          description: |
+            Select how the disk image will be partitioned. 'auto-lvm' will use raw unless
+            there are one or more mountpoints in which case it will use LVM. 'lvm' always
+            uses LVM, even when there are no extra mountpoints. 'raw' uses raw partitions
+            even when there are one or more mountpoints.
+        fips:
+          $ref: '#/components/schemas/FIPS'
+        installer:
+          $ref: '#/components/schemas/Installer'
+        rpm:
+          $ref: '#/components/schemas/RPMCustomization'
+        rhsm:
+          $ref: '#/components/schemas/RHSMCustomization'
+    Container:
+      type: object
+      required:
+        - source
+      properties:
+        source:
+          type: string
+          description: Reference to the container to embed
+          example: 'registry.example.com/image:tag'
+        name:
+          type: string
+          description: Name to use for the container from the image
+        tls_verify:
+          type: boolean
+          description: Control TLS verifification
+          example: true
+    FirewallCustomization:
+      type: object
+      description: Firewalld configuration
+      additionalProperties: false
+      properties:
+        ports:
+          type: array
+          description: List of ports (or port ranges) and protocols to open
+          example: ["22:tcp", "80:tcp", "imap:tcp"]
+          items:
+            type: string
+        services:
+          $ref: '#/components/schemas/FirewallServices'
+    BlueprintFirewall:
+      type: object
+      description: Firewalld configuration
+      additionalProperties: false
+      properties:
+        ports:
+          type: array
+          description: List of ports (or port ranges) and protocols to open
+          example: ["22:tcp", "80:tcp", "imap:tcp"]
+          items:
+            type: string
+        services:
+          $ref: '#/components/schemas/FirewallServices'
+        zones:
+          type: array
+          items:
+            $ref: '#/components/schemas/FirewallZones'
+    FirewallServices:
+      type: object
+      description: Firewalld services to enable or disable
+      additionalProperties: false
+      properties:
+        enabled:
+          type: array
+          description: List of services to enable
+          example: ["ftp", "ntp"]
+          items:
+            type: string
+        disabled:
+          type: array
+          description: List of services to disable
+          example: ["telnet"]
+          items:
+            type: string
+    FirewallZones:
+      type: object
+      description: |
+        Bind a list of network sources to a zone to restrict traffic from
+        those sources based on the settings of the zone.
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: |
+            name of the zone, if left empty the sources will apply to
+            the default zone.
+        sources:
+          type: array
+          description: List of sources for the zone
+          items:
+            type: string
+            description: <source>[/<mask>]|<MAC>|ipset:<ipset>
+    Directory:
+      type: object
+      description: |
+        A custom directory to create in the final artifact.
+      required:
+        - path
+      properties:
+        path:
+          type: string
+          description: Path to the directory
+          example: '/etc/mydir'
+        mode:
+          type: string
+          description: Permissions string for the directory in octal format
+          example: "0755"
+        user:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Owner of the directory as a user name or a uid
+          example: 'root'
+        group:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Group of the directory as a group name or a gid
+          example: 'root'
+        ensure_parents:
+          type: boolean
+          description: Ensure that the parent directories exist
+          default: false
+    File:
+      type: object
+      description: |
+        A custom file to create in the final artifact.
+      required:
+        - path
+      properties:
+        path:
+          type: string
+          description: Path to the file
+          example: '/etc/myfile'
+        mode:
+          type: string
+          description: Permissions string for the file in octal format
+          example: "0644"
+        user:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Owner of the file as a uid or a user name
+          example: 'root'
+        group:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Group of the file as a gid or a group name
+          example: 'root'
+        data:
+          type: string
+          description: Contents of the file as plain text
+        ensure_parents:
+          type: boolean
+          description: Ensure that the parent directories exist
+          example: true
+          default: false
+    BlueprintFile:
+      type: object
+      description: |
+        A custom file to create in the final artifact.
+      required:
+        - path
+      properties:
+        path:
+          type: string
+          description: Path to the file
+          example: '/etc/myfile'
+        mode:
+          type: string
+          description: Permissions string for the file in octal format
+          example: "0644"
+        user:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Owner of the file as a uid or a user name
+          example: 'root'
+        group:
+          oneOf:
+            - type: string
+            - type: integer
+          description: Group of the file as a gid or a group name
+          example: 'root'
+        data:
+          type: string
+          description: Contents of the file as plain text
+    Filesystem:
+      type: object
+      required:
+        - mountpoint
+        - min_size
+      properties:
+        mountpoint:
+          type: string
+          example: '/var'
+        min_size:
+          x-go-type: uint64
+          example: 2147483648
+          description: 'size of the filesystem in bytes'
+    BlueprintFilesystem:
+      type: object
+      required:
+        - mountpoint
+        - minsize
+      properties:
+        mountpoint:
+          type: string
+          example: '/var'
+        minsize:
+          x-go-type: uint64
+          example: 2147483648
+          description: 'size of the filesystem in bytes'
+    OSTree:
+      type: object
+      properties:
+        url:
+          type: string
+        contenturl:
+          type: string
+          description: |
+            A URL which, if set, is used for fetching content. Implies that `url` is set as well,
+            which will be used for metadata only.
+        ref:
+          type: string
+          example: 'rhel/8/x86_64/edge'
+        parent:
+          type: string
+          description: >
+            Can be either a commit (example:
+            02604b2da6e954bd34b8b82a835e5a77d2b60ffa), or a branch-like
+            reference (example: rhel/8/x86_64/edge)
+          example: 'rhel/8/x86_64/edge'
+        rhsm:
+          type: boolean
+          default: false
+          description: |
+            Determines whether a valid subscription manager (candlepin) identity is required to
+            access this repository. Consumer certificates will be used as client certificates when
+            fetching metadata and content.
+    Subscription:
+      type: object
+      required:
+        - organization
+        - activation_key
+        - server_url
+        - base_url
+        - insights
+      properties:
+        organization:
+          type: string
+          example: '2040324'
+        activation_key:
+          type: string
+          format: password
+          example: 'my-secret-key'
+        server_url:
+          type: string
+          format: uri
+          example: 'subscription.rhsm.redhat.com'
+        base_url:
+          type: string
+          format: uri
+          example: 'http://cdn.redhat.com/'
+        insights:
+          type: boolean
+          example: true
+        rhc:
+          type: boolean
+          default: false
+          example: true
+          description: |
+            Optional flag to use rhc to register the system, which also always enables Insights.
+    User:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: "user1"
+        groups:
+          type: array
+          items:
+            type: string
+            example: "group1"
+        key:
+          type: string
+          example: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrGKErMYi+MMUwuHaRAJmRLoIzRf2qD2dD5z0BTx/6x"
+        password:
+          type: string
+          format: password
+          description: |
+            If the password starts with $6$, $5$, or $2b$ it will be stored as
+            an encrypted password. Otherwise it will be treated as a plain text
+            password.
+    BlueprintUser:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: "user1"
+        description:
+          type: string
+        password:
+          type: string
+          description: |
+            If the password starts with $6$, $5$, or $2b$ it will be stored as
+            an encrypted password. Otherwise it will be treated as a plain text
+            password.
+        key:
+          type: string
+          description: ssh public key
+          example: "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAINrGKErMYi+MMUwuHaRAJmRLoIzRf2qD2dD5z0BTx/6x"
+        home:
+          type: string
+          description: The user's home directory
+        shell:
+          type: string
+          description: Login shell to use
+        groups:
+          type: array
+          items:
+            type: string
+            example: "group1"
+          description: A list of additional groups to add the user to
+        uid:
+          type: integer
+          description: User id to use instead of the default
+        gid:
+          type: integer
+          description: Group id to use instead of the default
+    Kernel:
+      type: object
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Name of the kernel to use
+          example: kernel-debug
+        append:
+          type: string
+          description: Appends arguments to the bootloader kernel command line
+          example: nosmt=force
+    Services:
+      type: object
+      additionalProperties: false
+      properties:
+        enabled:
+          description: List of services to enable by default
+          type: array
+          minItems: 1
+          items:
+            type: string
+            example: "nftables"
+        disabled:
+          description: List of services to disable by default
+          type: array
+          minItems: 1
+          items:
+            type: string
+            example: "firewalld"
+        masked:
+          description: List of services to mask by default
+          type: array
+          minItems: 1
+          items:
+            type: string
+            example: "telnetd"
+    Timezone:
+      type: object
+      description: Timezone configuration
+      additionalProperties: false
+      properties:
+        timezone:
+          type: string
+          description: Name of the timezone, defaults to UTC
+          example: US/Eastern
+        ntpservers:
+          type: array
+          description: List of ntp servers
+          example: ["0.north-america.pool.ntp.org", "1.north-america.pool.ntp.org"]
+          items:
+            type: string
+    Locale:
+      type: object
+      description: Locale configuration
+      additionalProperties: false
+      properties:
+        languages:
+          type: array
+          description: |
+            List of locales to be installed, the first one becomes primary, subsequent ones are secondary
+          example: ["en_US.UTF-8"]
+          items:
+            type: string
+        keyboard:
+          type: string
+          description: Sets the keyboard layout
+          example: us
+    FDO:
+      type: object
+      additionalProperties: false
+      description: FIDO device onboard configuration
+      properties:
+        manufacturing_server_url:
+          type: string
+        diun_pub_key_insecure:
+          type: string
+        diun_pub_key_hash:
+          type: string
+        diun_pub_key_root_certs:
+          type: string
+        di_mfg_string_type_mac_iface:
+          type: string
+    FIPS:
+      type: object
+      additionalProperties: false
+      description: System FIPS mode setup
+      properties:
+        enabled:
+          type: boolean
+          description: Enables the system FIPS mode
+          default: false
+    Ignition:
+      type: object
+      additionalProperties: false
+      description: Ignition configuration
+      properties:
+        embedded:
+          $ref: '#/components/schemas/IgnitionEmbedded'
+        firstboot:
+          $ref: '#/components/schemas/IgnitionFirstboot'
+    IgnitionEmbedded:
+      type: object
+      additionalProperties: false
+      required:
+        - config
+      properties:
+        config:
+          type: string
+    IgnitionFirstboot:
+      type: object
+      additionalProperties: false
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          description: Provisioning URL
+    Group:
+      type: object
+      additionalProperties: false
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Name of the group to create
+        gid:
+          type: integer
+          description: Group id of the group to create (optional)
+    Koji:
+      type: object
+      additionalProperties: false
+      required:
+        - server
+        - task_id
+        - name
+        - version
+        - release
+      properties:
+        server:
+          type: string
+          format: uri
+          example: 'https://koji.fedoraproject.org/kojihub'
+        task_id:
+          type: integer
+          example: 42
+        name:
+          type: string
+          example: Fedora-Cloud-Base
+        version:
+          type: string
+          example: '31'
+        release:
+          type: string
+          example: '20200907.0'
+    ComposeId:
+      allOf:
+        - $ref: '#/components/schemas/ObjectReference'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: string
+              format: uuid
+              example: '123e4567-e89b-12d3-a456-426655440000'
+
+    CloneComposeBody:
+      oneOf:
+        - $ref: '#/components/schemas/AWSEC2CloneCompose'
+
+    AWSEC2CloneCompose:
+      type: object
+      additionalProperties: false
+      required:
+        - region
+      properties:
+        region:
+          type: string
+        share_with_accounts:
+          type: array
+          example: ['123456789012']
+          items:
+            type: string
+
+    CloneComposeResponse:
+      allOf:
+        - $ref: '#/components/schemas/ObjectReference'
+        - type: object
+          required:
+            - id
+          properties:
+            id:
+              type: string
+              format: uuid
+              example: '123e4567-e89b-12d3-a456-426655440000'
+
+    CloneStatus:
+      allOf:
+        - $ref: '#/components/schemas/ObjectReference'
+        - $ref: '#/components/schemas/UploadStatus'
+
+  parameters:
+    page:
+      name: page
+      in: query
+      description: Page index
+      required: false
+      schema:
+        type: string
+      examples:
+        page:
+          value: "1"
+    size:
+      name: size
+      in: query
+      description: Number of items in each page
+      required: false
+      schema:
+        type: string
+      examples:
+        size:
+          value: "100"
+
+  securitySchemes:
+    Bearer:
+      scheme: bearer
+      bearerFormat: JWT
+      type: http

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const RHSM_API = '/api/rhsm/v2';
 export const EDGE_API = '/api/edge/v1';
 export const CONTENT_SOURCES_API = '/api/content-sources/v1';
 export const PROVISIONING_API = '/api/provisioning/v1';
+export const CLOUD_API = '/api/image-builder-composer/v2';
 export const CREATE_BLUEPRINT = `${IMAGE_BUILDER_API}/blueprints`;
 export const EDIT_BLUEPRINT = `${IMAGE_BUILDER_API}/blueprints`;
 

--- a/src/store/cloudApi.ts
+++ b/src/store/cloudApi.ts
@@ -1,0 +1,847 @@
+import { emptyCloudApi as api } from './emptyCloudApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({
+    getComposeStatus: build.query<
+      GetComposeStatusApiResponse,
+      GetComposeStatusApiArg
+    >({
+      query: (queryArg) => ({ url: `/composes/${queryArg.id}` }),
+    }),
+    getComposeMetadata: build.query<
+      GetComposeMetadataApiResponse,
+      GetComposeMetadataApiArg
+    >({
+      query: (queryArg) => ({ url: `/composes/${queryArg.id}/metadata` }),
+    }),
+    getComposeLogs: build.query<
+      GetComposeLogsApiResponse,
+      GetComposeLogsApiArg
+    >({
+      query: (queryArg) => ({ url: `/composes/${queryArg.id}/logs` }),
+    }),
+    getComposeManifests: build.query<
+      GetComposeManifestsApiResponse,
+      GetComposeManifestsApiArg
+    >({
+      query: (queryArg) => ({ url: `/composes/${queryArg.id}/manifests` }),
+    }),
+    postCloneCompose: build.mutation<
+      PostCloneComposeApiResponse,
+      PostCloneComposeApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/composes/${queryArg.id}/clone`,
+        method: 'POST',
+        body: queryArg.cloneComposeBody,
+      }),
+    }),
+    getCloneStatus: build.query<
+      GetCloneStatusApiResponse,
+      GetCloneStatusApiArg
+    >({
+      query: (queryArg) => ({ url: `/clones/${queryArg.id}` }),
+    }),
+    postCompose: build.mutation<PostComposeApiResponse, PostComposeApiArg>({
+      query: (queryArg) => ({
+        url: `/compose`,
+        method: 'POST',
+        body: queryArg.composeRequest,
+      }),
+    }),
+  }),
+  overrideExisting: false,
+});
+export { injectedRtkApi as cloudApi };
+export type GetComposeStatusApiResponse =
+  /** status 200 compose status */ ComposeStatus;
+export type GetComposeStatusApiArg = {
+  /** ID of compose status to get */
+  id: string;
+};
+export type GetComposeMetadataApiResponse =
+  /** status 200 The metadata for the given compose. */ ComposeMetadata;
+export type GetComposeMetadataApiArg = {
+  /** ID of compose status to get */
+  id: string;
+};
+export type GetComposeLogsApiResponse =
+  /** status 200 The logs for the given compose, in no particular format (though valid JSON). */ ComposeLogs;
+export type GetComposeLogsApiArg = {
+  /** ID of compose status to get */
+  id: string;
+};
+export type GetComposeManifestsApiResponse =
+  /** status 200 The manifest for the given compose. */ ComposeManifests;
+export type GetComposeManifestsApiArg = {
+  /** ID of compose status to get */
+  id: string;
+};
+export type PostCloneComposeApiResponse =
+  /** status 201 The new image is being created */ CloneComposeResponse;
+export type PostCloneComposeApiArg = {
+  /** ID of the compose */
+  id: string;
+  cloneComposeBody: CloneComposeBody;
+};
+export type GetCloneStatusApiResponse =
+  /** status 200 image status */ CloneStatus;
+export type GetCloneStatusApiArg = {
+  /** ID of image status to get */
+  id: string;
+};
+export type PostComposeApiResponse =
+  /** status 201 Compose has started */ ComposeId;
+export type PostComposeApiArg = {
+  composeRequest: ComposeRequest;
+};
+export type ObjectReference = {
+  id: string;
+  kind: string;
+  href: string;
+};
+export type ComposeStatusValue = 'success' | 'failure' | 'pending';
+export type ImageStatusValue =
+  | 'success'
+  | 'failure'
+  | 'pending'
+  | 'building'
+  | 'uploading'
+  | 'registering';
+export type UploadStatusValue = 'success' | 'failure' | 'pending' | 'running';
+export type UploadTypes =
+  | 'aws'
+  | 'aws.s3'
+  | 'gcp'
+  | 'azure'
+  | 'container'
+  | 'oci.objectstorage'
+  | 'pulp.ostree'
+  | 'local';
+export type Awsec2UploadStatus = {
+  ami: string;
+  region: string;
+};
+export type Awss3UploadStatus = {
+  url: string;
+};
+export type GcpUploadStatus = {
+  project_id: string;
+  image_name: string;
+};
+export type AzureUploadStatus = {
+  image_name: string;
+};
+export type ContainerUploadStatus = {
+  /** FQDN of the uploaded image
+   */
+  url: string;
+  /** Digest of the manifest of the uploaded container on the registry
+   */
+  digest: string;
+};
+export type OciUploadStatus = {
+  url: string;
+};
+export type PulpOsTreeUploadStatus = {
+  repo_url: string;
+};
+export type UploadStatus = {
+  status: UploadStatusValue;
+  type: UploadTypes;
+  options:
+    | Awsec2UploadStatus
+    | Awss3UploadStatus
+    | GcpUploadStatus
+    | AzureUploadStatus
+    | ContainerUploadStatus
+    | OciUploadStatus
+    | PulpOsTreeUploadStatus;
+};
+export type ComposeStatusError = {
+  id: number;
+  reason: string;
+  details?: any;
+};
+export type ImageStatus = {
+  status: ImageStatusValue;
+  upload_status?: UploadStatus;
+  upload_statuses?: UploadStatus[];
+  error?: ComposeStatusError;
+};
+export type KojiStatus = {
+  build_id?: number;
+};
+export type ComposeStatus = ObjectReference & {
+  status: ComposeStatusValue;
+  image_status: ImageStatus;
+  image_statuses?: ImageStatus[];
+  koji_status?: KojiStatus;
+};
+export type Error = ObjectReference & {
+  code: string;
+  reason: string;
+  operation_id: string;
+  details?: any;
+};
+export type PackageMetadata = {
+  type: string;
+  name: string;
+  version: string;
+  release: string;
+  epoch?: string;
+  arch: string;
+  sigmd5: string;
+  signature?: string;
+};
+export type ComposeMetadata = ObjectReference & {
+  /** Package list including NEVRA */
+  packages?: PackageMetadata[];
+  /** ID (hash) of the built commit */
+  ostree_commit?: string;
+};
+export type KojiLogs = {
+  init: any;
+  import: any;
+};
+export type ComposeLogs = ObjectReference & {
+  image_builds: object[];
+  koji?: KojiLogs;
+};
+export type ComposeManifests = ObjectReference & {
+  manifests: object[];
+};
+export type CloneComposeResponse = ObjectReference & {
+  id: string;
+};
+export type Awsec2CloneCompose = {
+  region: string;
+  share_with_accounts?: string[];
+};
+export type CloneComposeBody = Awsec2CloneCompose;
+export type CloneStatus = ObjectReference & UploadStatus;
+export type ComposeId = ObjectReference & {
+  id: string;
+};
+export type ImageTypes =
+  | 'aws'
+  | 'aws-ha-rhui'
+  | 'aws-rhui'
+  | 'aws-sap-rhui'
+  | 'azure'
+  | 'azure-eap7-rhui'
+  | 'azure-rhui'
+  | 'azure-sap-rhui'
+  | 'edge-commit'
+  | 'edge-container'
+  | 'edge-installer'
+  | 'gcp'
+  | 'gcp-rhui'
+  | 'guest-image'
+  | 'image-installer'
+  | 'iot-bootable-container'
+  | 'iot-commit'
+  | 'iot-container'
+  | 'iot-installer'
+  | 'iot-raw-image'
+  | 'iot-simplified-installer'
+  | 'live-installer'
+  | 'minimal-raw'
+  | 'oci'
+  | 'vsphere'
+  | 'vsphere-ova'
+  | 'wsl';
+export type Repository = {
+  /** Determines whether a valid subscription is required to access this repository. */
+  rhsm?: boolean;
+  baseurl?: string;
+  mirrorlist?: string;
+  metalink?: string;
+  /** GPG key used to sign packages in this repository. */
+  gpgkey?: string;
+  check_gpg?: boolean;
+  /** Enables gpg verification of the repository metadata
+   */
+  check_repo_gpg?: boolean;
+  ignore_ssl?: boolean;
+  /** Disables modularity filtering for this repository.
+   */
+  module_hotfixes?: boolean;
+  /** Naming package sets for a repository assigns it to a specific part
+    (pipeline) of the build process.
+     */
+  package_sets?: string[];
+};
+export type OsTree = {
+  url?: string;
+  /** A URL which, if set, is used for fetching content. Implies that `url` is set as well,
+    which will be used for metadata only.
+     */
+  contenturl?: string;
+  ref?: string;
+  /** Can be either a commit (example: 02604b2da6e954bd34b8b82a835e5a77d2b60ffa), or a branch-like reference (example: rhel/8/x86_64/edge)
+   */
+  parent?: string;
+  /** Determines whether a valid subscription manager (candlepin) identity is required to
+    access this repository. Consumer certificates will be used as client certificates when
+    fetching metadata and content.
+     */
+  rhsm?: boolean;
+};
+export type Awsec2UploadOptions = {
+  region: string;
+  snapshot_name?: string;
+  share_with_accounts: string[];
+};
+export type Awss3UploadOptions = {
+  region: string;
+  /** If set to false (the default value), a long, obfuscated URL
+    is returned. Its expiration might be sooner than for other upload
+    targets.
+
+    If set to true, a shorter URL is returned and
+    its expiration is the same as for the other upload targets.
+     */
+  public?: boolean;
+};
+export type GcpUploadOptions = {
+  /** The GCP region where the OS image will be imported to and shared from.
+    The value must be a valid GCP location. See https://cloud.google.com/storage/docs/locations.
+    If not specified, the multi-region location closest to the source
+    (source Storage Bucket location) is chosen automatically.
+     */
+  region: string;
+  /** Name of an existing STANDARD Storage class Bucket. */
+  bucket?: string;
+  /** The name to use for the imported and shared Compute Engine image.
+    The image name must be unique within the GCP project, which is used
+    for the OS image upload and import. If not specified a random
+    'composer-api-<uuid>' string is used as the image name.
+     */
+  image_name?: string;
+  /** List of valid Google accounts to share the imported Compute Engine image with.
+    Each string must contain a specifier of the account type. Valid formats are:
+      - 'user:{emailid}': An email address that represents a specific
+        Google account. For example, 'alice@example.com'.
+      - 'serviceAccount:{emailid}': An email address that represents a
+        service account. For example, 'my-other-app@appspot.gserviceaccount.com'.
+      - 'group:{emailid}': An email address that represents a Google group.
+        For example, 'admins@example.com'.
+      - 'domain:{domain}': The G Suite domain (primary) that represents all
+        the users of that domain. For example, 'google.com' or 'example.com'.
+    If not specified, the imported Compute Engine image is not shared with any
+    account.
+     */
+  share_with_accounts?: string[];
+};
+export type AzureUploadOptions = {
+  /** ID of the tenant where the image should be uploaded.
+    How to find it in the Azure Portal:
+    https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant
+     */
+  tenant_id: string;
+  /** ID of subscription where the image should be uploaded.
+   */
+  subscription_id: string;
+  /** Name of the resource group where the image should be uploaded.
+   */
+  resource_group: string;
+  /** Location of the provided resource_group, where the image should be uploaded and registered.
+    How to list all locations:
+    https://docs.microsoft.com/en-us/cli/azure/account?view=azure-cli-latest#az_account_list_locations'
+    If the location is not specified, it is deducted from the provided resource_group.
+     */
+  location?: string;
+  /** Name of the uploaded image. It must be unique in the given resource group.
+    If name is omitted from the request, a random one based on a UUID is
+    generated.
+     */
+  image_name?: string;
+};
+export type ContainerUploadOptions = {
+  /** Name for the created container image
+   */
+  name?: string;
+  /** Tag for the created container image
+   */
+  tag?: string;
+};
+export type LocalUploadOptions = {
+  /** This is used in combination with the OSBUILD_LOCALSAVE environmental
+    variable on the server to enable saving the compose locally. This
+    is for development use only, and is not available to users.
+     */
+  local_save: boolean;
+};
+export type OciUploadOptions = object;
+export type PulpOsTreeUploadOptions = {
+  /** Basepath for distributing the repository */
+  basepath: string;
+  /** Repository to import the ostree commit to */
+  repository?: string;
+  server_address?: string;
+};
+export type UploadOptions =
+  | Awsec2UploadOptions
+  | Awss3UploadOptions
+  | GcpUploadOptions
+  | AzureUploadOptions
+  | ContainerUploadOptions
+  | LocalUploadOptions
+  | OciUploadOptions
+  | PulpOsTreeUploadOptions;
+export type UploadTarget = {
+  /** The name of the upload target that matches the upload_options.
+   */
+  type: UploadTypes;
+  upload_options: UploadOptions;
+};
+export type ImageRequest = {
+  architecture: string;
+  image_type: ImageTypes;
+  repositories: Repository[];
+  ostree?: OsTree;
+  /** The type and options for multiple upload targets. Each item defines
+    a separate upload destination with its own options. Multiple
+    different targets as well as multiple targets of the same kind are
+    supported.
+     */
+  upload_targets?: UploadTarget[];
+  /** Top level upload options for a single upload target. If this is
+    defined, it is used with the default target type for the image type
+    and is combined with the targets defined in upload_targets.
+     */
+  upload_options?: UploadOptions;
+  /** Size of image, in bytes. When set to 0 the image size is a minimum
+    defined by the image type.
+     */
+  size?: any;
+};
+export type Container = {
+  /** Reference to the container to embed */
+  source: string;
+  /** Name to use for the container from the image */
+  name?: string;
+  /** Control TLS verifification */
+  tls_verify?: boolean;
+};
+export type Directory = {
+  /** Path to the directory */
+  path: string;
+  /** Permissions string for the directory in octal format */
+  mode?: string;
+  /** Owner of the directory as a user name or a uid */
+  user?: string | number;
+  /** Group of the directory as a group name or a gid */
+  group?: string | number;
+  /** Ensure that the parent directories exist */
+  ensure_parents?: boolean;
+};
+export type File = {
+  /** Path to the file */
+  path: string;
+  /** Permissions string for the file in octal format */
+  mode?: string;
+  /** Owner of the file as a uid or a user name */
+  user?: string | number;
+  /** Group of the file as a gid or a group name */
+  group?: string | number;
+  /** Contents of the file as plain text */
+  data?: string;
+  /** Ensure that the parent directories exist */
+  ensure_parents?: boolean;
+};
+export type Subscription = {
+  organization: string;
+  activation_key: string;
+  server_url: string;
+  base_url: string;
+  insights: boolean;
+  /** Optional flag to use rhc to register the system, which also always enables Insights.
+   */
+  rhc?: boolean;
+};
+export type User = {
+  name: string;
+  groups?: string[];
+  key?: string;
+  /** If the password starts with $6$, $5$, or $2b$ it will be stored as
+    an encrypted password. Otherwise it will be treated as a plain text
+    password.
+     */
+  password?: string;
+};
+export type CustomRepository = {
+  id: string;
+  name?: string;
+  filename?: string;
+  baseurl?: string[];
+  mirrorlist?: string;
+  metalink?: string;
+  enabled?: boolean;
+  gpgkey?: string[];
+  check_gpg?: boolean;
+  check_repo_gpg?: boolean;
+  ssl_verify?: boolean;
+  priority?: number;
+  module_hotfixes?: boolean;
+};
+export type OpenScapTailoring = {
+  selected?: string[];
+  unselected?: string[];
+};
+export type OpenScapjsonTailoring = {
+  profile_id: string;
+  filepath: string;
+};
+export type OpenScap = {
+  /** Puts a specified policy ID in the RHSM facts, so that any instances registered to
+    insights will be automatically connected to the compliance policy in the console.
+     */
+  policy_id?: string;
+  profile_id: string;
+  tailoring?: OpenScapTailoring;
+  json_tailoring?: OpenScapjsonTailoring;
+};
+export type Filesystem = {
+  mountpoint: string;
+  /** size of the filesystem in bytes */
+  min_size: any;
+};
+export type Services = {
+  /** List of services to enable by default */
+  enabled?: string[];
+  /** List of services to disable by default */
+  disabled?: string[];
+  /** List of services to mask by default */
+  masked?: string[];
+};
+export type Kernel = {
+  /** Name of the kernel to use */
+  name?: string;
+  /** Appends arguments to the bootloader kernel command line */
+  append?: string;
+};
+export type Group = {
+  /** Name of the group to create */
+  name: string;
+  /** Group id of the group to create (optional) */
+  gid?: number;
+};
+export type Timezone = {
+  /** Name of the timezone, defaults to UTC */
+  timezone?: string;
+  /** List of ntp servers */
+  ntpservers?: string[];
+};
+export type Locale = {
+  /** List of locales to be installed, the first one becomes primary, subsequent ones are secondary
+   */
+  languages?: string[];
+  /** Sets the keyboard layout */
+  keyboard?: string;
+};
+export type FirewallServices = {
+  /** List of services to enable */
+  enabled?: string[];
+  /** List of services to disable */
+  disabled?: string[];
+};
+export type FirewallCustomization = {
+  /** List of ports (or port ranges) and protocols to open */
+  ports?: string[];
+  services?: FirewallServices;
+};
+export type Fdo = {
+  manufacturing_server_url?: string;
+  diun_pub_key_insecure?: string;
+  diun_pub_key_hash?: string;
+  diun_pub_key_root_certs?: string;
+  di_mfg_string_type_mac_iface?: string;
+};
+export type IgnitionEmbedded = {
+  config: string;
+};
+export type IgnitionFirstboot = {
+  /** Provisioning URL */
+  url: string;
+};
+export type Ignition = {
+  embedded?: IgnitionEmbedded;
+  firstboot?: IgnitionFirstboot;
+};
+export type Fips = {
+  /** Enables the system FIPS mode */
+  enabled?: boolean;
+};
+export type Installer = {
+  unattended?: boolean;
+  'sudo-nopasswd'?: string[];
+};
+export type ImportKeys = {
+  files?: string[];
+};
+export type RpmCustomization = {
+  import_keys?: ImportKeys;
+};
+export type DnfPluginConfig = {
+  enabled?: boolean;
+};
+export type SubManDnfPluginsConfig = {
+  product_id?: DnfPluginConfig;
+  subscription_manager?: DnfPluginConfig;
+};
+export type SubManRhsmConfig = {
+  manage_repos?: boolean;
+};
+export type SubManRhsmCertdConfig = {
+  auto_registration?: boolean;
+};
+export type SubManConfig = {
+  rhsm?: SubManRhsmConfig;
+  rhsmcertd?: SubManRhsmCertdConfig;
+};
+export type RhsmConfig = {
+  dnf_plugins?: SubManDnfPluginsConfig;
+  subscription_manager?: SubManConfig;
+};
+export type RhsmCustomization = {
+  config?: RhsmConfig;
+};
+export type Customizations = {
+  containers?: Container[];
+  directories?: Directory[];
+  files?: File[];
+  subscription?: Subscription;
+  packages?: string[];
+  users?: User[];
+  /** Extra repositories for packages specified in customizations. These
+    repositories will only be used to depsolve and retrieve packages
+    for the OS itself (they will not be available for the build root or
+    any other part of the build process). The package_sets field for these
+    repositories is ignored.
+     */
+  payload_repositories?: Repository[];
+  /** Extra repositories for packages specified in customizations. These
+    repositories will be used to depsolve and retrieve packages. Additionally,
+    these packages will be saved and imported to the `/etc/yum.repos.d/` directory
+    on the image
+     */
+  custom_repositories?: CustomRepository[];
+  openscap?: OpenScap;
+  filesystem?: Filesystem[];
+  services?: Services;
+  /** Configures the hostname */
+  hostname?: string;
+  kernel?: Kernel;
+  /** List of groups to create */
+  groups?: Group[];
+  timezone?: Timezone;
+  locale?: Locale;
+  firewall?: FirewallCustomization;
+  /** Name of the installation device, currently only useful for the edge-simplified-installer type
+   */
+  installation_device?: string;
+  fdo?: Fdo;
+  ignition?: Ignition;
+  /** Select how the disk image will be partitioned. 'auto-lvm' will use raw unless
+    there are one or more mountpoints in which case it will use LVM. 'lvm' always
+    uses LVM, even when there are no extra mountpoints. 'raw' uses raw partitions
+    even when there are one or more mountpoints.
+     */
+  partitioning_mode?: 'raw' | 'lvm' | 'auto-lvm';
+  fips?: Fips;
+  installer?: Installer;
+  rpm?: RpmCustomization;
+  rhsm?: RhsmCustomization;
+};
+export type Koji = {
+  server: string;
+  task_id: number;
+  name: string;
+  version: string;
+  release: string;
+};
+export type Package = {
+  /** Name of the package to install. File globbing is supported,
+    eg. 'openssh-*'
+     */
+  name: string;
+  /** Optional version of the package to install. If left blank the
+    latest available version will be used. Wildcards are supported
+    eg. '4.11.*'
+     */
+  version?: string;
+};
+export type PackageGroup = {
+  /** Package group name */
+  name: string;
+};
+export type SshKey = {
+  /** User to configure the ssh key for */
+  user: string;
+  /** Adds the key to the user's authorized_keys file */
+  key: string;
+};
+export type BlueprintUser = {
+  name: string;
+  description?: string;
+  /** If the password starts with $6$, $5$, or $2b$ it will be stored as
+    an encrypted password. Otherwise it will be treated as a plain text
+    password.
+     */
+  password?: string;
+  /** ssh public key */
+  key?: string;
+  /** The user's home directory */
+  home?: string;
+  /** Login shell to use */
+  shell?: string;
+  /** A list of additional groups to add the user to */
+  groups?: string[];
+  /** User id to use instead of the default */
+  uid?: number;
+  /** Group id to use instead of the default */
+  gid?: number;
+};
+export type FirewallZones = {
+  /** name of the zone, if left empty the sources will apply to
+    the default zone.
+     */
+  name?: string;
+  /** List of sources for the zone */
+  sources?: string[];
+};
+export type BlueprintFirewall = {
+  /** List of ports (or port ranges) and protocols to open */
+  ports?: string[];
+  services?: FirewallServices;
+  zones?: FirewallZones[];
+};
+export type BlueprintFilesystem = {
+  mountpoint: string;
+  /** size of the filesystem in bytes */
+  minsize: any;
+};
+export type BlueprintOpenScap = {
+  /** Puts a specified policy ID in the RHSM facts, so that any instances registered to
+    insights will be automatically connected to the compliance policy in the console.
+     */
+  policy_id?: string;
+  profile_id: string;
+  datastream?: string;
+  tailoring?: OpenScapTailoring;
+  json_tailoring?: OpenScapjsonTailoring;
+};
+export type BlueprintFile = {
+  /** Path to the file */
+  path: string;
+  /** Permissions string for the file in octal format */
+  mode?: string;
+  /** Owner of the file as a uid or a user name */
+  user?: string | number;
+  /** Group of the file as a gid or a group name */
+  group?: string | number;
+  /** Contents of the file as plain text */
+  data?: string;
+};
+export type BlueprintRepository = {
+  id: string;
+  baseurls?: string[];
+  gpgkeys?: string[];
+  metalink?: string;
+  mirrorlist?: string;
+  name?: string;
+  priority?: number;
+  enabled?: boolean;
+  gpgcheck?: boolean;
+  repo_gpgcheck?: boolean;
+  sslverify?: boolean;
+  filename?: string;
+  /** Disables modularity filtering for this repository.
+   */
+  module_hotfixes?: boolean;
+};
+export type BlueprintCustomizations = {
+  /** Configures the hostname */
+  hostname?: string;
+  kernel?: Kernel;
+  /** List of ssh keys */
+  sshkey?: SshKey[];
+  /** List of users to create */
+  user?: BlueprintUser[];
+  /** List of groups to create */
+  group?: Group[];
+  timezone?: Timezone;
+  locale?: Locale;
+  firewall?: BlueprintFirewall;
+  services?: Services;
+  /** List of filesystem mountpoints to create */
+  filesystem?: BlueprintFilesystem[];
+  /** Name of the installation device, currently only useful for the edge-simplified-installer type
+   */
+  installation_device?: string;
+  /** Select how the disk image will be partitioned. 'auto-lvm' will use raw unless
+    there are one or more mountpoints in which case it will use LVM. 'lvm' always
+    uses LVM, even when there are no extra mountpoints. 'raw' uses raw partitions
+    even when there are one or more mountpoints.
+     */
+  partitioning_mode?: 'raw' | 'lvm' | 'auto-lvm';
+  fdo?: Fdo;
+  openscap?: BlueprintOpenScap;
+  ignition?: Ignition;
+  /** Directories to create in the final artifact */
+  directories?: Directory[];
+  /** Files to create in the final artifact */
+  files?: BlueprintFile[];
+  /** Repositories to write to /etc/yum.repos.d/ in the final image. Note
+    that these are not used at build time.
+     */
+  repositories?: BlueprintRepository[];
+  /** Enable FIPS mode */
+  fips?: boolean;
+  installer?: Installer;
+  rpm?: RpmCustomization;
+  rhsm?: RhsmCustomization;
+};
+export type Blueprint = {
+  name: string;
+  description?: string;
+  /** A semver version number */
+  version?: string;
+  /** The distribution to use for the compose. If left empty the host
+    distro will be used.
+     */
+  distro?: string;
+  /** Packages to be installed */
+  packages?: Package[];
+  /** An alias for packages, retained for backwards compatability
+   */
+  modules?: Package[];
+  /** Package groups to be installed */
+  groups?: PackageGroup[];
+  /** Container images to embed into the final artfact */
+  containers?: Container[];
+  customizations?: BlueprintCustomizations;
+};
+export type ComposeRequest = {
+  distribution: string;
+  image_request?: ImageRequest;
+  image_requests?: ImageRequest[];
+  customizations?: Customizations;
+  koji?: Koji;
+  blueprint?: Blueprint;
+};
+export const {
+  useGetComposeStatusQuery,
+  useLazyGetComposeStatusQuery,
+  useGetComposeMetadataQuery,
+  useLazyGetComposeMetadataQuery,
+  useGetComposeLogsQuery,
+  useLazyGetComposeLogsQuery,
+  useGetComposeManifestsQuery,
+  useLazyGetComposeManifestsQuery,
+  usePostCloneComposeMutation,
+  useGetCloneStatusQuery,
+  useLazyGetCloneStatusQuery,
+  usePostComposeMutation,
+} = injectedRtkApi;

--- a/src/store/emptyCloudApi.ts
+++ b/src/store/emptyCloudApi.ts
@@ -1,0 +1,10 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+import { CLOUD_API } from '../constants';
+
+// initialize an empty api service that we'll inject endpoints into later as needed
+export const emptyCloudApi = createApi({
+    reducerPath: 'cloudApi',
+    baseQuery: fetchBaseQuery({ baseUrl: window.location.origin + CLOUD_API }),
+    endpoints: () => ({}),
+});

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import promiseMiddleware from 'redux-promise-middleware';
 
 import { blueprintsSlice } from './BlueprintSlice';
+import { cloudApi } from './cloudApi';
 import { contentSourcesApi } from './contentSourcesApi';
 import { edgeApi } from './edgeApi';
 import { imageBuilderApi } from './enhancedImageBuilderApi';
@@ -24,6 +25,7 @@ export const reducer = combineReducers({
   [imageBuilderApi.reducerPath]: imageBuilderApi.reducer,
   [rhsmApi.reducerPath]: rhsmApi.reducer,
   [provisioningApi.reducerPath]: provisioningApi.reducer,
+  [cloudApi.reducerPath]: cloudApi.reducer,
   notifications: notificationsReducer,
   wizard: wizardSlice,
   blueprints: blueprintsSlice.reducer,
@@ -94,7 +96,8 @@ export const middleware = (getDefaultMiddleware: Function) =>
       contentSourcesApi.middleware,
       imageBuilderApi.middleware,
       rhsmApi.middleware,
-      provisioningApi.middleware
+      provisioningApi.middleware,
+      cloudApi.middleware
     );
 
 export const store = configureStore({ reducer, middleware });


### PR DESCRIPTION
This commit adds the Cloud API to RTK Query in preparation of porting cloudapi source code to image-builder-frontend
* paste entire cloudApi schema
* setup cloudApi in api/config file
* create new emptyCludApi.ts file
* add the new end point to the store
* npm run api that generate the cloudApi.ts file with all the endpoints