### PR TITLE
Insights Compliance integration (HMS-3829)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ contentSourcesApi.ts
 rhsmApi.ts
 provisioningApi.ts
 edgeApi.ts
+complianceApi.ts

--- a/api/codegen.sh
+++ b/api/codegen.sh
@@ -6,6 +6,7 @@ npx @rtk-query/codegen-openapi ./api/config/rhsm.ts &
 npx @rtk-query/codegen-openapi ./api/config/contentSources.ts &
 npx @rtk-query/codegen-openapi ./api/config/provisioning.ts &
 npx @rtk-query/codegen-openapi ./api/config/edge.ts &
+npx @rtk-query/codegen-openapi ./api/config/compliance.ts &
 
 # Wait for all background jobs to finish
 wait

--- a/api/config/compliance.ts
+++ b/api/config/compliance.ts
@@ -7,7 +7,7 @@ const config: ConfigFile = {
   outputFile: '../../src/store/complianceApi.ts',
   exportName: 'complianceApi',
   hooks: true,
-  filterEndpoints: [],
+  filterEndpoints: ['policies', 'policy'],
 };
 
 export default config;

--- a/api/config/compliance.ts
+++ b/api/config/compliance.ts
@@ -1,0 +1,13 @@
+import type { ConfigFile } from '@rtk-query/codegen-openapi';
+
+const config: ConfigFile = {
+  schemaFile: '../schema/compliance.json',
+  apiFile: '../../src/store/emptyComplianceApi.ts',
+  apiImport: 'emptyComplianceApi',
+  outputFile: '../../src/store/complianceApi.ts',
+  exportName: 'complianceApi',
+  hooks: true,
+  filterEndpoints: [],
+};
+
+export default config;

--- a/api/pull.sh
+++ b/api/pull.sh
@@ -2,3 +2,5 @@
 
 # Download the most up-to-date imageBuilder.yaml file and overwrite the existing one
 curl https://raw.githubusercontent.com/osbuild/image-builder/main/internal/v1/api.yaml -o ./api/schema/imageBuilder.yaml
+
+curl https://console.redhat.com/api/compliance/v2/openapi.json -o ./api/schema/compliance.json

--- a/api/schema/compliance.json
+++ b/api/schema/compliance.json
@@ -1,0 +1,16628 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Cloud Services for RHEL Compliance API v2",
+    "version": "v2",
+    "description": "UNDER DEVELOPMENT: This version of the API is not fully done and some parts of it might change! This is the API for Cloud Services for RHEL Compliance. You can find out more about Red Hat Cloud Services for RHEL at [https://console.redhat.com/](https://console.redhat.com/)"
+  },
+  "servers": [
+    {
+      "url": "https://{defaultHost}/api/compliance/v2",
+      "variables": {
+        "defaultHost": {
+          "default": "console.redhat.com"
+        }
+      }
+    }
+  ],
+  "paths": {
+    "/policies": {
+      "get": {
+        "summary": "Request Policies",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "os_major_version",
+                  "total_system_count",
+                  "business_objective",
+                  "compliance_threshold",
+                  "title:asc",
+                  "title:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc",
+                  "total_system_count:asc",
+                  "total_system_count:desc",
+                  "business_objective:asc",
+                  "business_objective:desc",
+                  "compliance_threshold:asc",
+                  "compliance_threshold:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Policies are searchable using attributes `title`, `os_major_version`, and `os_minor_version`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Lists Policies",
+        "operationId": "Policies",
+        "responses": {
+          "200": {
+            "description": "Lists Policies",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Policies": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "08bfd2a8-4cc8-48c8-ace4-0ee507c0ec83",
+                          "title": "Harum exercitationem omnis ut.",
+                          "description": "Ullam fugiat rerum. Qui quasi delectus. Doloribus voluptates aut.",
+                          "business_objective": null,
+                          "compliance_threshold": 65.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Quo accusantium amet incidunt.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_1ce10bb4faa2e0cd3fa5be77eeffc603"
+                        },
+                        {
+                          "id": "0cfec84e-0ace-4e1b-b545-4b9200cb7757",
+                          "title": "Dignissimos enim ut et.",
+                          "description": "Earum nemo expedita. Qui quae enim. Sit consectetur consequatur.",
+                          "business_objective": null,
+                          "compliance_threshold": 3.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Aspernatur veritatis a tempore.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_5b3985119bcd316cf07c3f08114b14f3"
+                        },
+                        {
+                          "id": "0d575872-3f57-4df4-9aca-355268cb5f28",
+                          "title": "Nostrum error possimus molestias.",
+                          "description": "Voluptatem iure temporibus. Aliquam ut ut. Impedit optio est.",
+                          "business_objective": null,
+                          "compliance_threshold": 98.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Consequuntur vero sequi suscipit.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_d2531f11eb1aada6055f3033df356695"
+                        },
+                        {
+                          "id": "171bc326-7689-4e1c-99ff-b2ca911c891c",
+                          "title": "Id voluptate tempora nobis.",
+                          "description": "Consequatur non voluptas. Perferendis id eos. Voluptates ipsum omnis.",
+                          "business_objective": null,
+                          "compliance_threshold": 37.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Reiciendis vel et quibusdam.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_cdf5057e531479dacdd6ae42e4e8ece7"
+                        },
+                        {
+                          "id": "1f5fb80b-585a-4a6c-ad68-399c09faa647",
+                          "title": "Asperiores doloremque voluptatem ut.",
+                          "description": "Ut eius optio. Quae voluptatibus molestiae. Eum occaecati praesentium.",
+                          "business_objective": null,
+                          "compliance_threshold": 83.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Qui omnis tempore repellendus.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_cb6f26110d6fcf52103679e2c8731fbc"
+                        },
+                        {
+                          "id": "224eec1a-6c85-4730-a400-ef2a71a29eb1",
+                          "title": "Omnis nam autem non.",
+                          "description": "Aliquid occaecati ut. Tempore assumenda reiciendis. Natus tempora ducimus.",
+                          "business_objective": null,
+                          "compliance_threshold": 52.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Architecto doloribus eos dolores.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_a9f7c64c0fc8870642c121e4912fb0db"
+                        },
+                        {
+                          "id": "227e33f8-b823-4167-8e49-1cf4cd7da91e",
+                          "title": "Distinctio necessitatibus enim et.",
+                          "description": "Illum doloremque sapiente. Sint culpa dolore. Dolor autem fuga.",
+                          "business_objective": null,
+                          "compliance_threshold": 8.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Quo repellendus dolorem aut.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_6507b132bd790706e045016e8064b6d9"
+                        },
+                        {
+                          "id": "25e82f75-cc06-4ffa-978d-9e582572536a",
+                          "title": "Laborum molestiae enim ullam.",
+                          "description": "Et reprehenderit ut. Et autem quidem. Fuga officiis odio.",
+                          "business_objective": null,
+                          "compliance_threshold": 67.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Et est quaerat quis.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_4f4246bfc7486810510d045ea3f8e516"
+                        },
+                        {
+                          "id": "47490333-a491-4794-9219-bf6a25d2136c",
+                          "title": "Voluptatem nisi dolores nobis.",
+                          "description": "Magnam veritatis dolorem. Aut nesciunt rem. Consectetur dignissimos est.",
+                          "business_objective": null,
+                          "compliance_threshold": 92.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Et corporis ut cum.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_e89509d5ec55fd8e0f1e6d07bf6d5453"
+                        },
+                        {
+                          "id": "5e06dd86-420c-4f40-82ec-a38824af3fbf",
+                          "title": "Quam commodi incidunt animi.",
+                          "description": "Quos error libero. Vel ut error. Quam nisi et.",
+                          "business_objective": null,
+                          "compliance_threshold": 8.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Quia tenetur aut ullam.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_c396a87cb29a5143448c5c50f54c3a7b"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies?limit=10&offset=0",
+                        "last": "/api/compliance/v2/policies?limit=10&offset=20",
+                        "next": "/api/compliance/v2/policies?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Policies sorted by \"os_major_version:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "00c7f979-4b7f-4495-a63d-b7596b5113df",
+                          "title": "Velit est occaecati consequuntur.",
+                          "description": "Occaecati assumenda in. Velit nobis consequatur. Pariatur numquam quae.",
+                          "business_objective": null,
+                          "compliance_threshold": 99.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Labore repellat qui iure.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_370a471f6dda3065604d3585348db5cb"
+                        },
+                        {
+                          "id": "0e6836bd-0572-4e34-aed9-97ff0188a66e",
+                          "title": "Omnis aliquid maxime quaerat.",
+                          "description": "Eum dolorum eum. Autem omnis officiis. Voluptas et ut.",
+                          "business_objective": null,
+                          "compliance_threshold": 95.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Facere saepe odit totam.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_a03c93c8135761b0622ea1f876c1a2de"
+                        },
+                        {
+                          "id": "19f98337-1549-4666-9123-633f1774c0fc",
+                          "title": "Magnam ut voluptas error.",
+                          "description": "Et ut veritatis. A quam et. Omnis sit ducimus.",
+                          "business_objective": null,
+                          "compliance_threshold": 69.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Et sit consequatur harum.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_1fa111958cd8b2d766ad3f618404cfc7"
+                        },
+                        {
+                          "id": "1f543a35-265c-4ecd-b1af-9c7fc3e69f31",
+                          "title": "Deserunt dolorem et consectetur.",
+                          "description": "Omnis voluptate dolorem. Quaerat aut cum. Ad aliquid voluptate.",
+                          "business_objective": null,
+                          "compliance_threshold": 7.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Unde non dolorem iste.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_67da77f8257715bd3403a85f8676d0a2"
+                        },
+                        {
+                          "id": "1f765d81-02f2-403b-b6f5-c2a0087505e5",
+                          "title": "Aut omnis illo ad.",
+                          "description": "Ipsam est qui. Consequatur aut dolores. Atque consequuntur qui.",
+                          "business_objective": null,
+                          "compliance_threshold": 11.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Qui sunt blanditiis dolores.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_a93d77e46103666ca1a96914dbf817f7"
+                        },
+                        {
+                          "id": "32d6f2a3-e25c-4fb2-aabd-d97d93c93fda",
+                          "title": "Perferendis hic et suscipit.",
+                          "description": "Eum perspiciatis fugit. Mollitia dolorem nulla. Praesentium ut dolor.",
+                          "business_objective": null,
+                          "compliance_threshold": 14.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Dolore voluptatem deserunt sunt.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_cc0a8f390dd2df60609c6fe9651eb33f"
+                        },
+                        {
+                          "id": "35933f82-68d4-4218-b52b-187b8dffde15",
+                          "title": "Aut quod quis et.",
+                          "description": "Vel qui et. Maxime ea commodi. Amet rerum quae.",
+                          "business_objective": null,
+                          "compliance_threshold": 89.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Hic quia quod nobis.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_1bf3ff3c09fe2fba442572f82345c4d8"
+                        },
+                        {
+                          "id": "3bff8b47-ff41-4d76-a62c-9c43e31a2479",
+                          "title": "Similique corrupti aliquid id.",
+                          "description": "Ut recusandae dolor. Laborum sequi veritatis. Enim dolorum id.",
+                          "business_objective": null,
+                          "compliance_threshold": 95.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Mollitia nihil sed sapiente.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_76fddda0146369b8e737eb220309bca8"
+                        },
+                        {
+                          "id": "3f35bc92-9916-4c30-b25d-290926d8748a",
+                          "title": "Iure odit veniam quia.",
+                          "description": "Natus vitae accusamus. Vel alias sint. Laudantium id et.",
+                          "business_objective": null,
+                          "compliance_threshold": 66.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Sit minima qui accusamus.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_8613ee01236aa75ccfd79694b703bd6a"
+                        },
+                        {
+                          "id": "5eca814c-1a39-4647-b380-8db8d4ad1c90",
+                          "title": "Sequi sunt ipsa laudantium.",
+                          "description": "Nisi cupiditate beatae. Magnam vel aut. Similique labore magnam.",
+                          "business_objective": null,
+                          "compliance_threshold": 67.0,
+                          "total_system_count": 0,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Enim est laboriosam repudiandae.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_1d204cfc390c87c483165622b156de90"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "os_major_version"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies?limit=10&offset=0&sort_by=os_major_version",
+                        "last": "/api/compliance/v2/policies?limit=10&offset=20&sort_by=os_major_version",
+                        "next": "/api/compliance/v2/policies?limit=10&offset=10&sort_by=os_major_version"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Policies filtered by \"(os_major_version=8)\"": {
+                    "value": {
+                      "data": [],
+                      "meta": {
+                        "total": 0,
+                        "filter": "(os_major_version=8)",
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies?filter=%28os_major_version%3D8%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/policies?filter=%28os_major_version%3D8%29&limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/policy"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Create a Policy",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Create a Policy with the provided attributes",
+        "operationId": "CreatePolicy",
+        "responses": {
+          "201": {
+            "description": "Creates a Policy",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Response example": {
+                    "value": {
+                      "data": {
+                        "id": "aa290518-1e6c-40e7-afe0-b929259ce1bd",
+                        "title": "Foo",
+                        "description": "Hello World",
+                        "business_objective": "Serious Business Objective",
+                        "compliance_threshold": 33.3,
+                        "total_system_count": null,
+                        "type": "policy",
+                        "os_major_version": 7,
+                        "profile_title": "Sit quibusdam omnis quo.",
+                        "ref_id": "xccdf_org.ssgproject.content_profile_e1d51ef3c1a7d695c48abbbbe6f5be21"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/policy"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/policy"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{policy_id}": {
+      "get": {
+        "summary": "Request a Policy",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Returns a Policy",
+        "operationId": "Policy",
+        "responses": {
+          "200": {
+            "description": "Returns a Policy",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Policy": {
+                    "value": {
+                      "data": {
+                        "id": "7b321367-944b-4006-ba19-f940402e4146",
+                        "title": "Iusto dolorum atque hic.",
+                        "description": "Quae quis officia. Omnis nam est. Ut facere quas.",
+                        "business_objective": null,
+                        "compliance_threshold": 33.0,
+                        "total_system_count": 0,
+                        "type": "policy",
+                        "os_major_version": 7,
+                        "profile_title": "Nisi dolores nam earum.",
+                        "ref_id": "xccdf_org.ssgproject.content_profile_d2b855a916452e021379a22f27fed444"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/policy"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Policy": {
+                    "value": {
+                      "errors": [
+                        "V2::Policy not found with ID cd837f8a-aa1d-4aba-860c-9ac7f5ddd638"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a Policy",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Updates a Policy with the provided attributes",
+        "operationId": "UpdatePolicy",
+        "responses": {
+          "202": {
+            "description": "Updates a Policy",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns the updated Policy": {
+                    "value": {
+                      "data": {
+                        "id": "a82b2249-5082-4779-bd6c-20b8a1b443ef",
+                        "title": "Eius id aut beatae.",
+                        "description": "Nulla dolores magni. Ipsam corrupti rerum. Est praesentium quos.",
+                        "business_objective": null,
+                        "compliance_threshold": 100.0,
+                        "total_system_count": 0,
+                        "type": "policy",
+                        "os_major_version": 7,
+                        "profile_title": "Autem maiores aut magni.",
+                        "ref_id": "xccdf_org.ssgproject.content_profile_c72ad7899a31e970c6deb857d3e4699a"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/policy"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/policy_update"
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a Policy",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Deletes a Policy",
+        "operationId": "DeletePolicy",
+        "responses": {
+          "202": {
+            "description": "Deletes a Policy",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Deletes a Policy": {
+                    "value": {
+                      "data": {
+                        "id": "8833431d-5432-4752-bff7-6b29be74e36c",
+                        "title": "Voluptates minus deleniti cumque.",
+                        "description": "Accusamus autem explicabo. Fuga quia accusamus. Illum dolores non.",
+                        "business_objective": null,
+                        "compliance_threshold": 33.0,
+                        "total_system_count": 0,
+                        "type": "policy",
+                        "os_major_version": 7,
+                        "profile_title": "Fuga nisi cumque dolorem.",
+                        "ref_id": "xccdf_org.ssgproject.content_profile_32af9cd09e0ff3179267ade1fe8f4394"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/policy"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/systems/{system_id}/policies": {
+      "get": {
+        "summary": "Request Policies assigned to a System",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "os_major_version",
+                  "total_system_count",
+                  "business_objective",
+                  "compliance_threshold",
+                  "title:asc",
+                  "title:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc",
+                  "total_system_count:asc",
+                  "total_system_count:desc",
+                  "business_objective:asc",
+                  "business_objective:desc",
+                  "compliance_threshold:asc",
+                  "compliance_threshold:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Policies are searchable using attributes `title`, `os_major_version`, and `os_minor_version`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "system_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Systems"
+        ],
+        "description": "Lists Policies under a System",
+        "operationId": "SystemsPolicies",
+        "responses": {
+          "200": {
+            "description": "Lists Policies",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Policies under a System": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "05f3b077-61ab-4402-9759-11242e28c21c",
+                          "title": "Pariatur voluptatum molestiae tenetur.",
+                          "description": "Labore consequatur magni. Temporibus aut suscipit. Maxime vitae quo.",
+                          "business_objective": null,
+                          "compliance_threshold": 49.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Magnam possimus qui et.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_1f6eec11d215315ae53debfa8c5c458e"
+                        },
+                        {
+                          "id": "08d7f16f-c170-4d9a-8377-cbd88ae5708e",
+                          "title": "Eius magnam suscipit consequuntur.",
+                          "description": "Cum minus quis. Qui et minima. Eaque magnam nam.",
+                          "business_objective": null,
+                          "compliance_threshold": 28.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Velit quia minus alias.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_72b6fb28e92716bda6a1defb20c894ba"
+                        },
+                        {
+                          "id": "107c2a3c-f841-422d-ac56-dc1c0ae9a3da",
+                          "title": "Repellat veritatis cupiditate autem.",
+                          "description": "Velit ut eligendi. Consequatur eum labore. Architecto qui unde.",
+                          "business_objective": null,
+                          "compliance_threshold": 97.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Et aut laboriosam natus.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_f00c73d99a1c8a91afc9c8eeab324589"
+                        },
+                        {
+                          "id": "1435224b-7ed7-43dc-a890-ae6b35509b3e",
+                          "title": "Modi molestias temporibus et.",
+                          "description": "Vitae autem fugit. Consectetur quis suscipit. Laboriosam provident iste.",
+                          "business_objective": null,
+                          "compliance_threshold": 66.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Et inventore quod doloribus.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_4ff70f8e426497aa0227390f10c9ad88"
+                        },
+                        {
+                          "id": "1724336a-0372-4a76-8ceb-99d23b50439e",
+                          "title": "Deserunt exercitationem eos perferendis.",
+                          "description": "Consequatur commodi voluptate. Ducimus dolor maxime. Asperiores id nihil.",
+                          "business_objective": null,
+                          "compliance_threshold": 83.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Sunt earum vel doloremque.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_3a3a1817dd3eb4c275a760a3711deaeb"
+                        },
+                        {
+                          "id": "1f8c71e7-7ab9-49fb-86b7-bbb5e06714f5",
+                          "title": "In eos error tempora.",
+                          "description": "Et iste quod. Non aut voluptas. Voluptas tenetur sit.",
+                          "business_objective": null,
+                          "compliance_threshold": 58.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Voluptatibus alias quia inventore.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_3aefd36192f0ebea259d2dd31833d0ef"
+                        },
+                        {
+                          "id": "282e4365-4bf2-49f1-b233-55388a658e51",
+                          "title": "Inventore in vel soluta.",
+                          "description": "Minus dolor nam. Magni ullam sit. Voluptates aliquid et.",
+                          "business_objective": null,
+                          "compliance_threshold": 99.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Architecto labore incidunt in.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_3108e5f6360faadcfa1595addf36bead"
+                        },
+                        {
+                          "id": "28c24f4d-c802-4d6f-bf96-2c6664c57133",
+                          "title": "Ex et nam molestias.",
+                          "description": "Doloremque fugit eveniet. Sapiente nostrum magnam. Saepe officiis sed.",
+                          "business_objective": null,
+                          "compliance_threshold": 79.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Culpa sint beatae magni.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_a8da034d2fcbcf2f3f4a7abf8dc3d93e"
+                        },
+                        {
+                          "id": "2a9ebbc1-b473-4d50-ae59-ad57257bd83a",
+                          "title": "Impedit quidem et molestias.",
+                          "description": "Voluptas deserunt voluptas. Doloremque dolor nostrum. Perspiciatis possimus vel.",
+                          "business_objective": null,
+                          "compliance_threshold": 42.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Eius veritatis voluptates adipisci.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_3457d28e015ffcf908715db97af15cfb"
+                        },
+                        {
+                          "id": "2d66b6b8-9dc7-4733-b47a-9ee68260f033",
+                          "title": "Fugiat laborum ea quae.",
+                          "description": "Incidunt ut velit. Facere laboriosam architecto. Repellat fugit blanditiis.",
+                          "business_objective": null,
+                          "compliance_threshold": 12.0,
+                          "total_system_count": 1,
+                          "type": "policy",
+                          "os_major_version": 7,
+                          "profile_title": "Incidunt rem ut qui.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_e566ac22a3b00bad60fe40c3ad5b4be7"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/systems/1c078941-6124-4e1f-9ba5-4674a87c4049/policies?limit=10&offset=0",
+                        "last": "/api/compliance/v2/systems/1c078941-6124-4e1f-9ba5-4674a87c4049/policies?limit=10&offset=20",
+                        "next": "/api/compliance/v2/systems/1c078941-6124-4e1f-9ba5-4674a87c4049/policies?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/policy"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/profiles": {
+      "get": {
+        "summary": "Request Profiles",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "title:asc",
+                  "title:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Profiles are searchable using attributes `title` and `ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Lists Profiles",
+        "operationId": "Profiles",
+        "responses": {
+          "200": {
+            "description": "Lists Profiles",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Profiles": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "17adf173-e66b-480f-80b4-8a0efc8da1da",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_1c46e2826e4e66abd33095e4d9f09a45",
+                          "title": "Dolore laboriosam sint atque.",
+                          "description": "Quia aliquid quae. Dolore sint ut. Labore ratione tenetur.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "19d43551-0c47-43c9-924e-dc6cce01d9a0",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_93d63661d36cbb8b091e9e90cc2445c1",
+                          "title": "Molestias id quaerat eum.",
+                          "description": "Est est illum. Alias unde vel. Quas enim libero.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "2c3175e6-3e6d-4767-98a2-ca707dfff851",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_9ede2a05c26024c4aa94f6e4dea09ab6",
+                          "title": "Minima occaecati velit velit.",
+                          "description": "Quis nisi veritatis. Fugiat velit quia. Deserunt sequi aut.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "4f099176-a7eb-4ad7-bd55-4b866d075240",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_d34426df880e92d3dd6f677c4b4a6bd9",
+                          "title": "Nemo dolores et sit.",
+                          "description": "Accusantium debitis rerum. Fugit facilis officia. Exercitationem illo perspiciatis.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "577bda6e-30eb-4ed6-8d57-b97ded9b6f2d",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_866cc3d99e18f6a87fedc24266acc8d2",
+                          "title": "Veritatis placeat explicabo tempora.",
+                          "description": "Repudiandae reprehenderit alias. Dolorem totam rerum. Et repudiandae necessitatibus.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "6f476b01-ec64-48fb-acc5-5a6764c7f65b",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_3411faac1bf93383ef6f31c5c8f20a98",
+                          "title": "Eius quas saepe necessitatibus.",
+                          "description": "Quod asperiores non. Non eum ut. Labore enim voluptas.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "830e59dc-e51d-4438-ae64-aedbb3c1b554",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_6eb59f0224e1d77d8bfcd6683c27b5e6",
+                          "title": "Perspiciatis ut enim sit.",
+                          "description": "Alias ad eos. Provident possimus magni. Veniam libero aut.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "835b39d2-0a01-45ac-8d20-4f50da0e06f6",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_133dfe7e25cc800db8c1ee73d9d676ee",
+                          "title": "Perspiciatis facilis ratione voluptas.",
+                          "description": "Et et quam. Officiis repellat ex. Rerum quis vel.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "8ad3f6dd-d20b-4e7f-a714-dbaaa2ae394b",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_e0ecf7f97fc2f4aa8b2b502279fc6caa",
+                          "title": "Accusamus provident iure dolores.",
+                          "description": "Quasi iure earum. Et occaecati repudiandae. Aliquam voluptas aliquid.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "8d6bd2e2-32d8-40a4-9dfe-5c5ded9badad",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_667946c5952aa3dd4f07b8554cc3c474",
+                          "title": "Et quae molestiae sapiente.",
+                          "description": "Aut atque labore. Eius laboriosam impedit. Quas sed qui.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/ffac8e53-977a-4b46-8185-ae9a54b1ffb4/profiles?limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides/ffac8e53-977a-4b46-8185-ae9a54b1ffb4/profiles?limit=10&offset=20",
+                        "next": "/api/compliance/v2/security_guides/ffac8e53-977a-4b46-8185-ae9a54b1ffb4/profiles?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Profiles sorted by \"title:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "ce09ac9a-1b0e-4c31-bd60-de0083853f0a",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_b98bf12c25981cf3d1bf379f60deb2b2",
+                          "title": "Architecto ad voluptas cupiditate.",
+                          "description": "Saepe quasi tempore. Magnam iure ut. Magnam ut quo.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "e84090bf-e395-486e-b84f-635a813659aa",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_fabcdd025c1177e093d68c04b5bbf0cd",
+                          "title": "Culpa aliquid corporis neque.",
+                          "description": "Quod omnis commodi. Totam et et. Velit numquam nam.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "3377893e-cdfd-4513-8268-3b13d9324d8f",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_5355570f73f6ad32c68f3c754c1d5264",
+                          "title": "Cum quod est modi.",
+                          "description": "Non mollitia voluptatem. Blanditiis nihil ea. Quos rerum id.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "e6f4be02-ef10-41a1-99d9-897ece9bbd22",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_d8bf6be841fe56557119208877fa3428",
+                          "title": "Enim vero quia rerum.",
+                          "description": "Doloribus eos omnis. Est earum voluptate. Voluptatem adipisci provident.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "07852622-7650-4a65-8382-bc6db5f41dfe",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_f8862edf6d996aee94fcab2eb7f9b91f",
+                          "title": "Eos optio a est.",
+                          "description": "Facere eveniet nulla. Magni at praesentium. Non mollitia ea.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "3604383a-1f2e-4ad7-88d8-af13ef45df52",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_1be00ec1a8cd6e05e56485dfef427666",
+                          "title": "Est quidem omnis et.",
+                          "description": "Ut inventore assumenda. Quae consectetur maiores. Ratione natus hic.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "a9cf88b3-b56a-453e-96cc-6b0d47e83e0b",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_b313c7c41f14dcccc3269c13cf7b47cf",
+                          "title": "Facere labore fugit iste.",
+                          "description": "Qui voluptatem iure. Consectetur possimus asperiores. Dolore voluptatem blanditiis.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "314497bd-d777-4767-b94a-f6b98ae08c1c",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_a4493cd5626e7821fc925b32671d260e",
+                          "title": "Id adipisci aperiam omnis.",
+                          "description": "Optio sint dignissimos. Optio temporibus velit. Laborum culpa officia.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "b6e323ae-767f-4281-901d-4bffdfffbc7a",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_e96e50bc6a36c62a68f99540c7be665a",
+                          "title": "Ipsam sint doloribus autem.",
+                          "description": "Enim a ut. Esse voluptatem voluptas. Fugiat voluptas dolorum.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        },
+                        {
+                          "id": "41066c08-ce03-43bc-9ff3-246e549706c9",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_5815cd2ec5402ce7755981f108b04762",
+                          "title": "Iusto eum et ut.",
+                          "description": "Sed enim magnam. A quam nostrum. Dignissimos sit adipisci.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "title"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/5cf95d23-a443-462f-bc13-051c3d567b0b/profiles?limit=10&offset=0&sort_by=title",
+                        "last": "/api/compliance/v2/security_guides/5cf95d23-a443-462f-bc13-051c3d567b0b/profiles?limit=10&offset=20&sort_by=title",
+                        "next": "/api/compliance/v2/security_guides/5cf95d23-a443-462f-bc13-051c3d567b0b/profiles?limit=10&offset=10&sort_by=title"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Profiles filtered by '(title=Veritatis quo aperiam voluptatem.)'": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "05afb5de-36b2-4270-a008-0d64b4fbf633",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_5efdba699967d15852804c9d13df560c",
+                          "title": "Veritatis quo aperiam voluptatem.",
+                          "description": "Occaecati provident ut. Corporis est quia. Dolorum nisi placeat.",
+                          "value_overrides": {},
+                          "type": "profile"
+                        }
+                      ],
+                      "meta": {
+                        "total": 1,
+                        "filter": "(title=\"Veritatis quo aperiam voluptatem.\")",
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/f72d8deb-3434-441a-8e79-e92a1228186d/profiles?filter=%28title%3D%22Veritatis+quo+aperiam+voluptatem.%22%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides/f72d8deb-3434-441a-8e79-e92a1228186d/profiles?filter=%28title%3D%22Veritatis+quo+aperiam+voluptatem.%22%29&limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/profile"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/profiles/{profile_id}": {
+      "get": {
+        "summary": "Request a Profile",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "profile_id",
+            "in": "path",
+            "required": true,
+            "description": "UUID or a ref_id with '.' characters replaced with '-'",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Returns a Profile",
+        "operationId": "Profile",
+        "responses": {
+          "200": {
+            "description": "Returns a Profile",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Profile": {
+                    "value": {
+                      "data": {
+                        "id": "e45f74e2-3ed0-4038-b913-80074ff73d1d",
+                        "ref_id": "xccdf_org.ssgproject.content_profile_b50d82d4fa571f86c20d63f5aa7297bb",
+                        "title": "Delectus eveniet molestiae et.",
+                        "description": "Ratione ducimus quae. Nam eos vitae. Quaerat ea odit.",
+                        "value_overrides": {},
+                        "type": "profile"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/profile"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Profile": {
+                    "value": {
+                      "errors": [
+                        "V2::Profile not found with ID d7a9ba81-69b9-4fe0-b414-93cb0366b22c"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports": {
+      "get": {
+        "summary": "Request Reports",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "os_major_version",
+                  "business_objective",
+                  "compliance_threshold",
+                  "percent_compliant",
+                  "title:asc",
+                  "title:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc",
+                  "business_objective:asc",
+                  "business_objective:desc",
+                  "compliance_threshold:asc",
+                  "compliance_threshold:desc",
+                  "percent_compliant:asc",
+                  "percent_compliant:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Reports are searchable using attributes `title`, `os_major_version`, and `with_reported_systems`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Lists Reports",
+        "operationId": "Reports",
+        "responses": {
+          "200": {
+            "description": "Lists Reports",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Reports": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "2673c73e-edde-4ab9-a504-3e395e6d252a",
+                          "title": "Voluptas doloremque velit quia.",
+                          "description": "Qui quia omnis. Ea nostrum iure. Ipsa eius assumenda.",
+                          "business_objective": "capacitor",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Quia officia fugit qui.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_323f423b7e52dbcb6e1bc13356a2a627",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        },
+                        {
+                          "id": "411e4971-98fd-4adb-ad5a-07d618dba338",
+                          "title": "Quasi provident est in.",
+                          "description": "Quae quos corrupti. Odio a fugit. Iusto rerum rem.",
+                          "business_objective": "pixel",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Vel qui aperiam sed.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_ccad5385f00bf0041637a69991cfde79",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        },
+                        {
+                          "id": "7b5be64f-5bcb-4b7e-bb73-67d7d906e7bd",
+                          "title": "Incidunt molestias delectus officia.",
+                          "description": "Consectetur delectus nemo. Natus sit ipsa. Sapiente sit odit.",
+                          "business_objective": "bandwidth",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Quo repellat repudiandae rerum.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_5c4c617182d1156008d5f50bd98c10a0",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        },
+                        {
+                          "id": "9a14f4ac-5203-4fbd-b534-4e78ebd3550f",
+                          "title": "Quia nulla officiis et.",
+                          "description": "Est eius doloremque. Architecto delectus exercitationem. Perspiciatis nostrum magni.",
+                          "business_objective": "capacitor",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Voluptatem animi et est.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_479eed1f1677dbd9e7aab0c846ec59ca",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        },
+                        {
+                          "id": "e31ad048-1733-4124-af9c-f96a9d954708",
+                          "title": "Sed accusantium praesentium voluptas.",
+                          "description": "Ut et id. Ducimus voluptatem hic. Adipisci pariatur quis.",
+                          "business_objective": "capacitor",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Voluptates nihil earum alias.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_5aefd5a8a818375493a98a60b5910c97",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        }
+                      ],
+                      "meta": {
+                        "total": 5,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports?limit=10&offset=0",
+                        "last": "/api/compliance/v2/reports?limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Reports sorted by \"os_major_version:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "1a3fbbb1-222f-468d-99dd-64dc5ef0023f",
+                          "title": "Corporis consequatur consequatur voluptate.",
+                          "description": "Assumenda et minus. Quo tempora esse. Minus vitae voluptas.",
+                          "business_objective": "application",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Aliquid iusto commodi velit.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_b24c732a308acb9bcd64f507df65716f",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        },
+                        {
+                          "id": "20fadc4a-a9d4-47d4-9f18-db3a3de96b72",
+                          "title": "Perferendis distinctio cumque quos.",
+                          "description": "Dolorum accusantium repudiandae. Magnam alias blanditiis. Dolorum exercitationem enim.",
+                          "business_objective": "protocol",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Sed eveniet et tenetur.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_3819a815b6fedcbc51467967792d4134",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        },
+                        {
+                          "id": "2cb63c99-046e-45ac-9545-229708bb1ed7",
+                          "title": "Cupiditate quo nisi voluptatibus.",
+                          "description": "Provident accusamus nulla. Consequatur quam dolore. At temporibus sunt.",
+                          "business_objective": "program",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Fugiat in vel et.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_7ab05775f1a51c1a9b00a4b7e7d345fc",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        },
+                        {
+                          "id": "3c29c783-9067-4c1b-9861-5ca1cfbefdb7",
+                          "title": "Corrupti est maiores exercitationem.",
+                          "description": "Rerum ipsa eius. Distinctio provident autem. Ratione quam eos.",
+                          "business_objective": "hard drive",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Dolorum voluptatibus vel ut.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_9ffcfb085a132c4c503e31b37cb2a67b",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        },
+                        {
+                          "id": "7fe9bf55-38fd-47d1-8c2d-3d3e15de8adb",
+                          "title": "Fuga ipsa unde aliquam.",
+                          "description": "Quos est saepe. Et ad pariatur. Qui qui placeat.",
+                          "business_objective": "driver",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Facere minima et eos.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_9f88451da093137c923e2dba6abe01f4",
+                          "all_systems_exposed": true,
+                          "percent_compliant": 25,
+                          "assigned_system_count": 4,
+                          "compliant_system_count": 1,
+                          "unsupported_system_count": 2,
+                          "reported_system_count": 4
+                        }
+                      ],
+                      "meta": {
+                        "total": 5,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "os_major_version"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports?limit=10&offset=0&sort_by=os_major_version",
+                        "last": "/api/compliance/v2/reports?limit=10&offset=0&sort_by=os_major_version"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/report"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/os_versions": {
+      "get": {
+        "summary": "Request the list of available OS versions",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Reports are searchable using attributes `title`, `os_major_version`, and `with_reported_systems`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "This feature is exclusively used by the frontend",
+        "operationId": "ReportsOS",
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "Lists available OS versions",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of available OS versions": {
+                    "value": [],
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{report_id}": {
+      "get": {
+        "summary": "Request a Report",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Returns a Report",
+        "operationId": "Report",
+        "responses": {
+          "200": {
+            "description": "Returns a Report",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Report": {
+                    "value": {
+                      "data": {
+                        "id": "cdc54c71-2fa1-4613-a593-b6d7b8924c29",
+                        "title": "Molestiae consequuntur consequatur quibusdam.",
+                        "description": "Accusamus fugiat nemo. Maxime porro nihil. Qui porro reiciendis.",
+                        "business_objective": "circuit",
+                        "compliance_threshold": 90.0,
+                        "type": "report",
+                        "os_major_version": 9,
+                        "profile_title": "Iure neque incidunt necessitatibus.",
+                        "ref_id": "xccdf_org.ssgproject.content_profile_0fc13524011a9aa1cbf39b284541548f",
+                        "all_systems_exposed": true,
+                        "percent_compliant": 25,
+                        "assigned_system_count": 4,
+                        "compliant_system_count": 1,
+                        "unsupported_system_count": 2,
+                        "reported_system_count": 4
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/report"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Report": {
+                    "value": {
+                      "errors": [
+                        "V2::Report not found with ID bfb5321f-73c5-4d73-9229-366e9b599811"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a Report results",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Deletes Report's test results",
+        "operationId": "DeleteReport",
+        "responses": {
+          "202": {
+            "description": "Deletes Report's test results",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Deletes Report's test results": {
+                    "value": {
+                      "data": {
+                        "id": "55d2ba3d-3c76-4c69-872f-f5d52df410a8",
+                        "title": "Vel voluptatem qui nesciunt.",
+                        "description": "Est qui temporibus. Id voluptatem consequatur. Inventore harum aut.",
+                        "business_objective": "capacitor",
+                        "compliance_threshold": 90.0,
+                        "type": "report",
+                        "os_major_version": 9,
+                        "profile_title": "Dignissimos optio a assumenda.",
+                        "ref_id": "xccdf_org.ssgproject.content_profile_96c15e42bb5c2852ce6d75172e776ed9",
+                        "all_systems_exposed": true,
+                        "percent_compliant": 25,
+                        "assigned_system_count": 4,
+                        "compliant_system_count": 1,
+                        "unsupported_system_count": 2,
+                        "reported_system_count": 4
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{report_id}/stats": {
+      "get": {
+        "summary": "Request detailed stats for a Report",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Returns detailed stats for a Report",
+        "deprecated": true,
+        "operationId": "ReportStats",
+        "responses": {
+          "200": {
+            "description": "Returns detailed stats for a Report",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns detailed stats for a Report": {
+                    "value": {
+                      "top_failed_rules": []
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/report_stats"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Report": {
+                    "value": {
+                      "errors": [
+                        "V2::Report not found with ID 2aacf722-3d3d-4086-8dbb-a8d80a685bf2"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/systems/{system_id}/reports": {
+      "get": {
+        "summary": "Request Reports",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "os_major_version",
+                  "business_objective",
+                  "compliance_threshold",
+                  "percent_compliant",
+                  "title:asc",
+                  "title:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc",
+                  "business_objective:asc",
+                  "business_objective:desc",
+                  "compliance_threshold:asc",
+                  "compliance_threshold:desc",
+                  "percent_compliant:asc",
+                  "percent_compliant:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Reports are searchable using attributes `title`, `os_major_version`, and `with_reported_systems`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "system_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Lists Reports",
+        "operationId": "SystemReports",
+        "responses": {
+          "200": {
+            "description": "Lists Reports",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Reports": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "2c4d926a-b7ae-4fc5-a461-75c67d2adba6",
+                          "title": "Velit qui enim quos.",
+                          "description": "Dolorum quo voluptates. Sed facilis eum. Ducimus ad impedit.",
+                          "business_objective": "circuit",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Odit maiores ipsam laborum.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_3432ea3fb15b2fcd262df8367243bea6",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        },
+                        {
+                          "id": "2d36e1f7-a7f7-440e-b956-06554da9e7f8",
+                          "title": "Adipisci voluptatem harum debitis.",
+                          "description": "Ab perferendis et. Recusandae non ut. Autem rerum magni.",
+                          "business_objective": "firewall",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Aut sunt eos ex.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_71e3c17ea064b3b057a4e25016a7529e",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        },
+                        {
+                          "id": "50199ff2-8a79-45f4-becc-3915495aca68",
+                          "title": "Eum quae omnis voluptatem.",
+                          "description": "Nulla repellendus ducimus. Omnis ratione laboriosam. Ea sequi quo.",
+                          "business_objective": "array",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Molestias quos expedita mollitia.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_b84797309b2cc814aebbca770a2c92bf",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        },
+                        {
+                          "id": "697e62f6-860a-44b9-b12b-636f3d0cfa86",
+                          "title": "Ipsam esse corrupti minus.",
+                          "description": "Aliquam fuga autem. Aut velit accusamus. Libero molestiae qui.",
+                          "business_objective": "feed",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Consectetur vero omnis eius.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_a13d82c8c69ebb5003492fd4fa196dfa",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        },
+                        {
+                          "id": "d00d9df4-6184-4bf0-8bf1-c97cdf1c9a9b",
+                          "title": "Et tempora officiis et.",
+                          "description": "Soluta ipsa eveniet. Dolorem iste voluptas. Dolorum voluptas ea.",
+                          "business_objective": "port",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Ex non labore rerum.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_fc8f957c3bad7660305bbc52d15b415b",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        }
+                      ],
+                      "meta": {
+                        "total": 5,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/systems/6f064072-0638-446e-9356-40e23da4a95a/reports?limit=10&offset=0",
+                        "last": "/api/compliance/v2/systems/6f064072-0638-446e-9356-40e23da4a95a/reports?limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Reports sorted by \"title:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "45493a81-9ef0-4c3d-8d5a-0167918b1561",
+                          "title": "Autem non dolores facilis.",
+                          "description": "Et molestiae quis. Quae eligendi dolorem. Repellendus aliquam dolorem.",
+                          "business_objective": "panel",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Aut maxime officia nihil.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_af65a1fb8362843846a028e227d21b36",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        },
+                        {
+                          "id": "8d96977c-f64e-41af-95f0-b94d531076ff",
+                          "title": "Maiores voluptates assumenda debitis.",
+                          "description": "Molestias corporis sint. Quis eius quidem. Iusto aspernatur aut.",
+                          "business_objective": "protocol",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Dolor repudiandae non maiores.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_3381d2a43e0b60131cdb48b733308776",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        },
+                        {
+                          "id": "a74a128e-0585-470e-b738-e2dfe290003f",
+                          "title": "Qui commodi quia tempore.",
+                          "description": "Quibusdam deserunt voluptatum. Qui expedita dolores. Placeat architecto mollitia.",
+                          "business_objective": "panel",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Culpa repellat doloribus deleniti.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_e6c50c461b55411b62f1d00729f79373",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        },
+                        {
+                          "id": "421b4991-2140-4752-b8d0-d724eafc8dc0",
+                          "title": "Rerum pariatur architecto nulla.",
+                          "description": "Id perferendis maxime. Voluptate vel voluptas. Quod qui voluptatibus.",
+                          "business_objective": "bus",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Commodi quibusdam velit sint.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_92009ea48d960440ff2c826eaa0e724d",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        },
+                        {
+                          "id": "a4f1f0bd-2a1b-4d8d-aadc-1d45ac5311d4",
+                          "title": "Ut aperiam impedit iusto.",
+                          "description": "Vel quo architecto. Aperiam voluptate earum. Repellendus qui quaerat.",
+                          "business_objective": "driver",
+                          "compliance_threshold": 90.0,
+                          "type": "report",
+                          "os_major_version": 8,
+                          "profile_title": "Occaecati ab in odit.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_99470f38c94281516ee733714b80855f",
+                          "all_systems_exposed": false,
+                          "percent_compliant": 0,
+                          "compliant_system_count": 0,
+                          "unsupported_system_count": 0,
+                          "reported_system_count": 0
+                        }
+                      ],
+                      "meta": {
+                        "total": 5,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "title"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/systems/e2b12287-727a-4954-9718-e70bbd596776/reports?limit=10&offset=0&sort_by=title",
+                        "last": "/api/compliance/v2/systems/e2b12287-727a-4954-9718-e70bbd596776/reports?limit=10&offset=0&sort_by=title"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/report"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/rule_groups": {
+      "get": {
+        "summary": "Request Rule Groups",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "precedence",
+                  "precedence:asc",
+                  "precedence:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Rule Groups are searchable using attributes `title` and `ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Lists Rule Groups",
+        "operationId": "Rule Groups",
+        "responses": {
+          "200": {
+            "description": "Lists Rule Groups",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Rule Groups": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "0666d598-2c3e-4a2c-a848-d58ea410c176",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_b5abee67cf4b85cb7137f7b167f7acb3",
+                          "title": "Quasi qui minima quidem.",
+                          "rationale": "Quae eum quo. Dignissimos rerum delectus. Eaque omnis autem.",
+                          "description": "Quo enim ullam. Vero soluta rerum. Consequatur aliquid velit.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "2db7efe6-e94a-4c3c-a4b2-866891ac1595",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_3b003b3ec20a05423536af13817c4cc0",
+                          "title": "Alias quia natus quasi.",
+                          "rationale": "Ea odit quia. Eius perspiciatis repellendus. Laborum ipsa non.",
+                          "description": "Ex ut consequatur. Enim culpa et. Alias nobis qui.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "2e7231ef-4b07-4ee3-8e69-8e2b5e6af44e",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_0efbcd45d2a0784fe0661d04068f361a",
+                          "title": "Sed adipisci ratione id.",
+                          "rationale": "Et molestiae eum. Commodi exercitationem ut. Omnis et eaque.",
+                          "description": "Aut voluptatem optio. Beatae excepturi voluptatibus. Dolorum beatae minus.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "2ebe5f82-99d7-49f5-af46-18d724020311",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_14d39004692bd13fb4b81bb5dda6b4e0",
+                          "title": "Quia cupiditate nobis quo.",
+                          "rationale": "Sed aliquid voluptatibus. Aut quia veritatis. Aut corrupti aliquid.",
+                          "description": "Sed facilis est. Minima enim temporibus. Dolorem labore voluptas.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "3128a7d2-1029-495a-8d61-da5524689beb",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_0f998577362bbf4910231bd5860e6035",
+                          "title": "Et qui id enim.",
+                          "rationale": "Sint et omnis. Dolores culpa molestias. Architecto aliquam ut.",
+                          "description": "Sit itaque velit. Et saepe voluptatem. Dignissimos magni odio.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "3e795de3-20e9-4181-99c1-d4ad6904a652",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_d46aeea4e77be11e426763fa477085d1",
+                          "title": "Aliquid nobis excepturi voluptates.",
+                          "rationale": "Error qui in. Tenetur cum in. Quod dolorem sed.",
+                          "description": "Debitis accusamus deleniti. Officiis ut maxime. Totam modi cum.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "4b01692e-3b28-4ffc-a8d0-42f386bf8b2e",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_a81641b30a7b534666a26808d07099b7",
+                          "title": "Et inventore et non.",
+                          "rationale": "Qui neque aliquid. Illum dolorem quia. Autem qui porro.",
+                          "description": "Incidunt ipsa temporibus. Illum accusamus saepe. Commodi laudantium inventore.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "4f2b36a0-f2d5-4677-8eba-e9515580802e",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_7374298364ffcc21147351303db8af60",
+                          "title": "Dolores eum error ea.",
+                          "rationale": "Est et excepturi. Aut dignissimos nobis. Rerum iusto occaecati.",
+                          "description": "Et quia et. Ad qui consequatur. Dolore aut excepturi.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "503476ed-6a12-4aa1-a4e3-25726707e81c",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_8a09f97bdb68b61c8e8178cc30aec699",
+                          "title": "Aut nihil autem consectetur.",
+                          "rationale": "Eveniet omnis nostrum. Voluptatibus soluta debitis. Tempore qui facere.",
+                          "description": "Doloremque minima aut. Aut ipsam occaecati. Qui perferendis quibusdam.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "608a3f4f-6bc7-42b6-8b60-2135f9654603",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_e03180ec7ec82e13f97576b4965b9983",
+                          "title": "Ut impedit libero eos.",
+                          "rationale": "Dolores sequi voluptatem. Dolorum ab perspiciatis. Est vero quisquam.",
+                          "description": "Quia in autem. Sint et minus. Commodi illo beatae.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/7ea5b1f9-c5c9-48d1-ac69-07f8b05856e3/rule_groups?limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides/7ea5b1f9-c5c9-48d1-ac69-07f8b05856e3/rule_groups?limit=10&offset=20",
+                        "next": "/api/compliance/v2/security_guides/7ea5b1f9-c5c9-48d1-ac69-07f8b05856e3/rule_groups?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Rule Groups sorted by \"precedence:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "008c5ef2-aa88-4a83-94ef-8a02249f784a",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_42b7897660ccce19d8a89ace29ee86a6",
+                          "title": "Sint iure voluptates quo.",
+                          "rationale": "Aut aut vel. Exercitationem consequatur ipsam. Et et rerum.",
+                          "description": "Doloribus fuga explicabo. Modi non quo. Quidem ut maxime.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "0353d6c4-250f-41b0-b989-fd4e787726f9",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_828eee3bbca961369596eff7c4838a2b",
+                          "title": "Perferendis omnis alias natus.",
+                          "rationale": "Voluptates iusto molestiae. Et velit inventore. Neque aut deleniti.",
+                          "description": "Doloribus et quae. Vel in consectetur. Repellendus dolore ut.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "0a7d8897-a541-48c7-b044-3cb9bd151114",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_dd10579b37f5052fed41e2da1b403c91",
+                          "title": "Dolor aliquam et pariatur.",
+                          "rationale": "Impedit dolorum sit. Voluptas sit dolorem. Veritatis voluptatibus suscipit.",
+                          "description": "Placeat sint voluptatem. Incidunt aliquid sit. Quis quod sunt.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "14b76adc-905e-48bd-bafc-9eefc9174da1",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_1be4978abc602b6246f33ab0963845eb",
+                          "title": "Explicabo corporis possimus facilis.",
+                          "rationale": "Animi cumque dolores. Unde reprehenderit enim. Veritatis illum ab.",
+                          "description": "Vero quam doloremque. Nihil molestiae esse. Modi atque ex.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "2164acaf-2f8e-4ecc-8276-a2dd24c41adb",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_704f9552df03f31eafda5f83f8897f5b",
+                          "title": "Illum eos qui quaerat.",
+                          "rationale": "Magni voluptates error. Ullam sit animi. Eum totam perferendis.",
+                          "description": "Id quia aliquid. Eveniet accusamus hic. Delectus et aut.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "2359f147-caf0-495f-a766-ef85b35306a3",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_bfcf0f0ffd25cdae183c859bcf00437b",
+                          "title": "Doloremque id quas et.",
+                          "rationale": "Nesciunt rerum sequi. Vitae dolorum blanditiis. Sint autem et.",
+                          "description": "Recusandae laudantium similique. Quas iste illum. Est cumque qui.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "2c87d9de-6209-48f0-958d-ac62643257f2",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_6361bd84ce284ca3330350f518ba3469",
+                          "title": "Nulla vel explicabo earum.",
+                          "rationale": "Et nihil dicta. Reiciendis officia repudiandae. Sunt nulla dolorem.",
+                          "description": "Dolores veritatis fugit. Cumque aut saepe. Mollitia ipsa voluptatem.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "3493bb70-c4f2-4d02-9f39-817d5ad6effb",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_db517cbebfe76587108d42ba826d0825",
+                          "title": "Minima ullam id quis.",
+                          "rationale": "Neque recusandae dolorem. Maiores possimus voluptatem. Quis labore voluptates.",
+                          "description": "Sint excepturi est. Iusto sint nesciunt. Rerum ad asperiores.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "3fa250e5-b9f2-43bb-ad42-8a8cb5ad8f4a",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_59f4665e3171f08327c4e2ab856d6218",
+                          "title": "Cum quis totam dolores.",
+                          "rationale": "Sed odit autem. In recusandae repellat. Eveniet rem labore.",
+                          "description": "Culpa totam enim. Totam beatae dolores. Delectus exercitationem eos.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        },
+                        {
+                          "id": "41213af7-0425-4cbd-8096-8afe4e234b7c",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_group_a698a5f1d3df7b87302eb52f91101779",
+                          "title": "Quas facilis id minima.",
+                          "rationale": "Illum qui rerum. Eligendi sed ad. Quisquam sit ut.",
+                          "description": "Architecto non iure. Culpa at eaque. Expedita reiciendis ea.",
+                          "precedence": null,
+                          "type": "rule_group"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "precedence"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/d3ee0fa3-7634-42fb-9c69-08879db87f7d/rule_groups?limit=10&offset=0&sort_by=precedence",
+                        "last": "/api/compliance/v2/security_guides/d3ee0fa3-7634-42fb-9c69-08879db87f7d/rule_groups?limit=10&offset=20&sort_by=precedence",
+                        "next": "/api/compliance/v2/security_guides/d3ee0fa3-7634-42fb-9c69-08879db87f7d/rule_groups?limit=10&offset=10&sort_by=precedence"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/rule_group"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/rule_groups/{rule_group_id}": {
+      "get": {
+        "summary": "Request a Rule Group",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rule_group_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Returns a Rule Group",
+        "operationId": "RuleGroup",
+        "responses": {
+          "200": {
+            "description": "Returns a Rule Group",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Rule Group": {
+                    "value": {
+                      "data": {
+                        "id": "2fde3912-a518-4ef1-9b2f-8033506170a4",
+                        "ref_id": "xccdf_org.ssgproject.content_rule_group_bdd75d910442ee6f2286f891fc2a1069",
+                        "title": "Velit porro error vel.",
+                        "rationale": "Animi et deleniti. Aut soluta odio. Aut accusamus molestias.",
+                        "description": "Minus quas debitis. Commodi qui vel. Libero modi minus.",
+                        "precedence": null,
+                        "type": "rule_group"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/rule_group"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Rule Group": {
+                    "value": {
+                      "errors": [
+                        "V2::RuleGroup not found with ID 0920d465-d033-4de9-add2-563a3ab4e60b"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{report_id}/test_results/{test_result_id}/rule_results": {
+      "get": {
+        "summary": "Request Rule Results under a Report",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "result",
+                  "severity",
+                  "title",
+                  "precedence",
+                  "remediation_available",
+                  "result:asc",
+                  "result:desc",
+                  "severity:asc",
+                  "severity:desc",
+                  "title:asc",
+                  "title:desc",
+                  "precedence:asc",
+                  "precedence:desc",
+                  "remediation_available:asc",
+                  "remediation_available:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Rule Results are searchable using attributes `result`, `title`, `severity`, and `remediation_available`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "test_result_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Lists Rule Results under a Report",
+        "operationId": "ReportRuleResults",
+        "responses": {
+          "200": {
+            "description": "Lists Rule Results under a Report",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Rule Results": {
+                    "value": {
+                      "data": [],
+                      "meta": {
+                        "total": 0,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports/98a6b0a9-6660-4b79-9fea-697271de815d/test_results/8af3e1ad-0472-47d6-be3d-283fb8b57c0f/rule_results?limit=10&offset=0",
+                        "last": "/api/compliance/v2/reports/98a6b0a9-6660-4b79-9fea-697271de815d/test_results/8af3e1ad-0472-47d6-be3d-283fb8b57c0f/rule_results?limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Rule Results sorted by \"result:asc\"": {
+                    "value": {
+                      "data": [],
+                      "meta": {
+                        "total": 0,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "result"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports/6b7133c7-f8dd-4d33-af9d-90251611f13e/test_results/559ebc46-d558-4d6a-82b3-a1409b19bee5/rule_results?limit=10&offset=0&sort_by=result",
+                        "last": "/api/compliance/v2/reports/6b7133c7-f8dd-4d33-af9d-90251611f13e/test_results/559ebc46-d558-4d6a-82b3-a1409b19bee5/rule_results?limit=10&offset=0&sort_by=result"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Rule Results filtered by \"(title=foo)\"": {
+                    "value": {
+                      "data": [],
+                      "meta": {
+                        "total": 0,
+                        "filter": "(title=foo)",
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports/ddaf50f4-2f7f-4f69-81f9-8f3e796d6ccd/test_results/73875477-f1bd-412a-be02-761b3440558b/rule_results?filter=%28title%3Dfoo%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/reports/ddaf50f4-2f7f-4f69-81f9-8f3e796d6ccd/test_results/73875477-f1bd-412a-be02-761b3440558b/rule_results?filter=%28title%3Dfoo%29&limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/rule_result"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/rules": {
+      "get": {
+        "summary": "Request Rules",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "severity",
+                  "precedence",
+                  "remediation_available",
+                  "title:asc",
+                  "title:desc",
+                  "severity:asc",
+                  "severity:desc",
+                  "precedence:asc",
+                  "precedence:desc",
+                  "remediation_available:asc",
+                  "remediation_available:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Rules are searchable using attributes `title`, `severity`, and `remediation_available`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Lists Rules assigned",
+        "operationId": "Rules",
+        "responses": {
+          "200": {
+            "description": "Lists Rules",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Rules": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "04e055a7-fd08-4235-b392-954778f9778f",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_8291d570a52b6bb78bf7e77c38b8be49",
+                          "title": "Nihil ad vero perspiciatis.",
+                          "rationale": "Soluta dolore quae. Qui quod id. Temporibus sit perspiciatis.",
+                          "description": "Officia maiores natus. Eligendi dolorem eveniet. Vitae iusto ea.",
+                          "severity": "high",
+                          "precedence": 5756,
+                          "identifier": {
+                            "href": "http://powlowski.test/clifford",
+                            "label": "Belba Baggins"
+                          },
+                          "references": [
+                            {
+                              "href": "http://okuneva.test/marcos.gottlieb",
+                              "label": "Eldacar"
+                            },
+                            {
+                              "href": "http://zemlak-macejkovic.example/arielle.stoltenberg",
+                              "label": "Borlach"
+                            },
+                            {
+                              "href": "http://bayer.example/jutta.farrell",
+                              "label": "Folco Boffin"
+                            },
+                            {
+                              "href": "http://daugherty-kilback.test/jerica.mraz",
+                              "label": "Donnamira Took"
+                            },
+                            {
+                              "href": "http://frami.test/wilson_turcotte",
+                              "label": "Elboron"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "0a9399f0-e735-420c-be4a-cc0b9ff1bf8b",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_21d7e02bad6058afaa2a3af8b772d736",
+                          "title": "Deserunt quia suscipit omnis.",
+                          "rationale": "Error autem quia. Consequatur incidunt culpa. Possimus minus impedit.",
+                          "description": "Amet alias ullam. Est molestiae sed. Quidem ut corrupti.",
+                          "severity": "low",
+                          "precedence": 2931,
+                          "identifier": {
+                            "href": "http://blanda.test/oswaldo",
+                            "label": "Vinitharya"
+                          },
+                          "references": [
+                            {
+                              "href": "http://stark.test/rosa_jones",
+                              "label": "Beldir"
+                            },
+                            {
+                              "href": "http://bogisich.example/odette",
+                              "label": "Otto Boffin"
+                            },
+                            {
+                              "href": "http://kris.example/bud",
+                              "label": "Tanta Hornblower"
+                            },
+                            {
+                              "href": "http://barrows-stamm.test/erica_treutel",
+                              "label": "Galathil"
+                            },
+                            {
+                              "href": "http://hammes.test/wilfred",
+                              "label": "Axantur"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "0b087805-7aa2-43c6-9454-1a943e77a660",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_49949b5289cdebbcd2158dcac01dfc60",
+                          "title": "Dolores porro dolor in.",
+                          "rationale": "Iusto blanditiis quasi. Voluptatem labore facilis. Ut quae laudantium.",
+                          "description": "Facilis expedita placeat. Velit qui ut. Hic eaque inventore.",
+                          "severity": "high",
+                          "precedence": 6166,
+                          "identifier": {
+                            "href": "http://okon-stark.example/troy",
+                            "label": "Estella Bolger"
+                          },
+                          "references": [
+                            {
+                              "href": "http://sipes.test/chad",
+                              "label": "Lugdush"
+                            },
+                            {
+                              "href": "http://adams.example/shaunna_effertz",
+                              "label": "Bungo Baggins"
+                            },
+                            {
+                              "href": "http://williamson-schroeder.example/milford",
+                              "label": "Walda"
+                            },
+                            {
+                              "href": "http://paucek.test/jamal.adams",
+                              "label": "Herugar Bolger"
+                            },
+                            {
+                              "href": "http://mitchell.test/leopoldo_price",
+                              "label": "Araphor"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "16a04f0d-02d6-45b8-a6cb-ce179779d2cc",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_eb429539cb5f614932a8f493b6402621",
+                          "title": "Maiores reiciendis ut placeat.",
+                          "rationale": "Dolores et iste. Error molestiae quis. Eos soluta qui.",
+                          "description": "Doloremque inventore nostrum. Et qui dolorem. Saepe error cum.",
+                          "severity": "high",
+                          "precedence": 9884,
+                          "identifier": {
+                            "href": "http://goldner-okuneva.test/pasquale.mitchell",
+                            "label": "Araphor"
+                          },
+                          "references": [
+                            {
+                              "href": "http://gislason.example/georgiana.mitchell",
+                              "label": "Dodinas Brandybuck"
+                            },
+                            {
+                              "href": "http://hauck-spencer.example/lindsey.mcclure",
+                              "label": "Iago Grubb"
+                            },
+                            {
+                              "href": "http://simonis-kihn.example/benton_stark",
+                              "label": "Roäc"
+                            },
+                            {
+                              "href": "http://krajcik.test/ezequiel",
+                              "label": "Argon"
+                            },
+                            {
+                              "href": "http://williamson-herzog.example/felipe.bogan",
+                              "label": "Vorondil"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "190e5ebb-22e8-41cd-bf56-0441ba02c8ac",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_0de770c3870a508792f0b917c1cc39a8",
+                          "title": "Magni illum accusamus doloribus.",
+                          "rationale": "Perferendis est sint. Quia sit debitis. Repellendus iste sed.",
+                          "description": "Assumenda corrupti id. Laboriosam quis corporis. Minima culpa consequatur.",
+                          "severity": "high",
+                          "precedence": 4208,
+                          "identifier": {
+                            "href": "http://glover.test/hallie",
+                            "label": "Beleth"
+                          },
+                          "references": [
+                            {
+                              "href": "http://mayert-bailey.example/brynn.powlowski",
+                              "label": "Falco Chubb-Baggins"
+                            },
+                            {
+                              "href": "http://turner.example/mallie",
+                              "label": "Vidumavi"
+                            },
+                            {
+                              "href": "http://schumm.test/tabetha",
+                              "label": "Derufin"
+                            },
+                            {
+                              "href": "http://stanton.test/terrilyn.buckridge",
+                              "label": "Helm"
+                            },
+                            {
+                              "href": "http://paucek.example/antony",
+                              "label": "Urthel"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "200248d1-abc2-4ef2-b8d1-7e30029f1e2a",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_7d4ce86e81f8596c7f3619fe65f7f8ce",
+                          "title": "Voluptas omnis voluptatum repellendus.",
+                          "rationale": "Dolores voluptatem nihil. Quia in eveniet. Ut asperiores magnam.",
+                          "description": "Amet animi eos. In quia et. Et molestiae et.",
+                          "severity": "low",
+                          "precedence": 3540,
+                          "identifier": {
+                            "href": "http://altenwerth-bashirian.example/elayne.weimann",
+                            "label": "Watcher in the Water"
+                          },
+                          "references": [
+                            {
+                              "href": "http://wyman-dooley.example/chara.gusikowski",
+                              "label": "Hobson"
+                            },
+                            {
+                              "href": "http://trantow-borer.test/silvia",
+                              "label": "Forlong"
+                            },
+                            {
+                              "href": "http://ernser.test/maurita.rau",
+                              "label": "Nessanië"
+                            },
+                            {
+                              "href": "http://hansen-lemke.example/cami",
+                              "label": "Duinhir"
+                            },
+                            {
+                              "href": "http://hills.test/gabriela_flatley",
+                              "label": "Gollum"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "33bf8a5e-7592-4611-98d1-1bceb0cd49dc",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_0d1816b66323751ecd9527145b51d2a1",
+                          "title": "Doloribus ut minima sint.",
+                          "rationale": "Voluptatem iusto perspiciatis. Eius adipisci velit. Beatae rerum nihil.",
+                          "description": "Vero cumque libero. Aut assumenda labore. Exercitationem at quasi.",
+                          "severity": "high",
+                          "precedence": 8227,
+                          "identifier": {
+                            "href": "http://turcotte.example/etta_lind",
+                            "label": "Elatan"
+                          },
+                          "references": [
+                            {
+                              "href": "http://grimes.example/jo",
+                              "label": "Tosto Boffin"
+                            },
+                            {
+                              "href": "http://welch.example/bennie.cole",
+                              "label": "Hugo Boffin"
+                            },
+                            {
+                              "href": "http://blanda-smith.test/christine_wilkinson",
+                              "label": "Éothéod"
+                            },
+                            {
+                              "href": "http://herzog.test/cyrus",
+                              "label": "Dwalin"
+                            },
+                            {
+                              "href": "http://leuschke.test/roberto.emard",
+                              "label": "Orchaldor"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "4431d2ce-3f8a-478e-83c0-8f3ddd1a9c36",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_b40327c5e5a600d93d10366b0825cbb5",
+                          "title": "Et odio est earum.",
+                          "rationale": "Aut officia ullam. Suscipit provident ipsum. Pariatur hic omnis.",
+                          "description": "Aspernatur natus sunt. Aliquam molestias est. Est architecto ut.",
+                          "severity": "medium",
+                          "precedence": 5970,
+                          "identifier": {
+                            "href": "http://howell.example/billy_jenkins",
+                            "label": "Radbug"
+                          },
+                          "references": [
+                            {
+                              "href": "http://wiegand.test/jacinto",
+                              "label": "Flói"
+                            },
+                            {
+                              "href": "http://kihn.test/nancy_hahn",
+                              "label": "Uldor"
+                            },
+                            {
+                              "href": "http://littel-bernhard.test/harley",
+                              "label": "Daeron"
+                            },
+                            {
+                              "href": "http://pollich.test/shery.tromp",
+                              "label": "Anborn"
+                            },
+                            {
+                              "href": "http://powlowski-heaney.example/halina.quitzon",
+                              "label": "Hob Hayward"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "4bce2af9-a9fe-46b6-b36d-0731abaa312b",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_4008a70637d6501b006c3ac693c72637",
+                          "title": "Ut officiis eveniet reiciendis.",
+                          "rationale": "Voluptatibus occaecati accusamus. Quidem ipsum accusantium. Dolores alias voluptate.",
+                          "description": "Nobis numquam ut. A totam illum. Odit iusto esse.",
+                          "severity": "low",
+                          "precedence": 2914,
+                          "identifier": {
+                            "href": "http://kuhn-corkery.example/lucio_shields",
+                            "label": "Eärendil"
+                          },
+                          "references": [
+                            {
+                              "href": "http://wiza.test/louise.grimes",
+                              "label": "Chica Chubb"
+                            },
+                            {
+                              "href": "http://kling-murphy.test/latashia",
+                              "label": "Nimrodel"
+                            },
+                            {
+                              "href": "http://carter.example/ward.bogan",
+                              "label": "Rose Cotton"
+                            },
+                            {
+                              "href": "http://kub.test/lucretia",
+                              "label": "Walda"
+                            },
+                            {
+                              "href": "http://wisozk.example/refugio.marks",
+                              "label": "Iorlas"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "52e2417e-c58f-42be-b1c7-0d92bb24925f",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_6e300e9fd1f505650d7b78b70f8d4aae",
+                          "title": "Quae officia totam necessitatibus.",
+                          "rationale": "Nam est cum. Perspiciatis optio possimus. Aut dolor corrupti.",
+                          "description": "Natus ut nisi. Quia aut magnam. Nostrum impedit est.",
+                          "severity": "medium",
+                          "precedence": 1439,
+                          "identifier": {
+                            "href": "http://howe.example/cindi",
+                            "label": "Yávien"
+                          },
+                          "references": [
+                            {
+                              "href": "http://boehm-nikolaus.test/jon",
+                              "label": "Bregil"
+                            },
+                            {
+                              "href": "http://oreilly.test/werner_stark",
+                              "label": "Thorin Stonehelm"
+                            },
+                            {
+                              "href": "http://ryan.example/vickie",
+                              "label": "Drogo Baggins"
+                            },
+                            {
+                              "href": "http://nolan.example/oscar.gorczany",
+                              "label": "Hundad"
+                            },
+                            {
+                              "href": "http://botsford-flatley.example/brant.mcclure",
+                              "label": "Berilac Brandybuck"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/564e180d-df96-40cd-84fa-830b366de122/rules?limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides/564e180d-df96-40cd-84fa-830b366de122/rules?limit=10&offset=20",
+                        "next": "/api/compliance/v2/security_guides/564e180d-df96-40cd-84fa-830b366de122/rules?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Rules sorted by \"precedence:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "983fe134-fbec-43b8-bf73-1a100607f3e7",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_3b7030193d798537e0ed19b7c88430c6",
+                          "title": "Omnis aliquam maxime voluptatem.",
+                          "rationale": "Dolores voluptate non. Explicabo expedita qui. Perspiciatis totam a.",
+                          "description": "Est odit amet. Id illo numquam. Mollitia eligendi molestiae.",
+                          "severity": "medium",
+                          "precedence": 156,
+                          "identifier": {
+                            "href": "http://rodriguez.test/karyl",
+                            "label": "Ivriniel"
+                          },
+                          "references": [
+                            {
+                              "href": "http://lubowitz.example/beckie",
+                              "label": "Scatha"
+                            },
+                            {
+                              "href": "http://witting-feest.example/glynis.cummings",
+                              "label": "Ancalagon"
+                            },
+                            {
+                              "href": "http://turner.example/octavia",
+                              "label": "Berilac Brandybuck"
+                            },
+                            {
+                              "href": "http://medhurst.example/ray.kihn",
+                              "label": "Briffo Boffin"
+                            },
+                            {
+                              "href": "http://ledner-glover.test/gino.bode",
+                              "label": "Malbeth"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "679df184-9fab-4a0c-8ef5-93f272dd620b",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_c3ddf03f5cda92dd983fb287254c8fae",
+                          "title": "Et suscipit earum perspiciatis.",
+                          "rationale": "Non possimus qui. Ea ut rerum. Aut et nihil.",
+                          "description": "Quis excepturi hic. Mollitia animi vero. Reprehenderit ducimus eum.",
+                          "severity": "medium",
+                          "precedence": 490,
+                          "identifier": {
+                            "href": "http://waters-volkman.test/sterling.mclaughlin",
+                            "label": "Ulrad"
+                          },
+                          "references": [
+                            {
+                              "href": "http://grimes.example/annamae",
+                              "label": "Faramir Took"
+                            },
+                            {
+                              "href": "http://bradtke.example/charlie",
+                              "label": "Nina Lightfoot"
+                            },
+                            {
+                              "href": "http://pouros.example/emily",
+                              "label": "Ulwarth"
+                            },
+                            {
+                              "href": "http://wiegand.test/miyoko",
+                              "label": "Huor"
+                            },
+                            {
+                              "href": "http://hilll.example/marcos_larson",
+                              "label": "Angrod"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "d706a1a1-081f-4075-821b-8a211d7357b5",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_333487c57e1169b001257001132860af",
+                          "title": "Sint non iste iusto.",
+                          "rationale": "Omnis ad veniam. Qui nihil voluptate. Voluptates nihil dicta.",
+                          "description": "Saepe repellat ut. Odio numquam non. Veniam vel eos.",
+                          "severity": "high",
+                          "precedence": 610,
+                          "identifier": {
+                            "href": "http://wolf.example/weston_stokes",
+                            "label": "Beril"
+                          },
+                          "references": [
+                            {
+                              "href": "http://ziemann-shanahan.example/bradford",
+                              "label": "Aravorn"
+                            },
+                            {
+                              "href": "http://goldner.example/leigh",
+                              "label": "Gundahar Bolger"
+                            },
+                            {
+                              "href": "http://moore.test/inez.hirthe",
+                              "label": "Gorbadoc Brandybuck"
+                            },
+                            {
+                              "href": "http://farrell.test/lauren.fahey",
+                              "label": "Orchaldor"
+                            },
+                            {
+                              "href": "http://dibbert-dubuque.example/tory.lockman",
+                              "label": "Lotho Sackville-Baggins"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "cdbef027-e1b3-4646-90f9-414cd0c9bf3c",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_4b1601ca9e61cc3dd098b764dfd8433b",
+                          "title": "Nisi vel incidunt iure.",
+                          "rationale": "Voluptas in tempore. Est atque reiciendis. Provident maiores facere.",
+                          "description": "Eaque sit voluptatem. Eius totam aperiam. Expedita assumenda ea.",
+                          "severity": "low",
+                          "precedence": 1303,
+                          "identifier": {
+                            "href": "http://nolan-lubowitz.test/reginia",
+                            "label": "Gollum"
+                          },
+                          "references": [
+                            {
+                              "href": "http://weissnat.test/cristine_carroll",
+                              "label": "Otho Sackville-Baggins"
+                            },
+                            {
+                              "href": "http://schiller.example/isobel",
+                              "label": "Telchar"
+                            },
+                            {
+                              "href": "http://harvey.test/farrah.rogahn",
+                              "label": "Bór"
+                            },
+                            {
+                              "href": "http://kilback.example/lonna_stark",
+                              "label": "Angbor"
+                            },
+                            {
+                              "href": "http://schiller.example/abdul",
+                              "label": "Dagnir"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "fc57b120-cd7b-4649-9750-e3cfe37448f1",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_d2883071d70dfeeaf827a72bd8806c31",
+                          "title": "Temporibus qui consectetur nihil.",
+                          "rationale": "Impedit iusto maiores. Illo dolorem maxime. Sint nemo facilis.",
+                          "description": "Veritatis ut blanditiis. Sed architecto repudiandae. Magnam aut saepe.",
+                          "severity": "medium",
+                          "precedence": 1941,
+                          "identifier": {
+                            "href": "http://jast.test/maynard",
+                            "label": "Gilmith"
+                          },
+                          "references": [
+                            {
+                              "href": "http://heathcote.test/hayden",
+                              "label": "Ted Sandyman"
+                            },
+                            {
+                              "href": "http://johnson-torphy.example/calvin.farrell",
+                              "label": "Falco Chubb-Baggins"
+                            },
+                            {
+                              "href": "http://langworth.example/francisco",
+                              "label": "Almarian"
+                            },
+                            {
+                              "href": "http://nicolas.example/keven.legros",
+                              "label": "Ar-Gimilzôr"
+                            },
+                            {
+                              "href": "http://lang.example/nickolas_lowe",
+                              "label": "Ar-Adûnakhôr"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "3f109c39-41d1-4b16-9629-d2a2ea1528b1",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_c4190b666c1d908205dc34d15f9aefef",
+                          "title": "Rerum eum vel maiores.",
+                          "rationale": "Culpa quo sed. Aut hic mollitia. Sequi voluptatibus aut.",
+                          "description": "Eius vero est. Iure quod fugiat. Non at alias.",
+                          "severity": "high",
+                          "precedence": 2023,
+                          "identifier": {
+                            "href": "http://pollich-fahey.test/hedwig_pacocha",
+                            "label": "Pervinca Took"
+                          },
+                          "references": [
+                            {
+                              "href": "http://schmeler.example/damian.streich",
+                              "label": "Great Goblin"
+                            },
+                            {
+                              "href": "http://rippin.test/fritz.farrell",
+                              "label": "Malantur"
+                            },
+                            {
+                              "href": "http://bruen-emard.example/jule.doyle",
+                              "label": "Belba Baggins"
+                            },
+                            {
+                              "href": "http://gulgowski-oconner.example/jessie.mayert",
+                              "label": "Vardilmë"
+                            },
+                            {
+                              "href": "http://grady-mosciski.example/dalene_olson",
+                              "label": "Angbor"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "5d6b1f4a-b1f2-4308-93a7-84966e4b99b7",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_b1a20af981235ed6ef42c491b2edf2cd",
+                          "title": "Velit aut rerum illum.",
+                          "rationale": "Maxime porro quos. Qui natus unde. Et iusto porro.",
+                          "description": "Aut ipsum nesciunt. Sit aliquam maxime. Consequatur sed at.",
+                          "severity": "low",
+                          "precedence": 2056,
+                          "identifier": {
+                            "href": "http://reichel.test/johnny",
+                            "label": "Gorlim"
+                          },
+                          "references": [
+                            {
+                              "href": "http://hettinger.example/rick.bode",
+                              "label": "Elenwë"
+                            },
+                            {
+                              "href": "http://stiedemann.example/samuel",
+                              "label": "Aghan"
+                            },
+                            {
+                              "href": "http://rau.test/kim.larkin",
+                              "label": "Saruman"
+                            },
+                            {
+                              "href": "http://wolff.example/kieth",
+                              "label": "Argonui"
+                            },
+                            {
+                              "href": "http://will.test/vincenzo_jones",
+                              "label": "Ailinel"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "3b17152f-2106-42a5-9030-1c3693f9a515",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_b85bec4600e5b64173622792553d1c65",
+                          "title": "Qui dolores at et.",
+                          "rationale": "Et tempora earum. Rerum qui sit. Qui veniam autem.",
+                          "description": "Optio aperiam sunt. Labore sit laborum. Velit sunt minima.",
+                          "severity": "high",
+                          "precedence": 2099,
+                          "identifier": {
+                            "href": "http://flatley-donnelly.test/collin",
+                            "label": "Míriel"
+                          },
+                          "references": [
+                            {
+                              "href": "http://abbott-herzog.test/kristi_auer",
+                              "label": "Alphros"
+                            },
+                            {
+                              "href": "http://howell.test/booker.thiel",
+                              "label": "Elfhelm"
+                            },
+                            {
+                              "href": "http://hyatt.example/candelaria.legros",
+                              "label": "Fastolph Bolger"
+                            },
+                            {
+                              "href": "http://klocko.example/danelle.jaskolski",
+                              "label": "Sauron"
+                            },
+                            {
+                              "href": "http://hoeger.example/kyle",
+                              "label": "Nár"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "0522ac86-9b76-49a1-9873-a8862d6cf7b0",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_1b3883b4a1f5f67f4b57e61f2b8fb3c7",
+                          "title": "Harum deleniti nisi minima.",
+                          "rationale": "Iure consectetur mollitia. Eius soluta veniam. Voluptates eligendi officiis.",
+                          "description": "Nam consequatur adipisci. Placeat est non. Qui et debitis.",
+                          "severity": "medium",
+                          "precedence": 2155,
+                          "identifier": {
+                            "href": "http://ullrich.test/chas_legros",
+                            "label": "Tar-Telperiën"
+                          },
+                          "references": [
+                            {
+                              "href": "http://lueilwitz.example/larry",
+                              "label": "Thorondor"
+                            },
+                            {
+                              "href": "http://johnson.test/connie_conn",
+                              "label": "Glóredhel"
+                            },
+                            {
+                              "href": "http://stehr.test/gay",
+                              "label": "Ghân-buri-Ghân"
+                            },
+                            {
+                              "href": "http://green-cole.example/margaretta.doyle",
+                              "label": "Guilin"
+                            },
+                            {
+                              "href": "http://padberg.example/rosanna.legros",
+                              "label": "Herumor"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "c0a8d3c2-6362-4e9a-9c36-85919821ba03",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_f94e9f5ae56f8dc106863f45c00ab48e",
+                          "title": "Illo perspiciatis sed quis.",
+                          "rationale": "Quisquam sint perspiciatis. Accusantium ea numquam. Unde repudiandae quia.",
+                          "description": "Et debitis architecto. Et at sequi. Dolorem delectus repudiandae.",
+                          "severity": "medium",
+                          "precedence": 2642,
+                          "identifier": {
+                            "href": "http://romaguera-schuster.example/ward.reynolds",
+                            "label": "Bruno Bracegirdle"
+                          },
+                          "references": [
+                            {
+                              "href": "http://koepp.example/desire",
+                              "label": "Imlach"
+                            },
+                            {
+                              "href": "http://bins.example/margurite",
+                              "label": "Flói"
+                            },
+                            {
+                              "href": "http://luettgen-kuhic.example/velia.jones",
+                              "label": "Araval"
+                            },
+                            {
+                              "href": "http://thompson.test/yun.parker",
+                              "label": "Ornendil"
+                            },
+                            {
+                              "href": "http://goyette-hoeger.test/philip",
+                              "label": "Amarië"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "precedence"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/aad03bb5-85ea-495d-b5cc-79585605537a/rules?limit=10&offset=0&sort_by=precedence",
+                        "last": "/api/compliance/v2/security_guides/aad03bb5-85ea-495d-b5cc-79585605537a/rules?limit=10&offset=20&sort_by=precedence",
+                        "next": "/api/compliance/v2/security_guides/aad03bb5-85ea-495d-b5cc-79585605537a/rules?limit=10&offset=10&sort_by=precedence"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/rule"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/rules/{rule_id}": {
+      "get": {
+        "summary": "Request a Rule",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "description": "UUID or a ref_id with '.' characters replaced with '-'",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Returns a Rule",
+        "operationId": "Rule",
+        "responses": {
+          "200": {
+            "description": "Returns a Rule",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Rule": {
+                    "value": {
+                      "data": {
+                        "id": "de9aea62-edb4-4e98-9c20-f73221b907d2",
+                        "ref_id": "xccdf_org.ssgproject.content_rule_f86aa126fccb6d6f1932e38e1a6109a8",
+                        "title": "Velit eaque aut modi.",
+                        "rationale": "Architecto porro ducimus. Magni culpa possimus. Repellat error voluptas.",
+                        "description": "Consequatur maxime et. Voluptate et modi. Repellat perspiciatis ipsum.",
+                        "severity": "high",
+                        "precedence": 7952,
+                        "identifier": {
+                          "href": "http://walsh.test/dexter.stark",
+                          "label": "Enerdhil"
+                        },
+                        "references": [
+                          {
+                            "href": "http://borer.test/colton",
+                            "label": "Belba Baggins"
+                          },
+                          {
+                            "href": "http://rempel-price.test/jarrett",
+                            "label": "Lavender Grubb"
+                          },
+                          {
+                            "href": "http://breitenberg.example/jacob_kiehn",
+                            "label": "Gethron"
+                          },
+                          {
+                            "href": "http://turner.test/carol.tillman",
+                            "label": "Isilmë"
+                          },
+                          {
+                            "href": "http://okon.test/timmy",
+                            "label": "Dior"
+                          }
+                        ],
+                        "value_checks": null,
+                        "remediation_available": false,
+                        "type": "rule"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/rule"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Rule": {
+                    "value": {
+                      "errors": [
+                        "V2::Rule not found with ID 107780ce-7d4a-4e45-8ac3-d3c3c1866733"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/profiles/{profile_id}/rules": {
+      "get": {
+        "summary": "Request Rules assigned to a Profile",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "severity",
+                  "precedence",
+                  "remediation_available",
+                  "title:asc",
+                  "title:desc",
+                  "severity:asc",
+                  "severity:desc",
+                  "precedence:asc",
+                  "precedence:desc",
+                  "remediation_available:asc",
+                  "remediation_available:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Rules are searchable using attributes `title`, `severity`, and `remediation_available`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "profile_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Lists Rules assigned to a Profile",
+        "operationId": "ProfileRules",
+        "responses": {
+          "200": {
+            "description": "Lists Rules assigned to a Profile",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Rules": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "152ed732-e2cb-4d31-b487-727ccafaca6d",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_0367a4621b39718ed2d66533683bf8fa",
+                          "title": "Ut explicabo quis mollitia.",
+                          "rationale": "Voluptatem odio et. Non maxime a. Cum sed molestiae.",
+                          "description": "Inventore exercitationem iure. Libero nostrum excepturi. Aliquam delectus cumque.",
+                          "severity": "medium",
+                          "precedence": 8034,
+                          "identifier": {
+                            "href": "http://schmitt.example/bryce",
+                            "label": "Beechbone"
+                          },
+                          "references": [
+                            {
+                              "href": "http://conroy-boyer.test/ross",
+                              "label": "Baragund"
+                            },
+                            {
+                              "href": "http://heathcote-maggio.example/bart_swift",
+                              "label": "Adamanta Chubb"
+                            },
+                            {
+                              "href": "http://bartell.example/wilbur",
+                              "label": "Belen"
+                            },
+                            {
+                              "href": "http://kuvalis.example/evan",
+                              "label": "Aerin"
+                            },
+                            {
+                              "href": "http://conn-lakin.example/delila_anderson",
+                              "label": "Durin"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "19f8b4c9-02cc-4b72-9dac-b790eb94490d",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_83a2a249a503f72596cefe438e5b933e",
+                          "title": "Doloribus neque qui omnis.",
+                          "rationale": "In aut soluta. Laudantium qui ipsa. Doloribus quia odit.",
+                          "description": "Vel ipsa est. Ut repudiandae consequuntur. Et laudantium aliquid.",
+                          "severity": "high",
+                          "precedence": 4210,
+                          "identifier": {
+                            "href": "http://hintz.test/marie",
+                            "label": "Calmacil"
+                          },
+                          "references": [
+                            {
+                              "href": "http://hamill.example/winnifred",
+                              "label": "Fengel"
+                            },
+                            {
+                              "href": "http://schiller-hettinger.example/carleen_mayert",
+                              "label": "Heribald Bolger"
+                            },
+                            {
+                              "href": "http://auer-maggio.test/kirstie_stroman",
+                              "label": "Thorondir"
+                            },
+                            {
+                              "href": "http://bashirian-zboncak.example/roland.schaden",
+                              "label": "Arachon"
+                            },
+                            {
+                              "href": "http://kunde-herman.example/toshia",
+                              "label": "Ivriniel"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "1b0132e9-8782-434e-8e20-e915c6f117bd",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_415be0d94c25b84505b583da416efbc8",
+                          "title": "Consequatur sapiente molestiae nostrum.",
+                          "rationale": "Molestiae recusandae aut. Veniam consequatur ut. Reprehenderit dolorum alias.",
+                          "description": "Quisquam qui assumenda. Repellat voluptatem laboriosam. Voluptates quia aliquam.",
+                          "severity": "low",
+                          "precedence": 574,
+                          "identifier": {
+                            "href": "http://romaguera-ziemann.example/jestine",
+                            "label": "Malva Headstrong"
+                          },
+                          "references": [
+                            {
+                              "href": "http://berge.test/jason.wunsch",
+                              "label": "Ban"
+                            },
+                            {
+                              "href": "http://koelpin.test/curtis",
+                              "label": "Ingold"
+                            },
+                            {
+                              "href": "http://schumm.test/melisa_stanton",
+                              "label": "Elboron"
+                            },
+                            {
+                              "href": "http://tillman.example/sallie",
+                              "label": "Golfimbul"
+                            },
+                            {
+                              "href": "http://okeefe-dietrich.example/annita.luettgen",
+                              "label": "Emeldir"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "1e5ebfbf-d1ed-493e-926d-b044cc091c04",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_4af90a09051b2a236af3bdb42bf56ad5",
+                          "title": "Aut est iure aut.",
+                          "rationale": "Asperiores et minus. Saepe quos voluptatem. Esse et repellat.",
+                          "description": "Placeat voluptas quia. Commodi dignissimos quis. Voluptatibus iure praesentium.",
+                          "severity": "low",
+                          "precedence": 1606,
+                          "identifier": {
+                            "href": "http://labadie.test/terence",
+                            "label": "Uffo Boffin"
+                          },
+                          "references": [
+                            {
+                              "href": "http://nienow-grant.example/sueann.lubowitz",
+                              "label": "Borondir"
+                            },
+                            {
+                              "href": "http://larkin.test/elliott",
+                              "label": "Ar-Zimrathôn"
+                            },
+                            {
+                              "href": "http://predovic.test/alvaro_feil",
+                              "label": "Elemmakil"
+                            },
+                            {
+                              "href": "http://reilly-ziemann.example/jestine.morissette",
+                              "label": "Arvedui"
+                            },
+                            {
+                              "href": "http://kessler.test/ali",
+                              "label": "Orophin"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "2701f2be-b3e6-431c-8d3e-a7760ddab60d",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_8d97a1d702e27358be1c0b80619ea9f3",
+                          "title": "Impedit explicabo quos ipsum.",
+                          "rationale": "Aut quaerat est. Molestias incidunt magnam. Facere assumenda quos.",
+                          "description": "Voluptas dolorem provident. Occaecati voluptatem fugit. Quis voluptatem est.",
+                          "severity": "medium",
+                          "precedence": 4467,
+                          "identifier": {
+                            "href": "http://white.example/merideth",
+                            "label": "Elwing"
+                          },
+                          "references": [
+                            {
+                              "href": "http://runolfsson.example/lindsay",
+                              "label": "Eldarion"
+                            },
+                            {
+                              "href": "http://wisozk.example/shirley_torp",
+                              "label": "Bëor"
+                            },
+                            {
+                              "href": "http://heaney-muller.test/elton",
+                              "label": "Ar-Zimrathôn"
+                            },
+                            {
+                              "href": "http://reinger-murphy.test/craig.schultz",
+                              "label": "Ulfast"
+                            },
+                            {
+                              "href": "http://stehr-brekke.test/lesha",
+                              "label": "Peregrin Took"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "287111b4-aea8-4b48-b65f-bb2e26f962fe",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_9a8fa37dae0abe7d9fc61b8209153112",
+                          "title": "Quia et sed necessitatibus.",
+                          "rationale": "Dicta ut sed. Qui atque ipsa. Dolorem ut optio.",
+                          "description": "Aut accusantium nobis. Voluptatem veritatis ut. Incidunt non voluptatem.",
+                          "severity": "high",
+                          "precedence": 1212,
+                          "identifier": {
+                            "href": "http://dach.example/rich.zboncak",
+                            "label": "Dora Baggins"
+                          },
+                          "references": [
+                            {
+                              "href": "http://reichert.example/norris",
+                              "label": "Azaghâl"
+                            },
+                            {
+                              "href": "http://sawayn.test/anderson",
+                              "label": "Quickbeam"
+                            },
+                            {
+                              "href": "http://weimann.test/jordon.mohr",
+                              "label": "Wilibald Bolger"
+                            },
+                            {
+                              "href": "http://carroll-bechtelar.test/horacio.rogahn",
+                              "label": "Valandil"
+                            },
+                            {
+                              "href": "http://olson.test/val_gutkowski",
+                              "label": "Farmer Cotton"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "28aca8f2-379d-4480-a786-e4400f053f31",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_8a6fea972710ce04da0febcdce99e32d",
+                          "title": "Impedit est cum tenetur.",
+                          "rationale": "Aut repellendus quaerat. Expedita deleniti sed. Possimus autem ratione.",
+                          "description": "Sed dolore culpa. Quo ipsa rerum. Totam ratione pariatur.",
+                          "severity": "low",
+                          "precedence": 1261,
+                          "identifier": {
+                            "href": "http://rau-gleason.test/tommie",
+                            "label": "Gollum"
+                          },
+                          "references": [
+                            {
+                              "href": "http://schmidt-dubuque.example/fernando_nitzsche",
+                              "label": "Marhari"
+                            },
+                            {
+                              "href": "http://sporer.example/keri.kuhn",
+                              "label": "Galador"
+                            },
+                            {
+                              "href": "http://wyman-kuhn.example/stephaine.kautzer",
+                              "label": "Gimilzagar"
+                            },
+                            {
+                              "href": "http://oconnell.test/dustin",
+                              "label": "Ulrad"
+                            },
+                            {
+                              "href": "http://braun.example/darnell",
+                              "label": "Hildigard Took"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "3729a419-c2a1-45ba-bf39-252fec769099",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_f3038e2062e022a36a11be2f8b8f94b3",
+                          "title": "Qui ut molestiae aut.",
+                          "rationale": "Doloribus perferendis qui. Ex quasi dolores. Dignissimos quia sit.",
+                          "description": "Nisi repudiandae voluptate. Nulla quae delectus. Rerum maiores inventore.",
+                          "severity": "high",
+                          "precedence": 7662,
+                          "identifier": {
+                            "href": "http://wyman-satterfield.example/angelo",
+                            "label": "Anairë"
+                          },
+                          "references": [
+                            {
+                              "href": "http://heidenreich.test/reggie",
+                              "label": "Sagroth"
+                            },
+                            {
+                              "href": "http://pollich.test/doug.dietrich",
+                              "label": "Aravorn"
+                            },
+                            {
+                              "href": "http://mraz.test/zackary_jenkins",
+                              "label": "Ostoher"
+                            },
+                            {
+                              "href": "http://schmitt.example/mose.wehner",
+                              "label": "Saruman"
+                            },
+                            {
+                              "href": "http://dibbert-haag.example/antione.okon",
+                              "label": "Adam Hornblower"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "3f5ca9fe-b18b-486d-a803-90bfbddb5999",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_251322110ddeb8a931fb73da678e2ff7",
+                          "title": "Asperiores est qui tenetur.",
+                          "rationale": "Mollitia non repellendus. Commodi deserunt et. Sit fuga consequatur.",
+                          "description": "Odio et consequatur. Aut autem est. Ea animi accusamus.",
+                          "severity": "medium",
+                          "precedence": 1889,
+                          "identifier": {
+                            "href": "http://hermiston.test/mel",
+                            "label": "Bruno Bracegirdle"
+                          },
+                          "references": [
+                            {
+                              "href": "http://schroeder.test/kristle",
+                              "label": "Ar-Adûnakhôr"
+                            },
+                            {
+                              "href": "http://murphy.example/yuette",
+                              "label": "Angbor"
+                            },
+                            {
+                              "href": "http://casper-walter.example/chase.ebert",
+                              "label": "Tar-Aldarion"
+                            },
+                            {
+                              "href": "http://doyle.example/benedict_jenkins",
+                              "label": "Carc"
+                            },
+                            {
+                              "href": "http://robel-reynolds.example/eric_schumm",
+                              "label": "Hazad"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "510c99fc-4fca-4afe-b584-f9d933a9a36d",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_5ad7331cd45c74412cd00df622434778",
+                          "title": "Nesciunt sed recusandae voluptate.",
+                          "rationale": "Nam labore sed. Ut ea reiciendis. Iure nam facere.",
+                          "description": "Voluptas error tempore. Alias et veniam. Illum vel dolorem.",
+                          "severity": "high",
+                          "precedence": 9175,
+                          "identifier": {
+                            "href": "http://flatley.example/bryant_hegmann",
+                            "label": "Lóni"
+                          },
+                          "references": [
+                            {
+                              "href": "http://thompson.example/norman_hettinger",
+                              "label": "Andwise Roper"
+                            },
+                            {
+                              "href": "http://schneider.example/deidre_kuhic",
+                              "label": "Anardil"
+                            },
+                            {
+                              "href": "http://renner-lindgren.example/carleen_gusikowski",
+                              "label": "Brandir"
+                            },
+                            {
+                              "href": "http://macejkovic.test/olen",
+                              "label": "Willie Banks"
+                            },
+                            {
+                              "href": "http://heller.example/modesto.rowe",
+                              "label": "Mrs. Bunce"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/c87e9d85-e2e0-460b-8f50-f8a9e5f8d40d/profiles/d75b2eca-f8f3-4330-90db-b14b9fc96327/rules?limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides/c87e9d85-e2e0-460b-8f50-f8a9e5f8d40d/profiles/d75b2eca-f8f3-4330-90db-b14b9fc96327/rules?limit=10&offset=20",
+                        "next": "/api/compliance/v2/security_guides/c87e9d85-e2e0-460b-8f50-f8a9e5f8d40d/profiles/d75b2eca-f8f3-4330-90db-b14b9fc96327/rules?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Rules sorted by \"precedence:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "f470d23b-af0c-4dbe-bd77-4dd385d9f840",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_1a095130ee3870cc877bc5b3efca4077",
+                          "title": "Placeat aut qui est.",
+                          "rationale": "Impedit architecto aut. Voluptate eaque repellat. Possimus repellendus odio.",
+                          "description": "Nesciunt doloremque nihil. Sapiente ipsum nam. Exercitationem voluptas rerum.",
+                          "severity": "medium",
+                          "precedence": 88,
+                          "identifier": {
+                            "href": "http://cremin-morissette.test/sherman_boyer",
+                            "label": "Aragost"
+                          },
+                          "references": [
+                            {
+                              "href": "http://schmidt.test/foster",
+                              "label": "Elwing"
+                            },
+                            {
+                              "href": "http://stiedemann.test/rafael_muller",
+                              "label": "Arathorn"
+                            },
+                            {
+                              "href": "http://kris.example/anabel",
+                              "label": "Idril"
+                            },
+                            {
+                              "href": "http://streich.example/joaquina",
+                              "label": "Frumgar"
+                            },
+                            {
+                              "href": "http://brakus.test/georgetta.jacobs",
+                              "label": "Hirgon"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "f63ec04a-34f8-4769-a29f-890d54650b67",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_b260d44c9821edb98d5105bee34c3299",
+                          "title": "Eius odit et nesciunt.",
+                          "rationale": "Et ipsum nulla. Neque hic atque. Magni nihil dolore.",
+                          "description": "Vel ipsa est. Ipsum architecto corporis. Non rerum dolores.",
+                          "severity": "high",
+                          "precedence": 512,
+                          "identifier": {
+                            "href": "http://schimmel.test/omar",
+                            "label": "Ulrad"
+                          },
+                          "references": [
+                            {
+                              "href": "http://emard-stamm.example/mel_pacocha",
+                              "label": "Nora Bolger"
+                            },
+                            {
+                              "href": "http://labadie.test/carmen",
+                              "label": "Wilimar Bolger"
+                            },
+                            {
+                              "href": "http://kilback.example/isaiah.stanton",
+                              "label": "Aragorn"
+                            },
+                            {
+                              "href": "http://brown.test/edmundo.wehner",
+                              "label": "Eglantine Banks"
+                            },
+                            {
+                              "href": "http://hoeger.test/yong.stroman",
+                              "label": "Enthor"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "3d2cd4f3-5381-4b75-bf6a-46dd070adffb",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_054d063a5329daf0da07f07908134c19",
+                          "title": "Architecto id et commodi.",
+                          "rationale": "Quia tempora porro. Dolor nihil itaque. Veritatis similique assumenda.",
+                          "description": "Aperiam ea fugit. Cum odio voluptas. Vel pariatur voluptatibus.",
+                          "severity": "high",
+                          "precedence": 1207,
+                          "identifier": {
+                            "href": "http://kihn.example/dodie_schiller",
+                            "label": "Narmacil"
+                          },
+                          "references": [
+                            {
+                              "href": "http://grady-mckenzie.example/delia",
+                              "label": "Erling"
+                            },
+                            {
+                              "href": "http://kihn.test/hal",
+                              "label": "Ferumbras Took"
+                            },
+                            {
+                              "href": "http://breitenberg.example/ethyl.bashirian",
+                              "label": "Tar-Ardamin"
+                            },
+                            {
+                              "href": "http://hegmann.example/dirk",
+                              "label": "Great Eagle"
+                            },
+                            {
+                              "href": "http://walsh.example/dion",
+                              "label": "Anairë"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "c35fc0eb-0c67-4265-babf-757de77932c8",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_cbf04be768894b31312ffe1f8cd83455",
+                          "title": "Voluptatem sit maiores iusto.",
+                          "rationale": "Eligendi facilis vel. Aliquam tempora officia. Odio quam non.",
+                          "description": "Qui nesciunt ad. Esse nulla expedita. Porro recusandae illo.",
+                          "severity": "high",
+                          "precedence": 1590,
+                          "identifier": {
+                            "href": "http://lueilwitz.example/laurene.hammes",
+                            "label": "Tar-Palantir"
+                          },
+                          "references": [
+                            {
+                              "href": "http://oreilly.example/gino_glover",
+                              "label": "Hathaldir"
+                            },
+                            {
+                              "href": "http://robel-johnston.example/launa",
+                              "label": "Grim"
+                            },
+                            {
+                              "href": "http://cassin.example/janyce",
+                              "label": "Imin"
+                            },
+                            {
+                              "href": "http://lindgren.test/matilda",
+                              "label": "Angelimir"
+                            },
+                            {
+                              "href": "http://torp-klocko.example/tracee_pfeffer",
+                              "label": "Boar of Everholt"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "1e2e85b7-6719-44cc-9710-65264f82657f",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_f67dd5df78d4eea871e913379101f90f",
+                          "title": "Tenetur nesciunt sint iure.",
+                          "rationale": "Quia in cupiditate. Aspernatur laboriosam est. Recusandae sint pariatur.",
+                          "description": "Voluptatem vitae repellendus. Est animi sit. Eos perferendis esse.",
+                          "severity": "medium",
+                          "precedence": 2388,
+                          "identifier": {
+                            "href": "http://leffler-maggio.test/walton.effertz",
+                            "label": "Tar-Elendil"
+                          },
+                          "references": [
+                            {
+                              "href": "http://sporer.example/yajaira_smitham",
+                              "label": "Erling"
+                            },
+                            {
+                              "href": "http://olson.example/christen_weimann",
+                              "label": "Gaffer Gamgee"
+                            },
+                            {
+                              "href": "http://mcclure.test/perla.waelchi",
+                              "label": "Walda"
+                            },
+                            {
+                              "href": "http://jenkins.example/mitsue.upton",
+                              "label": "Polo Baggins"
+                            },
+                            {
+                              "href": "http://gutmann.test/quentin.schumm",
+                              "label": "Adrahil"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "dfc8aca9-e2dc-4da0-9374-39df44c2aac7",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_e21c9e585ead182b4ff606a5a80bbec4",
+                          "title": "Ab sint voluptatibus delectus.",
+                          "rationale": "A eum ea. Libero at pariatur. Velit nam deleniti.",
+                          "description": "Porro ut vitae. In velit nobis. Architecto cum doloribus.",
+                          "severity": "medium",
+                          "precedence": 2500,
+                          "identifier": {
+                            "href": "http://swaniawski-emard.example/pete",
+                            "label": "Berilac Brandybuck"
+                          },
+                          "references": [
+                            {
+                              "href": "http://muller.example/wesley_schiller",
+                              "label": "Valacar"
+                            },
+                            {
+                              "href": "http://brekke-bins.test/nelia_bernier",
+                              "label": "Déor"
+                            },
+                            {
+                              "href": "http://lowe-rippin.example/larita",
+                              "label": "Tom Bombadil"
+                            },
+                            {
+                              "href": "http://barton-murphy.test/kevin_sporer",
+                              "label": "Bucca of the Marish"
+                            },
+                            {
+                              "href": "http://glover-trantow.example/naida",
+                              "label": "Rudolph Bolger"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "f309601e-d04a-4d50-86b2-b0be061e7fe6",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_b394ceef29e76da9978a51560e8db13f",
+                          "title": "Reiciendis doloremque maxime amet.",
+                          "rationale": "Dolorem sunt minus. Vitae aut alias. Doloribus optio est.",
+                          "description": "Eius laudantium quod. Dolorem quia qui. Rem tempore inventore.",
+                          "severity": "high",
+                          "precedence": 2961,
+                          "identifier": {
+                            "href": "http://bins.test/sharyl_schimmel",
+                            "label": "Smaug"
+                          },
+                          "references": [
+                            {
+                              "href": "http://bruen.example/dusti",
+                              "label": "Gimilzagar"
+                            },
+                            {
+                              "href": "http://brown-walker.test/aimee",
+                              "label": "Nimloth of Doriath"
+                            },
+                            {
+                              "href": "http://barton.test/kami.mann",
+                              "label": "Bergil"
+                            },
+                            {
+                              "href": "http://schneider.example/don.mertz",
+                              "label": "Legolas"
+                            },
+                            {
+                              "href": "http://goldner.example/felicitas_schumm",
+                              "label": "Grishnákh"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "2536da91-6d5f-4201-8208-70e8060a700a",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_4e379d953b1752b0cd72f12aeedf06da",
+                          "title": "Qui vero eos impedit.",
+                          "rationale": "Vitae facilis dolores. Consequatur ut enim. Modi qui ipsum.",
+                          "description": "Est consectetur cum. Doloribus animi rerum. Sed odio magni.",
+                          "severity": "high",
+                          "precedence": 3375,
+                          "identifier": {
+                            "href": "http://schamberger-hayes.test/moises",
+                            "label": "Lindir"
+                          },
+                          "references": [
+                            {
+                              "href": "http://osinski.test/celia.dach",
+                              "label": "Turgon"
+                            },
+                            {
+                              "href": "http://gusikowski.test/freddy_greenholt",
+                              "label": "Denethor"
+                            },
+                            {
+                              "href": "http://langosh.example/krista",
+                              "label": "Berúthiel"
+                            },
+                            {
+                              "href": "http://rosenbaum-bartell.example/yen.treutel",
+                              "label": "Adamanta Chubb"
+                            },
+                            {
+                              "href": "http://murray.example/landon",
+                              "label": "Bowman Cotton"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "259999ee-0c66-4ed0-8385-e06286daba3a",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_201d3759950e3bf089cd6590df254591",
+                          "title": "In error magnam qui.",
+                          "rationale": "Amet occaecati culpa. Sunt velit rerum. Labore aliquam impedit.",
+                          "description": "Voluptatem sint deserunt. At deleniti consequatur. Ratione et error.",
+                          "severity": "low",
+                          "precedence": 3617,
+                          "identifier": {
+                            "href": "http://glover.test/maud_monahan",
+                            "label": "Tar-Ancalimë"
+                          },
+                          "references": [
+                            {
+                              "href": "http://koepp.test/walter",
+                              "label": "Imlach"
+                            },
+                            {
+                              "href": "http://fisher.example/delmar",
+                              "label": "Arvegil"
+                            },
+                            {
+                              "href": "http://bernier.example/loren.schinner",
+                              "label": "Nazgûl"
+                            },
+                            {
+                              "href": "http://nader-larkin.example/preston",
+                              "label": "Baranor"
+                            },
+                            {
+                              "href": "http://conroy.example/lindsey_skiles",
+                              "label": "Eärendil"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        },
+                        {
+                          "id": "ff5f6637-e615-421d-9f8f-bfe35f322b34",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_21f5b65b5490c7010e2e0952df456ad9",
+                          "title": "Est dolorem maiores laborum.",
+                          "rationale": "Fugit autem placeat. Enim aperiam quisquam. Impedit assumenda architecto.",
+                          "description": "Ut qui voluptas. Temporibus eveniet accusamus. Consequuntur exercitationem sit.",
+                          "severity": "high",
+                          "precedence": 4382,
+                          "identifier": {
+                            "href": "http://corkery.test/setsuko.simonis",
+                            "label": "Bodruith"
+                          },
+                          "references": [
+                            {
+                              "href": "http://kuhlman.test/herbert",
+                              "label": "Berúthiel"
+                            },
+                            {
+                              "href": "http://sawayn-kutch.example/dionna",
+                              "label": "Haldad"
+                            },
+                            {
+                              "href": "http://borer-smith.test/ron_ankunding",
+                              "label": "Lúthien"
+                            },
+                            {
+                              "href": "http://hodkiewicz.test/seth.murphy",
+                              "label": "Minto Burrows"
+                            },
+                            {
+                              "href": "http://rohan-fahey.example/sarai",
+                              "label": "Gram"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule",
+                          "remediation_issue_id": null
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "precedence"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/7b108f68-7140-4ba6-ad6c-849b81ad2cd6/profiles/53e9417e-f74b-4720-b725-812606301e51/rules?limit=10&offset=0&sort_by=precedence",
+                        "last": "/api/compliance/v2/security_guides/7b108f68-7140-4ba6-ad6c-849b81ad2cd6/profiles/53e9417e-f74b-4720-b725-812606301e51/rules?limit=10&offset=20&sort_by=precedence",
+                        "next": "/api/compliance/v2/security_guides/7b108f68-7140-4ba6-ad6c-849b81ad2cd6/profiles/53e9417e-f74b-4720-b725-812606301e51/rules?limit=10&offset=10&sort_by=precedence"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/rule"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/profiles/{profile_id}/rules/{rule_id}": {
+      "get": {
+        "summary": "Request a Rule assigned to a Profile",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "profile_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "description": "UUID or a ref_id with '.' characters replaced with '-'",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Returns a Rule assigned to a Profile",
+        "operationId": "ProfileRule",
+        "responses": {
+          "200": {
+            "description": "Returns a Rule assigned to a Profile",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Rule": {
+                    "value": {
+                      "data": {
+                        "id": "7e1ded67-f48a-4b03-9a8c-bd3c6d520fef",
+                        "ref_id": "xccdf_org.ssgproject.content_rule_42bc3b76646e124a46946b5867bca458",
+                        "title": "Ab consequatur quia iusto.",
+                        "rationale": "Laudantium quasi dignissimos. Non fuga sed. Labore nemo reprehenderit.",
+                        "description": "Temporibus autem magnam. Ut omnis non. Fugiat saepe omnis.",
+                        "severity": "low",
+                        "precedence": 1677,
+                        "identifier": {
+                          "href": "http://bechtelar-skiles.example/joselyn.konopelski",
+                          "label": "Halmir"
+                        },
+                        "references": [
+                          {
+                            "href": "http://ziemann.test/carol.wilkinson",
+                            "label": "Holman Cotton"
+                          },
+                          {
+                            "href": "http://walker.example/rosalee_paucek",
+                            "label": "Gundor"
+                          },
+                          {
+                            "href": "http://hamill-stracke.test/francisco",
+                            "label": "Estella Bolger"
+                          },
+                          {
+                            "href": "http://farrell.test/lulu_hegmann",
+                            "label": "Great Eagle"
+                          },
+                          {
+                            "href": "http://koepp.example/soo_christiansen",
+                            "label": "Rose Gardner"
+                          }
+                        ],
+                        "value_checks": null,
+                        "remediation_available": false,
+                        "type": "rule",
+                        "remediation_issue_id": null
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/rule"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Rule": {
+                    "value": {
+                      "errors": [
+                        "V2::Rule not found with ID 748d49d3-e8d1-4316-87bf-79a482db77bc"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{policy_id}/tailorings/{tailoring_id}/rules": {
+      "get": {
+        "summary": "Request Rules assigned to a Tailoring",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "severity",
+                  "precedence",
+                  "remediation_available",
+                  "title:asc",
+                  "title:desc",
+                  "severity:asc",
+                  "severity:desc",
+                  "precedence:asc",
+                  "precedence:desc",
+                  "remediation_available:asc",
+                  "remediation_available:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Rules are searchable using attributes `title`, `severity`, and `remediation_available`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tailoring_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Lists Rules assigned to a Tailoring",
+        "operationId": "TailoringRules",
+        "responses": {
+          "200": {
+            "description": "Lists Rules assigned to a Tailoring",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Rules": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "389b67a2-a853-4f4c-bbb9-55d1277d0c98",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_98894d64e3e03bc851958489b416fd53",
+                          "title": "Est incidunt esse molestias.",
+                          "rationale": "Assumenda eius molestiae. Aut et nobis. Beatae ut autem.",
+                          "description": "Reiciendis dicta et. Non et soluta. Maiores expedita dolorum.",
+                          "severity": "low",
+                          "precedence": 1784,
+                          "identifier": {
+                            "href": "http://aufderhar.example/granville.hagenes",
+                            "label": "Lalaith"
+                          },
+                          "references": [
+                            {
+                              "href": "http://johns.example/effie.ryan",
+                              "label": "Caranthir"
+                            },
+                            {
+                              "href": "http://turner-hermann.test/hyman",
+                              "label": "Aerin"
+                            },
+                            {
+                              "href": "http://gerlach-koch.example/eleonora_blick",
+                              "label": "Saradas Brandybuck"
+                            },
+                            {
+                              "href": "http://langworth.example/esther.crooks",
+                              "label": "Orodreth"
+                            },
+                            {
+                              "href": "http://little.example/micheal.ferry",
+                              "label": "Borondir"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        }
+                      ],
+                      "meta": {
+                        "total": 1,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/bf441e15-c6ef-475b-bd23-3d3c3e821efe/tailorings/366f3942-b57b-4d22-8a0c-8b70182fa698/rules?limit=10&offset=0",
+                        "last": "/api/compliance/v2/policies/bf441e15-c6ef-475b-bd23-3d3c3e821efe/tailorings/366f3942-b57b-4d22-8a0c-8b70182fa698/rules?limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Rules sorted by \"precedence:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "3a42166d-fbcd-4569-8aa7-6cb8b8685b78",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_9defe669ec55c47faafbb3acd18d5dcc",
+                          "title": "Nostrum et assumenda rerum.",
+                          "rationale": "Quae quia qui. Minus similique ut. Modi ea error.",
+                          "description": "Doloremque atque expedita. Illo qui nisi. Labore dolores non.",
+                          "severity": "high",
+                          "precedence": 2679,
+                          "identifier": {
+                            "href": "http://mosciski-considine.test/sebastian_leuschke",
+                            "label": "Ferdibrand Took"
+                          },
+                          "references": [
+                            {
+                              "href": "http://bartell-lynch.test/alexis",
+                              "label": "Orgulas Brandybuck"
+                            },
+                            {
+                              "href": "http://rogahn.example/emmanuel",
+                              "label": "Snaga"
+                            },
+                            {
+                              "href": "http://runolfsdottir.test/cordell",
+                              "label": "Thráin"
+                            },
+                            {
+                              "href": "http://wiza-lowe.test/flossie",
+                              "label": "Dorlas"
+                            },
+                            {
+                              "href": "http://robel.example/kerry",
+                              "label": "Agathor"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        }
+                      ],
+                      "meta": {
+                        "total": 1,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "precedence"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/189fcb78-ce5a-4621-822e-72a42ceefd09/tailorings/e0ed41f3-b7ad-4b27-a931-939b2012bbc4/rules?limit=10&offset=0&sort_by=precedence",
+                        "last": "/api/compliance/v2/policies/189fcb78-ce5a-4621-822e-72a42ceefd09/tailorings/e0ed41f3-b7ad-4b27-a931-939b2012bbc4/rules?limit=10&offset=0&sort_by=precedence"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/rule"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Bulk assign Rules to a Tailoring",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tailoring_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "This feature is exclusively used by the frontend",
+        "deprecated": true,
+        "operationId": "AssignRules",
+        "responses": {
+          "202": {
+            "description": "Assigns all specified rules and unassigns the rest",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of assigned Rules": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "244bed52-116c-43f4-858d-6a24774f27da",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_ff4a6010ca1b39b7e0ebe5a4a4b4b144",
+                          "title": "Praesentium sed enim unde.",
+                          "rationale": "Sed ratione unde. Fuga et sed. Odio aut eligendi.",
+                          "description": "Id quis magni. Voluptas id vero. Sequi voluptas qui.",
+                          "severity": "medium",
+                          "precedence": 7407,
+                          "identifier": {
+                            "href": "http://bruen-schuster.example/ernest",
+                            "label": "Ostoher"
+                          },
+                          "references": [
+                            {
+                              "href": "http://sipes.example/larita.casper",
+                              "label": "Guthláf"
+                            },
+                            {
+                              "href": "http://okeefe-toy.example/alejandro_champlin",
+                              "label": "Huan"
+                            },
+                            {
+                              "href": "http://mills-white.example/susy_lakin",
+                              "label": "Seredic Brandybuck"
+                            },
+                            {
+                              "href": "http://pagac.example/janet_thompson",
+                              "label": "Elros"
+                            },
+                            {
+                              "href": "http://waters.test/rina",
+                              "label": "Grishnákh"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "3bc686c6-c102-4750-8b9f-6c5691cac6ef",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_6b2e7c8ce0dcccd7439b80399068b8eb",
+                          "title": "In sapiente aut et.",
+                          "rationale": "Aut ullam quae. Et pariatur eum. Eos assumenda at.",
+                          "description": "Ea minima at. Eaque voluptatibus exercitationem. Quas voluptatum delectus.",
+                          "severity": "high",
+                          "precedence": 6660,
+                          "identifier": {
+                            "href": "http://schimmel.example/freeman_funk",
+                            "label": "Tar-Palantir"
+                          },
+                          "references": [
+                            {
+                              "href": "http://fisher.test/martin",
+                              "label": "Manthor"
+                            },
+                            {
+                              "href": "http://towne-brekke.example/corrina_fisher",
+                              "label": "Lorgan"
+                            },
+                            {
+                              "href": "http://macgyver-gibson.test/norman_hahn",
+                              "label": "Anson Roper"
+                            },
+                            {
+                              "href": "http://shields-jenkins.example/mac_willms",
+                              "label": "Angrim"
+                            },
+                            {
+                              "href": "http://hickle-spencer.test/kerry_ratke",
+                              "label": "Arveleg"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "478c4e0e-4322-476e-825c-85b9a34f23ed",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_3184b8b413b4a191a37549213893d782",
+                          "title": "Saepe qui doloribus amet.",
+                          "rationale": "Expedita minima sit. Libero provident aut. Quos perspiciatis aut.",
+                          "description": "Odio quia tempore. Officiis in est. Non odit minus.",
+                          "severity": "medium",
+                          "precedence": 4492,
+                          "identifier": {
+                            "href": "http://keebler.test/moriah",
+                            "label": "Olwë"
+                          },
+                          "references": [
+                            {
+                              "href": "http://hickle.test/shawnda.wilkinson",
+                              "label": "Marhwini"
+                            },
+                            {
+                              "href": "http://schuster-flatley.example/karey.lehner",
+                              "label": "Rorimac Brandybuck"
+                            },
+                            {
+                              "href": "http://bode-cole.example/willis",
+                              "label": "Erestor"
+                            },
+                            {
+                              "href": "http://hamill-kilback.test/erminia.schaden",
+                              "label": "Halfred Greenhand"
+                            },
+                            {
+                              "href": "http://ward-huels.test/orville",
+                              "label": "Elladan"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "4830a689-4938-418e-8b95-985979284bc5",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_a19f79d616ce2a21f40454fa3062567b",
+                          "title": "Ut nostrum aliquam ipsa.",
+                          "rationale": "Odit atque rerum. Nihil rerum doloremque. Tempore est nihil.",
+                          "description": "Id incidunt aut. Animi autem eum. Quo molestiae est.",
+                          "severity": "low",
+                          "precedence": 289,
+                          "identifier": {
+                            "href": "http://wilkinson.example/tiffani",
+                            "label": "Haldan"
+                          },
+                          "references": [
+                            {
+                              "href": "http://kemmer.test/earleen_jast",
+                              "label": "Mouth of Sauron"
+                            },
+                            {
+                              "href": "http://nolan-ankunding.test/alyce",
+                              "label": "King of the Dead"
+                            },
+                            {
+                              "href": "http://rosenbaum-witting.test/devin.koelpin",
+                              "label": "Pervinca Took"
+                            },
+                            {
+                              "href": "http://lehner.example/marylou.nitzsche",
+                              "label": "Angelica Baggins"
+                            },
+                            {
+                              "href": "http://herman.example/cathrine",
+                              "label": "Hildigrim Took"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "488329ca-56db-44d6-897f-ba62a2e0a014",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_aa16ccbf1d0c748ab6ad7cdfb8a8ed36",
+                          "title": "Sint alias nobis atque.",
+                          "rationale": "Ipsam explicabo molestiae. Numquam tempora enim. Molestias sed maiores.",
+                          "description": "Sit aut dolorum. Totam magni rerum. Omnis cupiditate exercitationem.",
+                          "severity": "low",
+                          "precedence": 6390,
+                          "identifier": {
+                            "href": "http://rutherford.example/colby_becker",
+                            "label": "Gorgol"
+                          },
+                          "references": [
+                            {
+                              "href": "http://vonrueden.test/dario",
+                              "label": "Aerin"
+                            },
+                            {
+                              "href": "http://wyman.example/serafina.abbott",
+                              "label": "Vinitharya"
+                            },
+                            {
+                              "href": "http://senger.test/melani.connelly",
+                              "label": "Fengel"
+                            },
+                            {
+                              "href": "http://connelly-rohan.test/karan.carroll",
+                              "label": "Bill Butcher"
+                            },
+                            {
+                              "href": "http://hudson.example/adrianna.corwin",
+                              "label": "Hareth"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "49ce2dfc-7804-4a87-9b77-1ed26d84751e",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_bacae14bff03750fd68a31c11142f0ae",
+                          "title": "Aut impedit minima dolorem.",
+                          "rationale": "Ut rerum qui. Laudantium minus sit. Veritatis quia et.",
+                          "description": "Unde minus reiciendis. Repellendus assumenda expedita. Deleniti eveniet illum.",
+                          "severity": "medium",
+                          "precedence": 4421,
+                          "identifier": {
+                            "href": "http://denesik-lindgren.example/whitney_schuster",
+                            "label": "Daddy Twofoot"
+                          },
+                          "references": [
+                            {
+                              "href": "http://altenwerth.example/tiesha",
+                              "label": "Tar-Alcarin"
+                            },
+                            {
+                              "href": "http://deckow.example/neda",
+                              "label": "Eärnur"
+                            },
+                            {
+                              "href": "http://cole.test/davina",
+                              "label": "Muzgash"
+                            },
+                            {
+                              "href": "http://yundt.example/rudolf",
+                              "label": "Haldir"
+                            },
+                            {
+                              "href": "http://upton.test/peter",
+                              "label": "Ferumbras Took"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "4b53084c-d752-4689-a9a0-fc5dbb7157fe",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_535fede33be32d2412f089ea46ad5213",
+                          "title": "Dolorum nesciunt voluptas vel.",
+                          "rationale": "Doloremque tempore vel. Possimus assumenda ut. Maiores quo quas.",
+                          "description": "Voluptate dolores et. Qui nam quod. Perferendis sunt eius.",
+                          "severity": "low",
+                          "precedence": 5708,
+                          "identifier": {
+                            "href": "http://heidenreich.example/lanette",
+                            "label": "Tatië"
+                          },
+                          "references": [
+                            {
+                              "href": "http://rohan.example/phylicia_brekke",
+                              "label": "Tar-Súrion"
+                            },
+                            {
+                              "href": "http://robel.test/leticia",
+                              "label": "Mogru"
+                            },
+                            {
+                              "href": "http://kreiger.example/emerita",
+                              "label": "Fíriel Fairbairn"
+                            },
+                            {
+                              "href": "http://quitzon.test/nolan",
+                              "label": "Scatha"
+                            },
+                            {
+                              "href": "http://padberg.test/scott",
+                              "label": "Eglantine Banks"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "4ecf6ff8-01d6-4257-82d8-bbc8f7c5ee8d",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_b646319d2d7551c492826d26cdb87bf6",
+                          "title": "Consequatur qui esse eum.",
+                          "rationale": "Quia unde deserunt. Facilis non dolor. Qui et necessitatibus.",
+                          "description": "Non corrupti ut. Omnis maxime vero. Quia dolorum maxime.",
+                          "severity": "medium",
+                          "precedence": 8086,
+                          "identifier": {
+                            "href": "http://gleason.test/luciano",
+                            "label": "Findis"
+                          },
+                          "references": [
+                            {
+                              "href": "http://bednar.example/reynaldo",
+                              "label": "Tar-Anárion"
+                            },
+                            {
+                              "href": "http://berge.example/ted_willms",
+                              "label": "Narvi"
+                            },
+                            {
+                              "href": "http://kuhlman.test/leann",
+                              "label": "Robin Smallburrow"
+                            },
+                            {
+                              "href": "http://kertzmann-volkman.example/brett_armstrong",
+                              "label": "Hatholdir"
+                            },
+                            {
+                              "href": "http://halvorson.test/mitchell",
+                              "label": "Hathaldir"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "59c21287-4c34-4c87-80cc-ba65a453fbe0",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_54d38c3b66500a6bfc9a64623257cb0e",
+                          "title": "Quia et et hic.",
+                          "rationale": "Quis et rerum. Quia iusto unde. Odit magni magnam.",
+                          "description": "Quod veniam deserunt. Et ut qui. Numquam minus eum.",
+                          "severity": "high",
+                          "precedence": 6083,
+                          "identifier": {
+                            "href": "http://rippin.example/adena_larson",
+                            "label": "Duinhir"
+                          },
+                          "references": [
+                            {
+                              "href": "http://grimes.test/geoffrey_fritsch",
+                              "label": "Calmacil"
+                            },
+                            {
+                              "href": "http://anderson.test/heike_kreiger",
+                              "label": "Thingol"
+                            },
+                            {
+                              "href": "http://dooley.test/peter_kulas",
+                              "label": "Mat Heathertoes"
+                            },
+                            {
+                              "href": "http://metz.test/suanne.zemlak",
+                              "label": "Mungo Baggins"
+                            },
+                            {
+                              "href": "http://langworth-larson.example/erlinda.gulgowski",
+                              "label": "Wulf"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        },
+                        {
+                          "id": "620e7873-0768-4194-80f2-a20d7bd4350f",
+                          "ref_id": "xccdf_org.ssgproject.content_rule_e1edef66aebdf94c940b8ee9083e7e3b",
+                          "title": "Nisi aperiam itaque nesciunt.",
+                          "rationale": "Voluptatem delectus voluptas. Nihil quibusdam nam. Necessitatibus qui maiores.",
+                          "description": "Illo asperiores sint. Quaerat quam itaque. Consequatur voluptatem corporis.",
+                          "severity": "high",
+                          "precedence": 6270,
+                          "identifier": {
+                            "href": "http://ritchie.test/shante",
+                            "label": "Tarcil"
+                          },
+                          "references": [
+                            {
+                              "href": "http://friesen.test/delpha",
+                              "label": "Ungoliant"
+                            },
+                            {
+                              "href": "http://nader-dietrich.test/agripina",
+                              "label": "Frár"
+                            },
+                            {
+                              "href": "http://dicki.example/jennell",
+                              "label": "Ar-Pharazôn"
+                            },
+                            {
+                              "href": "http://schamberger.example/bernita_bergstrom",
+                              "label": "Buffo Boffin"
+                            },
+                            {
+                              "href": "http://murray-gibson.example/celestina.heaney",
+                              "label": "Îbal"
+                            }
+                          ],
+                          "value_checks": null,
+                          "remediation_available": false,
+                          "type": "rule"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/e9337c6a-017b-4957-83ac-03bc68baa0d6/tailorings/29cf610e-254d-44a0-b9d6-a19aff50c3d7/rules?limit=10&offset=0",
+                        "last": "/api/compliance/v2/policies/e9337c6a-017b-4957-83ac-03bc68baa0d6/tailorings/29cf610e-254d-44a0-b9d6-a19aff50c3d7/rules?limit=10&offset=20",
+                        "next": "/api/compliance/v2/policies/e9337c6a-017b-4957-83ac-03bc68baa0d6/tailorings/29cf610e-254d-44a0-b9d6-a19aff50c3d7/rules?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/rule"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{policy_id}/tailorings/{tailoring_id}/rules/{rule_id}": {
+      "patch": {
+        "summary": "Assign a Rule to a Tailoring",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tailoring_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "description": "UUID or a ref_id with '.' characters replaced with '-'",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Assigns a Rule to a Tailoring",
+        "operationId": "AssignRule",
+        "responses": {
+          "202": {
+            "description": "Assigns a Rule to a Tailoring",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Assigns a Rule to a Tailoring": {
+                    "value": {
+                      "data": {
+                        "id": "37c833e3-b984-489d-b806-9e0c0cbb8d55",
+                        "ref_id": "xccdf_org.ssgproject.content_rule_0edb0d3f86712e3a540c6d2e887f9092",
+                        "title": "Iure accusamus quam consequatur.",
+                        "rationale": "Ipsa aperiam quia. Aut molestiae consequatur. Impedit perspiciatis omnis.",
+                        "description": "Officia in distinctio. Deleniti error omnis. Provident accusamus possimus.",
+                        "severity": "medium",
+                        "precedence": 5362,
+                        "identifier": {
+                          "href": "http://kreiger.example/soila_kunde",
+                          "label": "Robin Smallburrow"
+                        },
+                        "references": [
+                          {
+                            "href": "http://hoppe.test/anitra",
+                            "label": "Pelendur"
+                          },
+                          {
+                            "href": "http://jenkins-welch.example/kieth",
+                            "label": "Duinhir"
+                          },
+                          {
+                            "href": "http://hamill.example/stephane.mohr",
+                            "label": "Rudibert Bolger"
+                          },
+                          {
+                            "href": "http://huels.example/jerica.funk",
+                            "label": "Malach"
+                          },
+                          {
+                            "href": "http://kub.test/jeni",
+                            "label": "Morwen"
+                          }
+                        ],
+                        "value_checks": null,
+                        "remediation_available": false,
+                        "type": "rule"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns with Not found": {
+                    "value": {
+                      "errors": [
+                        "V2::Rule not found with ID cc8241a0-1ddb-4ef6-ad8f-8a2e71218cb5"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Unassign a Rule from a Tailoring",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tailoring_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "rule_id",
+            "in": "path",
+            "required": true,
+            "description": "UUID or a ref_id with '.' characters replaced with '-'",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Unassigns a Rule from a Tailoring",
+        "operationId": "UnassignRule",
+        "responses": {
+          "202": {
+            "description": "Unassigns a Rule from a Tailoring",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Unassigns a Rule from a Tailoring": {
+                    "value": {
+                      "data": {
+                        "id": "27b46ceb-df18-4b04-b809-8968d54e854f",
+                        "ref_id": "xccdf_org.ssgproject.content_rule_6d36956e751be1a3bad07a46954deb6c",
+                        "title": "Quaerat beatae suscipit aut.",
+                        "rationale": "Harum recusandae veniam. Et dolorem vero. Sit maxime sint.",
+                        "description": "Qui animi iste. In ut quia. Odit et error.",
+                        "severity": "high",
+                        "precedence": 1942,
+                        "identifier": {
+                          "href": "http://dare.example/sixta_wilkinson",
+                          "label": "Estella Bolger"
+                        },
+                        "references": [
+                          {
+                            "href": "http://paucek.example/jackie",
+                            "label": "Manthor"
+                          },
+                          {
+                            "href": "http://grant-reichert.example/carly",
+                            "label": "Ibun"
+                          },
+                          {
+                            "href": "http://emard.example/edmund",
+                            "label": "Togo Goodbody"
+                          },
+                          {
+                            "href": "http://yost-powlowski.test/daniel",
+                            "label": "Argonui"
+                          },
+                          {
+                            "href": "http://johns.example/troy_mclaughlin",
+                            "label": "Léod"
+                          }
+                        ],
+                        "value_checks": null,
+                        "remediation_available": false,
+                        "type": "rule"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when unassigning a non-existing Rule": {
+                    "value": {
+                      "errors": [
+                        "V2::Rule not found with ID 4185cd81-fd22-4769-a99c-f5d59263726e"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides": {
+      "get": {
+        "summary": "Request Security Guides",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "version",
+                  "os_major_version",
+                  "title:asc",
+                  "title:desc",
+                  "version:asc",
+                  "version:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Security Guides are searchable using attributes `title`, `version`, `ref_id`, `os_major_version`, `profile_ref_id`, and `os_minor_version`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Lists Security Guides",
+        "operationId": "SecurityGuides",
+        "responses": {
+          "200": {
+            "description": "Lists Security Guides",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Security Guides": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "03823fd9-bfbf-4935-887d-41b0cc247439",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Alias ea fugiat ut.",
+                          "version": "100.82.2",
+                          "description": "Temporibus doloremque aperiam. Asperiores molestias illo. Sapiente dolore nam.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "06c0bb0b-da3b-4d13-95ee-9d5de563d9da",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Officiis possimus quod expedita.",
+                          "version": "100.81.47",
+                          "description": "Molestiae eum rerum. Maiores sapiente soluta. At error qui.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "122ec6c8-1222-462b-8884-550e9af67cc5",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Consectetur eaque autem ipsa.",
+                          "version": "100.81.37",
+                          "description": "Facilis voluptas corporis. Quia fuga quas. Eos ea non.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "13ca08e9-ad3b-4814-a2ef-fdd1b78dba5f",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Est nihil ipsa amet.",
+                          "version": "100.81.38",
+                          "description": "Saepe distinctio culpa. Ratione rerum qui. Quidem eos nostrum.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "2b178c55-24e5-4e27-8665-96dd81481aa9",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Nam nobis aperiam recusandae.",
+                          "version": "100.82.7",
+                          "description": "Provident similique officiis. Qui fugiat quam. Animi aut rerum.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "37c95b3f-143c-4310-8199-141623ade6b5",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Qui veniam soluta libero.",
+                          "version": "100.81.49",
+                          "description": "Laborum delectus esse. Et dolore recusandae. Ipsa vero fugiat.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "4663211e-6885-4580-a506-e7e4bc9ce177",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Iste sint corporis aut.",
+                          "version": "100.81.40",
+                          "description": "Labore sapiente illum. Aut adipisci illum. Ipsam error quasi.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "47f14ed6-a260-4a62-a766-21f104e23a38",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Officia tenetur voluptatem voluptatem.",
+                          "version": "100.81.39",
+                          "description": "Amet aperiam quis. Omnis nemo voluptatem. Ut minus recusandae.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "4ac4062d-7d44-496f-831e-9f36d1109399",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Perferendis voluptatem aperiam iste.",
+                          "version": "100.82.8",
+                          "description": "Nobis ex eum. Qui et architecto. Illum voluptas consequatur.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "4c1e982a-7f26-43ca-bad4-812c056a75b1",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Corporis voluptate placeat dolore.",
+                          "version": "100.81.42",
+                          "description": "Magni expedita quod. Quod aut placeat. Voluptates officiis facilis.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides?limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides?limit=10&offset=20",
+                        "next": "/api/compliance/v2/security_guides?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Security Guides sorted by \"os_major_version:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "0a4e8d2b-57c1-4f6a-a3ae-21bb7003da79",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Eum ducimus autem autem.",
+                          "version": "100.82.32",
+                          "description": "Qui ipsum perspiciatis. Omnis necessitatibus nulla. Repellat eum quia.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "0dd1d9c3-b8e8-4ebc-9da4-c918731cabf5",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Aut omnis quae omnis.",
+                          "version": "100.82.33",
+                          "description": "Non iure dignissimos. Eum et sunt. Voluptates sint error.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "194c61e2-498e-4aaa-ae58-d54c3156c76b",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Doloremque recusandae qui dolor.",
+                          "version": "100.82.21",
+                          "description": "Et nobis eius. Hic expedita sint. Magnam aut est.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "1dfce097-3443-49e8-97f2-774715ec1b68",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Tenetur optio laudantium tempora.",
+                          "version": "100.82.22",
+                          "description": "Blanditiis fugit sunt. Et dolorem velit. Labore velit ab.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "32c7f979-feda-4a58-8c8c-f5f7c68e52a9",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Non et minima et.",
+                          "version": "100.82.12",
+                          "description": "Animi perferendis nemo. Et similique magnam. Magni ex inventore.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "3fdd2b2a-5e81-4bc7-8548-d37565795f57",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Placeat eos eveniet officiis.",
+                          "version": "100.82.15",
+                          "description": "Pariatur rerum ad. Expedita ipsam et. Aperiam eos doloremque.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "449837b5-2a66-4be3-9f72-a6a119e4f83d",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Adipisci quisquam dolor dolor.",
+                          "version": "100.82.31",
+                          "description": "Iste cupiditate neque. Maxime soluta consequatur. Qui sed voluptas.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "5205942c-4b78-4fde-ba7c-fe864aee345e",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Cumque autem nemo deserunt.",
+                          "version": "100.82.16",
+                          "description": "Unde fuga labore. Nostrum eligendi et. Eum deserunt enim.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "521ccbcf-0834-4707-986f-6f0bcb740a2d",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Deserunt sit et voluptatum.",
+                          "version": "100.82.26",
+                          "description": "Sint et deserunt. Temporibus illo suscipit. Cumque quo temporibus.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        },
+                        {
+                          "id": "6bcce771-9878-441f-b862-bfe4c9bdbb0f",
+                          "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                          "title": "Totam excepturi repudiandae necessitatibus.",
+                          "version": "100.82.36",
+                          "description": "Voluptatem delectus ut. At ab accusamus. Dicta illo porro.",
+                          "os_major_version": 7,
+                          "type": "security_guide"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "os_major_version"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides?limit=10&offset=0&sort_by=os_major_version",
+                        "last": "/api/compliance/v2/security_guides?limit=10&offset=20&sort_by=os_major_version",
+                        "next": "/api/compliance/v2/security_guides?limit=10&offset=10&sort_by=os_major_version"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Security Guides filtered by \"(os_major_version=8)\"": {
+                    "value": {
+                      "data": [],
+                      "meta": {
+                        "total": 0,
+                        "filter": "(os_major_version=8)",
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides?filter=%28os_major_version%3D8%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides?filter=%28os_major_version%3D8%29&limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/security_guide"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/os_versions": {
+      "get": {
+        "summary": "Request the list of available OS versions",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_major_version`, `os_minor_version`, `assigned_or_scanned`, `never_reported`, `group_name`, `policies`, and `profile_ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "This feature is exclusively used by the frontend",
+        "operationId": "SecurityGuidesOS",
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "Lists available OS versions",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of available OS versions": {
+                    "value": [
+                      7
+                    ],
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}": {
+      "get": {
+        "summary": "Request a Security Guide",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Returns a Security Guide",
+        "operationId": "SecurityGuide",
+        "responses": {
+          "200": {
+            "description": "Returns a Security Guide",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Security Guide": {
+                    "value": {
+                      "data": {
+                        "id": "3d4d1071-c136-41cc-8816-db08ddd199cb",
+                        "ref_id": "xccdf_org.ssgproject.content_benchmark_RHEL-7",
+                        "title": "Eum sed et cupiditate.",
+                        "version": "100.84.37",
+                        "description": "Magnam quo quam. Ad et non. Omnis qui autem.",
+                        "os_major_version": 7,
+                        "type": "security_guide"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/security_guide"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Security Guide": {
+                    "value": {
+                      "errors": [
+                        "V2::SecurityGuide not found with ID dbded627-f179-44e2-bcd6-fe8c49044e7a"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/rule_tree": {
+      "get": {
+        "summary": "Request the Rule Tree of a Security Guide",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Returns the Rule Tree of a Security Guide",
+        "operationId": "SecurityGuideRuleTree",
+        "responses": {
+          "200": {
+            "description": "Returns a the Rule Tree of Security Guide",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns the Rule Tree of a Security Guide": {
+                    "value": [
+                      {
+                        "id": "64134a28-f5fe-4c67-a6a6-d864b330f5c9",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "183a0d6b-1372-4248-83cf-1439b0b02fd9",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "1b47fd72-4fcc-43e8-83ef-2ffb8028af6f",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "5f27ee1e-9385-4368-8c56-2efb36449adc",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "8516968c-071e-4690-acd0-252da4ee7ed7",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "e3992ace-f9e0-4f46-b0d6-cdd34f78821d",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "a6a32cfe-621b-4f79-88af-9c8912a56219",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "1f076117-85fc-4bab-a280-26934c8368fb",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "e1f6e7af-53b9-41c5-bdd5-54b2fb59c279",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "6311a163-3961-466c-a55d-26493a3a4836",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "3477418a-09c7-4894-86f2-68b8258ca5a3",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "85c0cca8-65f8-4684-aca6-6391a55137bd",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "00d40435-b465-4e1c-b45d-d7c389c98b4d",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "18b468c3-b7c7-4600-9b63-2e07d4d8822d",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "88260e2e-a79e-4d9d-b0e2-7ebfc58df894",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "3bbaaf3a-e69f-4362-ba3f-3c8761a58794",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "c4f36695-83f9-4ca6-bc6a-520dd560a590",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "31f2be8c-23ef-4a1f-8740-8e83780a5eab",
+                            "type": "rule"
+                          }
+                        ]
+                      },
+                      {
+                        "id": "b027738c-71e7-4326-ada8-be6ed5d5804c",
+                        "type": "rule_group",
+                        "children": [
+                          {
+                            "id": "d3f4ed4d-2a78-4388-a43f-496cf6edaa3f",
+                            "type": "rule"
+                          }
+                        ]
+                      }
+                    ],
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/rule_tree"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Security Guide": {
+                    "value": {
+                      "errors": [
+                        "V2::SecurityGuide not found with ID d5c93e3b-cbdc-4c97-8284-62995208e2d0"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/supported_profiles": {
+      "get": {
+        "summary": "Request Supported Profiles",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "os_major_version",
+                  "os_minor_versions",
+                  "title:asc",
+                  "title:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc",
+                  "os_minor_versions:asc",
+                  "os_minor_versions:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Supported Profiles are searchable using attributes `os_major_version`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Lists Supported Profiles",
+        "operationId": "SupportedProfiles",
+        "responses": {
+          "200": {
+            "description": "Lists Supported Profiles",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Supported Profiles": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "fab8cb07-c309-4e45-b12e-3405833c44d7",
+                          "title": "Omnis ipsum perspiciatis ratione.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_a5630473bc0fd1d52f1bfb660b7c9f3a",
+                          "security_guide_id": "95cfd65e-626d-4efe-ac80-5764073a3e64",
+                          "security_guide_version": "100.85.17",
+                          "os_major_version": 7,
+                          "os_minor_versions": [
+                            3,
+                            2,
+                            1
+                          ],
+                          "type": "supported_profile"
+                        }
+                      ],
+                      "meta": {
+                        "total": 1,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/supported_profiles?limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides/supported_profiles?limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Supported Profiles sorted by \"os_major_version:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "a605b755-28fc-4529-a296-027c68c14a53",
+                          "title": "Perspiciatis adipisci esse voluptatem.",
+                          "ref_id": "xccdf_org.ssgproject.content_profile_79f6c994e10c3c0401f84e382b0703ac",
+                          "security_guide_id": "14c26667-4a22-410d-9169-f432a34458be",
+                          "security_guide_version": "100.85.18",
+                          "os_major_version": 7,
+                          "os_minor_versions": [
+                            3,
+                            2,
+                            1
+                          ],
+                          "type": "supported_profile"
+                        }
+                      ],
+                      "meta": {
+                        "total": 1,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "os_major_version"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/supported_profiles?limit=10&offset=0&sort_by=os_major_version",
+                        "last": "/api/compliance/v2/security_guides/supported_profiles?limit=10&offset=0&sort_by=os_major_version"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Supported Profiles filtered by \"(os_major_version=8)\"": {
+                    "value": {
+                      "data": [],
+                      "meta": {
+                        "total": 0,
+                        "filter": "(os_major_version=8)",
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/supported_profiles?filter=%28os_major_version%3D8%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides/supported_profiles?filter=%28os_major_version%3D8%29&limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/supported_profile"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/systems": {
+      "get": {
+        "summary": "Request Systems",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "display_name",
+                  "os_major_version",
+                  "os_minor_version",
+                  "groups",
+                  "display_name:asc",
+                  "display_name:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc",
+                  "os_minor_version:asc",
+                  "os_minor_version:desc",
+                  "groups:asc",
+                  "groups:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_major_version`, `os_minor_version`, `assigned_or_scanned`, `never_reported`, `group_name`, `policies`, and `profile_ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Systems"
+        ],
+        "description": "Lists Systems",
+        "operationId": "Systems",
+        "responses": {
+          "200": {
+            "description": "Lists Systems",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Systems": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "110ff146-513e-42c1-8a73-579963395595",
+                          "display_name": "veum-torphy.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.422Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.422Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.422Z",
+                          "updated": "2024-09-03T18:22:02.422Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "feed",
+                              "value": "haptic",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "online",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "card",
+                              "value": "multi-byte",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "haptic",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "multi-byte",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "1b3a6e64-cb14-4683-a700-30081f51afe7",
+                          "display_name": "hansen.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.427Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.427Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.427Z",
+                          "updated": "2024-09-03T18:22:02.427Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "pixel",
+                              "value": "open-source",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "neural",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "virtual",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "bluetooth",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "mobile",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "1bc3b7e4-8965-4940-a771-dfc10b8a29b3",
+                          "display_name": "bednar.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.429Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.429Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.429Z",
+                          "updated": "2024-09-03T18:22:02.429Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "application",
+                              "value": "redundant",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "online",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "redundant",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "cross-platform",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "online",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "256966cb-feae-4d1f-ab24-033fb3668033",
+                          "display_name": "harris-okuneva.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.442Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.442Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.442Z",
+                          "updated": "2024-09-03T18:22:02.442Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "transmitter",
+                              "value": "wireless",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "primary",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "auxiliary",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "online",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "mobile",
+                              "namespace": "copying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "3735d2d1-8728-4e08-8b05-59bb2cae3dfb",
+                          "display_name": "spinka.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.434Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.434Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.434Z",
+                          "updated": "2024-09-03T18:22:02.434Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "driver",
+                              "value": "back-end",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "card",
+                              "value": "solid state",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "system",
+                              "value": "bluetooth",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "port",
+                              "value": "online",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "haptic",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "3e9e089d-a4a8-4c5b-8049-c0825d2bbc27",
+                          "display_name": "green.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.448Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.448Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.448Z",
+                          "updated": "2024-09-03T18:22:02.448Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "monitor",
+                              "value": "back-end",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "primary",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "primary",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "protocol",
+                              "value": "mobile",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "online",
+                              "namespace": "navigating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "467ded82-2fe9-4770-9818-13fbfead240b",
+                          "display_name": "willms.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.438Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.438Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.438Z",
+                          "updated": "2024-09-03T18:22:02.438Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "panel",
+                              "value": "neural",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "optical",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "digital",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "digital",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "application",
+                              "value": "primary",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "48030cf3-632d-4a62-b002-faf032c1650a",
+                          "display_name": "quigley.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.424Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.424Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.424Z",
+                          "updated": "2024-09-03T18:22:02.424Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "interface",
+                              "value": "haptic",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "open-source",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "online",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "haptic",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "optical",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "67922223-a138-4d6d-8a46-7906949ac620",
+                          "display_name": "hansen.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.420Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.420Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.420Z",
+                          "updated": "2024-09-03T18:22:02.420Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "panel",
+                              "value": "primary",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "haptic",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "optical",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "neural",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "multi-byte",
+                              "namespace": "compressing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "71ff7736-0e12-46cf-bbd6-7eca2e5ab0ee",
+                          "display_name": "feeney.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.450Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.450Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.450Z",
+                          "updated": "2024-09-03T18:22:02.450Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "firewall",
+                              "value": "back-end",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "system",
+                              "value": "solid state",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "digital",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "mobile",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "multi-byte",
+                              "namespace": "indexing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/systems?limit=10&offset=0",
+                        "last": "/api/compliance/v2/systems?limit=10&offset=20",
+                        "next": "/api/compliance/v2/systems?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Systems sorted by \"os_major_version:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "0283e038-1ffe-43e5-88ea-a86da52824c7",
+                          "display_name": "hodkiewicz.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.498Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.498Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.498Z",
+                          "updated": "2024-09-03T18:22:02.498Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "card",
+                              "value": "mobile",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "cross-platform",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "array",
+                              "value": "cross-platform",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "mobile",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "multi-byte",
+                              "namespace": "backing up"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "09dc45b4-1968-49e8-b888-e69c8906b42b",
+                          "display_name": "zemlak.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.505Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.505Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.505Z",
+                          "updated": "2024-09-03T18:22:02.505Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "hard drive",
+                              "value": "redundant",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "multi-byte",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "mobile",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "auxiliary",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "system",
+                              "value": "mobile",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "0f5a266b-da7b-438e-96e4-d0b0a59e37d7",
+                          "display_name": "schuster.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.513Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.513Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.513Z",
+                          "updated": "2024-09-03T18:22:02.513Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "alarm",
+                              "value": "open-source",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "neural",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "system",
+                              "value": "1080p",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "primary",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "wireless",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "12f9056d-bd84-4392-b462-e9e0b515975d",
+                          "display_name": "mitchell-windler.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.506Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.506Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.506Z",
+                          "updated": "2024-09-03T18:22:02.506Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "card",
+                              "value": "mobile",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "neural",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "system",
+                              "value": "virtual",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "digital",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "back-end",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "1d7762ac-145f-4384-996b-17ee6f0465b8",
+                          "display_name": "green.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.497Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.497Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.497Z",
+                          "updated": "2024-09-03T18:22:02.497Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "bus",
+                              "value": "cross-platform",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "haptic",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "redundant",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "program",
+                              "value": "cross-platform",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "optical",
+                              "namespace": "hacking"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "311dbbe1-4872-48cc-bbba-2fc8a493921f",
+                          "display_name": "lakin-rolfson.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.507Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.507Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.507Z",
+                          "updated": "2024-09-03T18:22:02.507Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "panel",
+                              "value": "cross-platform",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "redundant",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "multi-byte",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "port",
+                              "value": "optical",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "1080p",
+                              "namespace": "connecting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "33e66226-8da7-45d5-bc36-5f2c4ec1f9a9",
+                          "display_name": "bruen.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.499Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.499Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.499Z",
+                          "updated": "2024-09-03T18:22:02.499Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "monitor",
+                              "value": "mobile",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "system",
+                              "value": "auxiliary",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "mobile",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "cross-platform",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "port",
+                              "value": "digital",
+                              "namespace": "navigating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "34ae256d-3c94-4ff2-9c4a-77f178055dde",
+                          "display_name": "hickle.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.500Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.500Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.500Z",
+                          "updated": "2024-09-03T18:22:02.500Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "interface",
+                              "value": "optical",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "primary",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "mobile",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "bluetooth",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "wireless",
+                              "namespace": "compressing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "3a02b4c0-b630-42d9-b40a-2ac154188ab2",
+                          "display_name": "durgan.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.510Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.510Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.510Z",
+                          "updated": "2024-09-03T18:22:02.510Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "port",
+                              "value": "bluetooth",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "haptic",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "open-source",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "application",
+                              "value": "haptic",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "neural",
+                              "namespace": "backing up"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "478fbedd-1a88-4d42-b771-d720f945369b",
+                          "display_name": "carter.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.518Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.518Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.518Z",
+                          "updated": "2024-09-03T18:22:02.518Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "interface",
+                              "value": "1080p",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "program",
+                              "value": "bluetooth",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "card",
+                              "value": "virtual",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "array",
+                              "value": "redundant",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "optical",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "os_major_version"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/systems?limit=10&offset=0&sort_by=os_major_version",
+                        "last": "/api/compliance/v2/systems?limit=10&offset=20&sort_by=os_major_version",
+                        "next": "/api/compliance/v2/systems?limit=10&offset=10&sort_by=os_major_version"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Systems filtered by \"(os_major_version=8)\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "0094a641-df56-4ef6-adfd-4e0cd80b6fc5",
+                          "display_name": "ebert.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.584Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.584Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.584Z",
+                          "updated": "2024-09-03T18:22:02.584Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "transmitter",
+                              "value": "cross-platform",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "cross-platform",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "wireless",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "redundant",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "cross-platform",
+                              "namespace": "generating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "0e6b0fdf-a405-4285-b105-188c898f913a",
+                          "display_name": "lemke-larkin.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.562Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.562Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.562Z",
+                          "updated": "2024-09-03T18:22:02.562Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "sensor",
+                              "value": "cross-platform",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "multi-byte",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "solid state",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "multi-byte",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "port",
+                              "value": "primary",
+                              "namespace": "navigating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "119f303a-ec9d-42fb-a11f-7843637b4d12",
+                          "display_name": "koelpin.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.555Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.555Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.555Z",
+                          "updated": "2024-09-03T18:22:02.555Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "monitor",
+                              "value": "multi-byte",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "multi-byte",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "open-source",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "digital",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "neural",
+                              "namespace": "generating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "16b5396a-0d75-4f2d-8a3a-e2542f864c8e",
+                          "display_name": "boehm.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.561Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.561Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.561Z",
+                          "updated": "2024-09-03T18:22:02.561Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "circuit",
+                              "value": "wireless",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "application",
+                              "value": "solid state",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "auxiliary",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "port",
+                              "value": "primary",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "redundant",
+                              "namespace": "calculating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "199e1f3e-37af-4708-b906-f55c2bbf0c91",
+                          "display_name": "jaskolski.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.563Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.563Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.563Z",
+                          "updated": "2024-09-03T18:22:02.563Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "feed",
+                              "value": "bluetooth",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "bluetooth",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "open-source",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "auxiliary",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "haptic",
+                              "namespace": "calculating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "248bf562-aea3-4ecc-b3f3-925574d45f07",
+                          "display_name": "schinner.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.583Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.583Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.583Z",
+                          "updated": "2024-09-03T18:22:02.583Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "monitor",
+                              "value": "optical",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "online",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "digital",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "optical",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "mobile",
+                              "namespace": "backing up"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "260a6a8a-4614-4270-8c78-00e6950a54e6",
+                          "display_name": "erdman.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.574Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.574Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.574Z",
+                          "updated": "2024-09-03T18:22:02.574Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "program",
+                              "value": "redundant",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "online",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "application",
+                              "value": "open-source",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "optical",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "cross-platform",
+                              "namespace": "connecting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "29963a0b-dddc-4a3c-bf86-0245089a7d40",
+                          "display_name": "barrows.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.576Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.576Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.576Z",
+                          "updated": "2024-09-03T18:22:02.576Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "feed",
+                              "value": "mobile",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "1080p",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "wireless",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "cross-platform",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "digital",
+                              "namespace": "synthesizing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "3a9a26f3-cca3-42c1-b96a-f91c2f297ac9",
+                          "display_name": "nitzsche.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.567Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.567Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.567Z",
+                          "updated": "2024-09-03T18:22:02.567Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "panel",
+                              "value": "solid state",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "bluetooth",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "array",
+                              "value": "1080p",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "bluetooth",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "wireless",
+                              "namespace": "copying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        },
+                        {
+                          "id": "462b9b65-ccaf-4aa3-80c2-5ca52fdb0aa7",
+                          "display_name": "rempel.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.577Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.577Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.577Z",
+                          "updated": "2024-09-03T18:22:02.577Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "bus",
+                              "value": "mobile",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "1080p",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "solid state",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "haptic",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "port",
+                              "value": "open-source",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": []
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "filter": "(os_major_version=8)",
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/systems?filter=%28os_major_version%3D8%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/systems?filter=%28os_major_version%3D8%29&limit=10&offset=20",
+                        "next": "/api/compliance/v2/systems?filter=%28os_major_version%3D8%29&limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/system"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/systems/os_versions": {
+      "get": {
+        "summary": "Request the list of available OS versions",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_major_version`, `os_minor_version`, `assigned_or_scanned`, `never_reported`, `group_name`, `policies`, and `profile_ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Systems"
+        ],
+        "description": "This feature is exclusively used by the frontend",
+        "operationId": "SystemsOS",
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "Lists available OS versions",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of available OS versions": {
+                    "value": [
+                      "8.0"
+                    ],
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/systems/{system_id}": {
+      "get": {
+        "summary": "Request a System",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "system_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Systems"
+        ],
+        "description": "Returns a System",
+        "operationId": "System",
+        "responses": {
+          "200": {
+            "description": "Returns a System",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a System": {
+                    "value": {
+                      "data": {
+                        "id": "56b57095-7f69-4645-ba00-acd83f6f468f",
+                        "display_name": "wisoky.test",
+                        "groups": [],
+                        "culled_timestamp": "2034-09-17T18:22:02.833Z",
+                        "stale_timestamp": "2034-09-03T18:22:02.833Z",
+                        "stale_warning_timestamp": "2034-09-10T18:22:02.833Z",
+                        "updated": "2024-09-03T18:22:02.833Z",
+                        "insights_id": null,
+                        "tags": [
+                          {
+                            "key": "firewall",
+                            "value": "wireless",
+                            "namespace": "generating"
+                          },
+                          {
+                            "key": "sensor",
+                            "value": "multi-byte",
+                            "namespace": "backing up"
+                          },
+                          {
+                            "key": "transmitter",
+                            "value": "digital",
+                            "namespace": "parsing"
+                          },
+                          {
+                            "key": "firewall",
+                            "value": "primary",
+                            "namespace": "hacking"
+                          },
+                          {
+                            "key": "interface",
+                            "value": "haptic",
+                            "namespace": "transmitting"
+                          }
+                        ],
+                        "type": "system",
+                        "os_major_version": 8,
+                        "os_minor_version": 0,
+                        "policies": []
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/system"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing System": {
+                    "value": {
+                      "errors": [
+                        "V2::System not found with ID 90f31b09-4e6b-4bb5-bfb0-c212d9ee64af"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{policy_id}/systems": {
+      "get": {
+        "summary": "Request Systems assigned to a Policy",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "display_name",
+                  "os_major_version",
+                  "os_minor_version",
+                  "groups",
+                  "display_name:asc",
+                  "display_name:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc",
+                  "os_minor_version:asc",
+                  "os_minor_version:desc",
+                  "groups:asc",
+                  "groups:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_major_version`, `os_minor_version`, `assigned_or_scanned`, `never_reported`, `group_name`, `policies`, and `profile_ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Lists Systems assigned to a Policy",
+        "operationId": "PolicySystems",
+        "responses": {
+          "200": {
+            "description": "Lists Systems assigned to a Policy",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Systems": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "00e94575-8202-4c0b-8065-95ccc3965331",
+                          "display_name": "wolff-jacobson.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.038Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.038Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.038Z",
+                          "updated": "2024-09-03T18:22:03.038Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "application",
+                              "value": "cross-platform",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "array",
+                              "value": "primary",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "array",
+                              "value": "digital",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "solid state",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "port",
+                              "value": "digital",
+                              "namespace": "quantifying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "218c6ab3-8673-418b-b74f-92ea3f67c45b",
+                          "display_name": "klocko.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.032Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.032Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.032Z",
+                          "updated": "2024-09-03T18:22:03.032Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "firewall",
+                              "value": "virtual",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "wireless",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "virtual",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "protocol",
+                              "value": "auxiliary",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "card",
+                              "value": "wireless",
+                              "namespace": "generating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "27e30589-5663-4c09-8408-807b06eea184",
+                          "display_name": "lebsack.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.895Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.895Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.895Z",
+                          "updated": "2024-09-03T18:22:02.895Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "sensor",
+                              "value": "online",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "haptic",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "application",
+                              "value": "optical",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "haptic",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "auxiliary",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "353c1d45-cdf9-440b-b144-6ad122873615",
+                          "display_name": "schmeler.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.004Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.004Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.004Z",
+                          "updated": "2024-09-03T18:22:03.004Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "feed",
+                              "value": "auxiliary",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "virtual",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "1080p",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "virtual",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "auxiliary",
+                              "namespace": "compressing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "37164adb-546f-47c8-8927-39bda6428414",
+                          "display_name": "moore-herzog.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.986Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.986Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.986Z",
+                          "updated": "2024-09-03T18:22:02.986Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "application",
+                              "value": "digital",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "mobile",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "wireless",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "haptic",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "solid state",
+                              "namespace": "navigating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "3c5dfbe4-745e-4e9d-9ce3-f7da04f130c6",
+                          "display_name": "lemke.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.045Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.045Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.045Z",
+                          "updated": "2024-09-03T18:22:03.045Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "bandwidth",
+                              "value": "mobile",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "auxiliary",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "primary",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "mobile",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "system",
+                              "value": "redundant",
+                              "namespace": "compressing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "4585f415-e976-46de-a2b4-9763019685d2",
+                          "display_name": "torp-lang.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.906Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.906Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.906Z",
+                          "updated": "2024-09-03T18:22:02.906Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "panel",
+                              "value": "haptic",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "bluetooth",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "digital",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "solid state",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "open-source",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "46c972de-4d91-41eb-92eb-6352f2b8a876",
+                          "display_name": "abernathy-schaden.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.025Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.025Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.025Z",
+                          "updated": "2024-09-03T18:22:03.025Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "protocol",
+                              "value": "primary",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "online",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "array",
+                              "value": "solid state",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "multi-byte",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "bluetooth",
+                              "namespace": "quantifying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "5444566d-aba3-4a0b-be38-ea6a6b61b293",
+                          "display_name": "labadie.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:02.939Z",
+                          "stale_timestamp": "2034-09-03T18:22:02.939Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:02.939Z",
+                          "updated": "2024-09-03T18:22:02.939Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "driver",
+                              "value": "haptic",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "optical",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "solid state",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "bluetooth",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "bluetooth",
+                              "namespace": "compressing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "65b5c0b9-7655-4bc6-b438-706582ef151d",
+                          "display_name": "dare.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.070Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.070Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.070Z",
+                          "updated": "2024-09-03T18:22:03.070Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "port",
+                              "value": "online",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "mobile",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "cross-platform",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "back-end",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "digital",
+                              "namespace": "quantifying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/ed8cf277-d0f4-43ed-b7fe-af292b2a6939/systems?limit=10&offset=0",
+                        "last": "/api/compliance/v2/policies/ed8cf277-d0f4-43ed-b7fe-af292b2a6939/systems?limit=10&offset=20",
+                        "next": "/api/compliance/v2/policies/ed8cf277-d0f4-43ed-b7fe-af292b2a6939/systems?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Systems sorted by \"os_major_version:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "010520df-0529-480d-b8b6-d3c6c6c3d395",
+                          "display_name": "schuppe.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.163Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.163Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.163Z",
+                          "updated": "2024-09-03T18:22:03.163Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "port",
+                              "value": "cross-platform",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "mobile",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "redundant",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "open-source",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "primary",
+                              "namespace": "calculating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "0bb194a1-1dcb-4ad7-a881-9b42e754bdc0",
+                          "display_name": "bergstrom.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.279Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.279Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.279Z",
+                          "updated": "2024-09-03T18:22:03.279Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "driver",
+                              "value": "back-end",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "mobile",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "digital",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "application",
+                              "value": "auxiliary",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "primary",
+                              "namespace": "connecting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "1a570234-dbce-4151-8fc7-613ee59df77c",
+                          "display_name": "lubowitz.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.259Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.259Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.259Z",
+                          "updated": "2024-09-03T18:22:03.260Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "sensor",
+                              "value": "primary",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "optical",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "back-end",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "multi-byte",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "1080p",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "20cd1bc6-ae7f-4634-9d26-3f179c55cda2",
+                          "display_name": "sipes.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.143Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.143Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.143Z",
+                          "updated": "2024-09-03T18:22:03.143Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "sensor",
+                              "value": "neural",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "haptic",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "digital",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "application",
+                              "value": "redundant",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "card",
+                              "value": "bluetooth",
+                              "namespace": "hacking"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "26e56e27-5de6-44b8-8287-e1811e9ad4fc",
+                          "display_name": "russel.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.215Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.215Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.215Z",
+                          "updated": "2024-09-03T18:22:03.215Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "circuit",
+                              "value": "open-source",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "virtual",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "open-source",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "port",
+                              "value": "primary",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "virtual",
+                              "namespace": "quantifying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "32d6e754-5a53-41c1-98b9-acef9c206164",
+                          "display_name": "weber.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.266Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.266Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.266Z",
+                          "updated": "2024-09-03T18:22:03.266Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "port",
+                              "value": "virtual",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "solid state",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "1080p",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "auxiliary",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "application",
+                              "value": "auxiliary",
+                              "namespace": "indexing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "33e9147d-e2d3-4fd7-a83f-75d26c07e28b",
+                          "display_name": "macejkovic.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.245Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.245Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.245Z",
+                          "updated": "2024-09-03T18:22:03.245Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "hard drive",
+                              "value": "open-source",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "system",
+                              "value": "cross-platform",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "bluetooth",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "online",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "application",
+                              "value": "1080p",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "3cfcbf3f-9b1c-47f0-85e4-5364dfaa1b64",
+                          "display_name": "gorczany.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.209Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.209Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.209Z",
+                          "updated": "2024-09-03T18:22:03.209Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "capacitor",
+                              "value": "multi-byte",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "multi-byte",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "1080p",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "redundant",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "virtual",
+                              "namespace": "copying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "3f5c6301-87c0-4832-8134-501056ceb89c",
+                          "display_name": "heathcote.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.189Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.189Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.189Z",
+                          "updated": "2024-09-03T18:22:03.189Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "monitor",
+                              "value": "primary",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "haptic",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "mobile",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "optical",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "1080p",
+                              "namespace": "backing up"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "4338842d-2404-4ef2-9274-089ea8db5011",
+                          "display_name": "jones-pacocha.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.273Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.273Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.273Z",
+                          "updated": "2024-09-03T18:22:03.273Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "bandwidth",
+                              "value": "primary",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "system",
+                              "value": "solid state",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "port",
+                              "value": "neural",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "port",
+                              "value": "mobile",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "bluetooth",
+                              "namespace": "backing up"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "os_major_version"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/26fdac22-401c-4e4d-93f8-f2c33b565f59/systems?limit=10&offset=0&sort_by=os_major_version",
+                        "last": "/api/compliance/v2/policies/26fdac22-401c-4e4d-93f8-f2c33b565f59/systems?limit=10&offset=20&sort_by=os_major_version",
+                        "next": "/api/compliance/v2/policies/26fdac22-401c-4e4d-93f8-f2c33b565f59/systems?limit=10&offset=10&sort_by=os_major_version"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Systems filtered by \"(os_major_version=8)\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "0b517c85-7538-4ec2-b164-708f15e45754",
+                          "display_name": "kutch.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.353Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.353Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.353Z",
+                          "updated": "2024-09-03T18:22:03.353Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "alarm",
+                              "value": "mobile",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "program",
+                              "value": "haptic",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "online",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "multi-byte",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "open-source",
+                              "namespace": "synthesizing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "16f8ae79-9ef1-4217-9af7-7456ddfd0c59",
+                          "display_name": "ernser.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.423Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.423Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.423Z",
+                          "updated": "2024-09-03T18:22:03.423Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "sensor",
+                              "value": "solid state",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "digital",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "haptic",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "digital",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "program",
+                              "value": "1080p",
+                              "namespace": "backing up"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "1fe8bdc2-f437-4949-8ba0-d688f0d1d9f7",
+                          "display_name": "dickens.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.410Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.410Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.410Z",
+                          "updated": "2024-09-03T18:22:03.410Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "array",
+                              "value": "optical",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "card",
+                              "value": "auxiliary",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "solid state",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "online",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "application",
+                              "value": "bluetooth",
+                              "namespace": "navigating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "2816ddb9-eb2c-49b2-910a-973d3e38f261",
+                          "display_name": "vonrueden.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.500Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.500Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.500Z",
+                          "updated": "2024-09-03T18:22:03.501Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "driver",
+                              "value": "solid state",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "port",
+                              "value": "redundant",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "multi-byte",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "cross-platform",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "array",
+                              "value": "open-source",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "38651ed5-92f5-4554-8e6f-96c3bfaec62c",
+                          "display_name": "beer.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.443Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.443Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.443Z",
+                          "updated": "2024-09-03T18:22:03.443Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "feed",
+                              "value": "neural",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "back-end",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "auxiliary",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "primary",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "optical",
+                              "namespace": "synthesizing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "3d1e8119-1c56-4d56-816a-db05583fc7ef",
+                          "display_name": "spinka.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.429Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.429Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.429Z",
+                          "updated": "2024-09-03T18:22:03.429Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "pixel",
+                              "value": "1080p",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "card",
+                              "value": "cross-platform",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "virtual",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "solid state",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "digital",
+                              "namespace": "generating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "48cf946c-ad1c-494a-a54d-014436559736",
+                          "display_name": "ruecker-botsford.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.472Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.472Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.472Z",
+                          "updated": "2024-09-03T18:22:03.472Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "array",
+                              "value": "redundant",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "application",
+                              "value": "wireless",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "mobile",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "optical",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "online",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "5402616e-3e48-4859-8752-cb5c700a0cb3",
+                          "display_name": "okuneva.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.416Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.416Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.416Z",
+                          "updated": "2024-09-03T18:22:03.416Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "application",
+                              "value": "digital",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "back-end",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "digital",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "neural",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "cross-platform",
+                              "namespace": "hacking"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "5bac2b26-3a89-4c8f-b020-826f9b3e15b3",
+                          "display_name": "heathcote.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.403Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.403Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.403Z",
+                          "updated": "2024-09-03T18:22:03.403Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "feed",
+                              "value": "bluetooth",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "optical",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "back-end",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "solid state",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "virtual",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "690e1afe-3139-4a9a-97e1-7ff010f8a160",
+                          "display_name": "price-romaguera.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:03.464Z",
+                          "stale_timestamp": "2034-09-03T18:22:03.464Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:03.464Z",
+                          "updated": "2024-09-03T18:22:03.464Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "bandwidth",
+                              "value": "primary",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "program",
+                              "value": "1080p",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "wireless",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "online",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "back-end",
+                              "namespace": "connecting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "filter": "(os_major_version=8)",
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/53e6c484-68dd-4d92-aad8-aeba8461ad9c/systems?filter=%28os_major_version%3D8%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/policies/53e6c484-68dd-4d92-aad8-aeba8461ad9c/systems?filter=%28os_major_version%3D8%29&limit=10&offset=20",
+                        "next": "/api/compliance/v2/policies/53e6c484-68dd-4d92-aad8-aeba8461ad9c/systems?filter=%28os_major_version%3D8%29&limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/system"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Bulk assign Systems to a Policy",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "This feature is exclusively used by the frontend",
+        "deprecated": true,
+        "operationId": "AssignSystems",
+        "responses": {
+          "202": {
+            "description": "Assigns all specified systems and unassigns the rest",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of assigned Systems": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "1b4696ab-d0d6-4199-bda0-4a30396d5249",
+                          "display_name": "dooley-johnson.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.262Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.262Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.262Z",
+                          "updated": "2024-09-03T18:22:04.262Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "interface",
+                              "value": "optical",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "multi-byte",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "mobile",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "bluetooth",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "array",
+                              "value": "solid state",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "4642ee95-8571-46b0-918a-349ddbcf1cfc",
+                          "display_name": "mosciski-gislason.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.233Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.233Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.233Z",
+                          "updated": "2024-09-03T18:22:04.233Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "application",
+                              "value": "cross-platform",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "neural",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "back-end",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "online",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "multi-byte",
+                              "namespace": "quantifying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "53f5aa77-f710-44e3-bcd0-a0a4a5a35b7e",
+                          "display_name": "hamill.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.241Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.241Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.241Z",
+                          "updated": "2024-09-03T18:22:04.241Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "capacitor",
+                              "value": "digital",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "bluetooth",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "card",
+                              "value": "bluetooth",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "application",
+                              "value": "wireless",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "solid state",
+                              "namespace": "synthesizing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "542a88df-4ee2-4cc6-a1a1-701fb764bdea",
+                          "display_name": "wintheiser.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.226Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.226Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.226Z",
+                          "updated": "2024-09-03T18:22:04.227Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "firewall",
+                              "value": "mobile",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "online",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "optical",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "digital",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "haptic",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "543db394-a4dc-4fe8-8172-10c8ac4eb2f5",
+                          "display_name": "cummings.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.225Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.225Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.225Z",
+                          "updated": "2024-09-03T18:22:04.225Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "monitor",
+                              "value": "1080p",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "solid state",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "1080p",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "application",
+                              "value": "haptic",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "application",
+                              "value": "online",
+                              "namespace": "copying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "6a0fc754-dbe2-4c9f-b345-57af13571a01",
+                          "display_name": "kozey.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.238Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.238Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.238Z",
+                          "updated": "2024-09-03T18:22:04.238Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "firewall",
+                              "value": "auxiliary",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "cross-platform",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "application",
+                              "value": "haptic",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "1080p",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "application",
+                              "value": "open-source",
+                              "namespace": "compressing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "6e9208c6-f104-4c80-a207-20c9d8aa5087",
+                          "display_name": "stiedemann-franecki.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.263Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.263Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.263Z",
+                          "updated": "2024-09-03T18:22:04.263Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "circuit",
+                              "value": "open-source",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "card",
+                              "value": "redundant",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "haptic",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "open-source",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "array",
+                              "value": "wireless",
+                              "namespace": "indexing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "78547704-b9a1-4ec6-b446-bfd3f85656fa",
+                          "display_name": "reichert.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.243Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.243Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.243Z",
+                          "updated": "2024-09-03T18:22:04.243Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "protocol",
+                              "value": "auxiliary",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "online",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "solid state",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "redundant",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "multi-byte",
+                              "namespace": "navigating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "7f3d7343-e440-4ed0-9c7e-1108a4316c65",
+                          "display_name": "torp-hodkiewicz.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.247Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.247Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.247Z",
+                          "updated": "2024-09-03T18:22:04.247Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "system",
+                              "value": "redundant",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "application",
+                              "value": "wireless",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "application",
+                              "value": "redundant",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "mobile",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "card",
+                              "value": "back-end",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        },
+                        {
+                          "id": "91997acf-e49d-4509-a847-76d39d0d6905",
+                          "display_name": "ortiz.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:04.232Z",
+                          "stale_timestamp": "2034-09-03T18:22:04.232Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:04.232Z",
+                          "updated": "2024-09-03T18:22:04.232Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "system",
+                              "value": "digital",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "1080p",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "protocol",
+                              "value": "multi-byte",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "system",
+                              "value": "wireless",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "multi-byte",
+                              "namespace": "quantifying"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/fa293bee-b428-4b4f-b4b7-c434bd2908b6/systems?limit=10&offset=0",
+                        "last": "/api/compliance/v2/policies/fa293bee-b428-4b4f-b4b7-c434bd2908b6/systems?limit=10&offset=20",
+                        "next": "/api/compliance/v2/policies/fa293bee-b428-4b4f-b4b7-c434bd2908b6/systems?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/system"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string",
+                      "examples": [
+                        "89fb0568-b058-4e5a-a682-e9821fe161fd"
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{policy_id}/systems/os_versions": {
+      "get": {
+        "summary": "Request the list of available OS versions",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_major_version`, `os_minor_version`, `assigned_or_scanned`, `never_reported`, `group_name`, `policies`, and `profile_ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Systems"
+        ],
+        "description": "This feature is exclusively used by the frontend",
+        "operationId": "PolicySystemsOS",
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "Lists available OS versions",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of available OS versions": {
+                    "value": [
+                      "8.0"
+                    ],
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{policy_id}/systems/{system_id}": {
+      "patch": {
+        "summary": "Assign a System to a Policy",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "system_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Assigns a System to a Policy",
+        "operationId": "AssignSystem",
+        "responses": {
+          "202": {
+            "description": "Assigns a System to a Policy",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Assigns a System to a Policy": {
+                    "value": {
+                      "data": {
+                        "id": "5701f467-706f-4083-beb7-152d4cec9f5e",
+                        "display_name": "bernhard.test",
+                        "groups": [],
+                        "culled_timestamp": "2034-09-17T18:22:04.533Z",
+                        "stale_timestamp": "2034-09-03T18:22:04.533Z",
+                        "stale_warning_timestamp": "2034-09-10T18:22:04.533Z",
+                        "updated": "2024-09-03T18:22:04.533Z",
+                        "insights_id": null,
+                        "tags": [
+                          {
+                            "key": "bus",
+                            "value": "1080p",
+                            "namespace": "hacking"
+                          },
+                          {
+                            "key": "pixel",
+                            "value": "solid state",
+                            "namespace": "connecting"
+                          },
+                          {
+                            "key": "sensor",
+                            "value": "1080p",
+                            "namespace": "navigating"
+                          },
+                          {
+                            "key": "microchip",
+                            "value": "1080p",
+                            "namespace": "hacking"
+                          },
+                          {
+                            "key": "bus",
+                            "value": "solid state",
+                            "namespace": "quantifying"
+                          }
+                        ],
+                        "type": "system",
+                        "os_major_version": 8,
+                        "os_minor_version": 0
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/system"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Assigns a System to a Policy": {
+                    "value": {
+                      "errors": [
+                        "V2::System not found with ID 6867dc14-40ad-4f92-899f-9d3ffc81a001"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Unassign a System from a Policy",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "system_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Unassigns a System from a Policy",
+        "operationId": "UnassignSystem",
+        "responses": {
+          "202": {
+            "description": "Unassigns a System from a Policy",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Unassigns a System from a Policy": {
+                    "value": {
+                      "data": {
+                        "id": "955302f9-3789-4475-b8e6-17f90d266225",
+                        "display_name": "romaguera.test",
+                        "groups": [],
+                        "culled_timestamp": "2034-09-17T18:22:04.658Z",
+                        "stale_timestamp": "2034-09-03T18:22:04.658Z",
+                        "stale_warning_timestamp": "2034-09-10T18:22:04.658Z",
+                        "updated": "2024-09-03T18:22:04.658Z",
+                        "insights_id": null,
+                        "tags": [
+                          {
+                            "key": "application",
+                            "value": "haptic",
+                            "namespace": "calculating"
+                          },
+                          {
+                            "key": "protocol",
+                            "value": "wireless",
+                            "namespace": "bypassing"
+                          },
+                          {
+                            "key": "panel",
+                            "value": "cross-platform",
+                            "namespace": "connecting"
+                          },
+                          {
+                            "key": "interface",
+                            "value": "digital",
+                            "namespace": "calculating"
+                          },
+                          {
+                            "key": "array",
+                            "value": "neural",
+                            "namespace": "synthesizing"
+                          }
+                        ],
+                        "type": "system",
+                        "os_major_version": 8,
+                        "os_minor_version": 0
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/system"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when unassigning a non-existing System": {
+                    "value": {
+                      "errors": [
+                        "V2::System not found with ID a164c7c6-c2d8-4c25-b648-c80ffc0e1047"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{report_id}/systems": {
+      "get": {
+        "summary": "Request Systems assigned to a Report",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "display_name",
+                  "os_major_version",
+                  "os_minor_version",
+                  "groups",
+                  "display_name:asc",
+                  "display_name:desc",
+                  "os_major_version:asc",
+                  "os_major_version:desc",
+                  "os_minor_version:asc",
+                  "os_minor_version:desc",
+                  "groups:asc",
+                  "groups:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_major_version`, `os_minor_version`, `assigned_or_scanned`, `never_reported`, `group_name`, `policies`, and `profile_ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Lists Systems assigned to a Report",
+        "operationId": "ReportSystems",
+        "responses": {
+          "200": {
+            "description": "Lists Systems assigned to a Report",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Systems": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "011085af-fd08-4bf0-b56f-008e8e9d17e5",
+                          "display_name": "watsica.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.153Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.153Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.153Z",
+                          "updated": "2024-09-03T18:22:05.153Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "card",
+                              "value": "primary",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "primary",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "open-source",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "virtual",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "redundant",
+                              "namespace": "hacking"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "0269ce33-2d1b-41b9-ae8b-21b39d325a0a",
+                          "display_name": "quigley.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.159Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.159Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.159Z",
+                          "updated": "2024-09-03T18:22:05.159Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "program",
+                              "value": "1080p",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "multi-byte",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "wireless",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "online",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "program",
+                              "value": "bluetooth",
+                              "namespace": "compressing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "1fd1b599-9d8d-4e4d-847c-04ad05dc1e1c",
+                          "display_name": "mills-hickle.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.133Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.133Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.133Z",
+                          "updated": "2024-09-03T18:22:05.133Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "driver",
+                              "value": "1080p",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "cross-platform",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "wireless",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "card",
+                              "value": "1080p",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "bluetooth",
+                              "namespace": "compressing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "26f7758e-f4c2-4948-845e-7d48de9ce80d",
+                          "display_name": "hudson-schinner.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.093Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.093Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.093Z",
+                          "updated": "2024-09-03T18:22:05.093Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "system",
+                              "value": "mobile",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "back-end",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "auxiliary",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "auxiliary",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "online",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "2b14f5b2-2b25-4ae1-994c-56e14f4970cc",
+                          "display_name": "cartwright-grimes.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.172Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.172Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.172Z",
+                          "updated": "2024-09-03T18:22:05.172Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "feed",
+                              "value": "open-source",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "auxiliary",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "wireless",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "system",
+                              "value": "multi-byte",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "multi-byte",
+                              "namespace": "connecting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "2db9b59c-06b9-43d9-8020-2327a482dc7a",
+                          "display_name": "vonrueden.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.078Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.078Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.078Z",
+                          "updated": "2024-09-03T18:22:05.078Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "alarm",
+                              "value": "multi-byte",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "cross-platform",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "open-source",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "program",
+                              "value": "digital",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "wireless",
+                              "namespace": "connecting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "325e7855-8627-406d-94e0-249905c10642",
+                          "display_name": "goldner.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.126Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.126Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.126Z",
+                          "updated": "2024-09-03T18:22:05.126Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "port",
+                              "value": "digital",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "cross-platform",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "back-end",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "online",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "protocol",
+                              "value": "virtual",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "345680eb-107a-4884-bec8-2462b888678c",
+                          "display_name": "bode.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.220Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.220Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.220Z",
+                          "updated": "2024-09-03T18:22:05.220Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "alarm",
+                              "value": "bluetooth",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "program",
+                              "value": "back-end",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "system",
+                              "value": "cross-platform",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "1080p",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "neural",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "3b80ce4c-6998-4b48-87b5-17f0701dfb19",
+                          "display_name": "donnelly-schultz.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.118Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.118Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.118Z",
+                          "updated": "2024-09-03T18:22:05.118Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "capacitor",
+                              "value": "optical",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "1080p",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "application",
+                              "value": "open-source",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "optical",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "protocol",
+                              "value": "virtual",
+                              "namespace": "hacking"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "3c8bada1-8fa9-4e93-9c3d-57346956ea26",
+                          "display_name": "bogisich.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.226Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.226Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.226Z",
+                          "updated": "2024-09-03T18:22:05.226Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "program",
+                              "value": "virtual",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "system",
+                              "value": "cross-platform",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "virtual",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "virtual",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "system",
+                              "value": "auxiliary",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "a63a6268-5b46-44dd-88de-e9970c6c78e3",
+                              "title": "Autem sed culpa adipisci."
+                            }
+                          ]
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports/a63a6268-5b46-44dd-88de-e9970c6c78e3/systems?limit=10&offset=0",
+                        "last": "/api/compliance/v2/reports/a63a6268-5b46-44dd-88de-e9970c6c78e3/systems?limit=10&offset=20",
+                        "next": "/api/compliance/v2/reports/a63a6268-5b46-44dd-88de-e9970c6c78e3/systems?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Systems sorted by \"os_major_version:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "0726a253-e71b-441b-b4e5-93e6dee80e35",
+                          "display_name": "mertz-keebler.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.721Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.721Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.721Z",
+                          "updated": "2024-09-03T18:22:05.721Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "sensor",
+                              "value": "back-end",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "solid state",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "bluetooth",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "virtual",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "neural",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "0bb501d9-7c4a-48bf-b0ea-0d30f5f48ef5",
+                          "display_name": "jones-abbott.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.630Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.630Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.630Z",
+                          "updated": "2024-09-03T18:22:05.630Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "feed",
+                              "value": "1080p",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "online",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "redundant",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "primary",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "mobile",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "2033e244-ac93-4a81-8853-aa2496e1108c",
+                          "display_name": "windler.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.661Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.661Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.661Z",
+                          "updated": "2024-09-03T18:22:05.661Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "application",
+                              "value": "wireless",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "redundant",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "auxiliary",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "optical",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "card",
+                              "value": "auxiliary",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "36ac2459-af75-42cb-8adb-2a887697cd5a",
+                          "display_name": "greenholt.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.636Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.636Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.636Z",
+                          "updated": "2024-09-03T18:22:05.636Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "alarm",
+                              "value": "wireless",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "port",
+                              "value": "online",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "digital",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "digital",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "virtual",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "3d0d1282-fc85-44ab-b6ef-660d4ea23270",
+                          "display_name": "bergnaum-bauch.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.667Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.667Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.667Z",
+                          "updated": "2024-09-03T18:22:05.667Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "card",
+                              "value": "1080p",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "haptic",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "virtual",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "neural",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "open-source",
+                              "namespace": "connecting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "4277ccfe-9559-4b30-a8a8-1535485cfb6e",
+                          "display_name": "hirthe-stroman.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.617Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.617Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.617Z",
+                          "updated": "2024-09-03T18:22:05.617Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "pixel",
+                              "value": "digital",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "primary",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "solid state",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "back-end",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "neural",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "55c4c16d-f289-4cdf-877a-1d774d606afb",
+                          "display_name": "effertz.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.649Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.649Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.649Z",
+                          "updated": "2024-09-03T18:22:05.649Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "pixel",
+                              "value": "optical",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "haptic",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "multi-byte",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "neural",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "system",
+                              "value": "haptic",
+                              "namespace": "connecting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "58222adb-0f09-43bd-a95f-ab3e1e0bef52",
+                          "display_name": "walker.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.678Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.678Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.678Z",
+                          "updated": "2024-09-03T18:22:05.678Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "sensor",
+                              "value": "digital",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "program",
+                              "value": "cross-platform",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "haptic",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "application",
+                              "value": "wireless",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "wireless",
+                              "namespace": "navigating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "795537c8-59b9-498a-ac26-764bbef20eab",
+                          "display_name": "roob.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.715Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.715Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.715Z",
+                          "updated": "2024-09-03T18:22:05.715Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "bandwidth",
+                              "value": "primary",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "back-end",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "redundant",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "redundant",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "digital",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "82e79011-bff0-4aaa-814c-fd1c2a64660c",
+                          "display_name": "keeling.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:05.726Z",
+                          "stale_timestamp": "2034-09-03T18:22:05.726Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:05.726Z",
+                          "updated": "2024-09-03T18:22:05.726Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "microchip",
+                              "value": "digital",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "online",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "auxiliary",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "port",
+                              "value": "neural",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "primary",
+                              "namespace": "generating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "671a9bda-184b-40df-aa62-9fb3574f7b71",
+                              "title": "Fuga et tempore et."
+                            }
+                          ]
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "os_major_version"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports/671a9bda-184b-40df-aa62-9fb3574f7b71/systems?limit=10&offset=0&sort_by=os_major_version",
+                        "last": "/api/compliance/v2/reports/671a9bda-184b-40df-aa62-9fb3574f7b71/systems?limit=10&offset=20&sort_by=os_major_version",
+                        "next": "/api/compliance/v2/reports/671a9bda-184b-40df-aa62-9fb3574f7b71/systems?limit=10&offset=10&sort_by=os_major_version"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Systems filtered by \"(os_major_version=8)\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "16441e43-4e34-4ebb-a173-a31911a9fcf0",
+                          "display_name": "pollich.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.223Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.223Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.223Z",
+                          "updated": "2024-09-03T18:22:06.223Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "bus",
+                              "value": "redundant",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "wireless",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "multi-byte",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "auxiliary",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "wireless",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "3644772c-6208-4fae-926d-2d9a58f26b08",
+                          "display_name": "rempel.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.275Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.275Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.275Z",
+                          "updated": "2024-09-03T18:22:06.275Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "bandwidth",
+                              "value": "optical",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "system",
+                              "value": "optical",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "1080p",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "primary",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "back-end",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "3c545f09-7ba9-4737-b0ca-f0a0c2000c99",
+                          "display_name": "ullrich.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.161Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.161Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.161Z",
+                          "updated": "2024-09-03T18:22:06.161Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "bus",
+                              "value": "back-end",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "program",
+                              "value": "solid state",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "system",
+                              "value": "virtual",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "system",
+                              "value": "auxiliary",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "mobile",
+                              "namespace": "generating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "4004d2a7-6402-4489-816a-cf745d493d77",
+                          "display_name": "schulist.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.090Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.090Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.090Z",
+                          "updated": "2024-09-03T18:22:06.090Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "card",
+                              "value": "digital",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "back-end",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "array",
+                              "value": "open-source",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "cross-platform",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "wireless",
+                              "namespace": "indexing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "4e55d145-c41f-44f4-82a8-8b2a23ebb9c1",
+                          "display_name": "koss.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.237Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.237Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.237Z",
+                          "updated": "2024-09-03T18:22:06.238Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "microchip",
+                              "value": "redundant",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "port",
+                              "value": "cross-platform",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "primary",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "program",
+                              "value": "1080p",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "bluetooth",
+                              "namespace": "generating"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "50115793-4ca1-4645-91c1-d85e9f27ff47",
+                          "display_name": "lesch-klein.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.216Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.216Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.216Z",
+                          "updated": "2024-09-03T18:22:06.216Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "pixel",
+                              "value": "mobile",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "optical",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "virtual",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "array",
+                              "value": "digital",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "multi-byte",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "54a87b41-74c2-40fe-bace-97c5a85c2fe3",
+                          "display_name": "doyle-quitzon.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.174Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.174Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.174Z",
+                          "updated": "2024-09-03T18:22:06.174Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "firewall",
+                              "value": "online",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "protocol",
+                              "value": "bluetooth",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "port",
+                              "value": "digital",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "back-end",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "haptic",
+                              "namespace": "backing up"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "5d0487b3-796c-4c84-b565-2bcc1b6edefa",
+                          "display_name": "mayer.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.250Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.250Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.250Z",
+                          "updated": "2024-09-03T18:22:06.250Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "program",
+                              "value": "cross-platform",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "mobile",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "card",
+                              "value": "optical",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "wireless",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "application",
+                              "value": "virtual",
+                              "namespace": "indexing"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "70968fbf-0b3f-4d59-85c7-14cda54cb682",
+                          "display_name": "raynor.test",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.116Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.116Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.116Z",
+                          "updated": "2024-09-03T18:22:06.116Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "monitor",
+                              "value": "solid state",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "multi-byte",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "solid state",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "open-source",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "solid state",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        },
+                        {
+                          "id": "71d9074a-00bc-42a6-8c3c-d5c551482d5f",
+                          "display_name": "lebsack-walter.example",
+                          "groups": [],
+                          "culled_timestamp": "2034-09-17T18:22:06.262Z",
+                          "stale_timestamp": "2034-09-03T18:22:06.262Z",
+                          "stale_warning_timestamp": "2034-09-10T18:22:06.262Z",
+                          "updated": "2024-09-03T18:22:06.262Z",
+                          "insights_id": null,
+                          "tags": [
+                            {
+                              "key": "firewall",
+                              "value": "multi-byte",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "online",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "bluetooth",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "auxiliary",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "wireless",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "type": "system",
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "policies": [
+                            {
+                              "id": "2f5222a8-760e-43ac-be02-ad53fee5d266",
+                              "title": "Dolor suscipit qui architecto."
+                            }
+                          ]
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "filter": "(os_major_version=8)",
+                        "tags": [],
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports/2f5222a8-760e-43ac-be02-ad53fee5d266/systems?filter=%28os_major_version%3D8%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/reports/2f5222a8-760e-43ac-be02-ad53fee5d266/systems?filter=%28os_major_version%3D8%29&limit=10&offset=20",
+                        "next": "/api/compliance/v2/reports/2f5222a8-760e-43ac-be02-ad53fee5d266/systems?filter=%28os_major_version%3D8%29&limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/system"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{report_id}/systems/os_versions": {
+      "get": {
+        "summary": "Request the list of available OS versions",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Systems are searchable using attributes `display_name`, `os_major_version`, `os_minor_version`, `assigned_or_scanned`, `never_reported`, `group_name`, `policies`, and `profile_ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Systems"
+        ],
+        "description": "This feature is exclusively used by the frontend",
+        "operationId": "ReportSystemsOS",
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "Lists available OS versions",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of available OS versions": {
+                    "value": [
+                      "8.0"
+                    ],
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{report_id}/systems/{system_id}": {
+      "get": {
+        "summary": "Request a System",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "system_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Returns a System under a Report",
+        "operationId": "ReportSystem",
+        "responses": {
+          "200": {
+            "description": "Returns a System under a Report",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a System under a Report": {
+                    "value": {
+                      "data": {
+                        "id": "e4d3f9af-3b54-4e88-ac2e-43792abf48fd",
+                        "display_name": "ryan.test",
+                        "groups": [],
+                        "culled_timestamp": "2034-09-17T18:22:07.878Z",
+                        "stale_timestamp": "2034-09-03T18:22:07.878Z",
+                        "stale_warning_timestamp": "2034-09-10T18:22:07.878Z",
+                        "updated": "2024-09-03T18:22:07.878Z",
+                        "insights_id": null,
+                        "tags": [
+                          {
+                            "key": "bus",
+                            "value": "virtual",
+                            "namespace": "backing up"
+                          },
+                          {
+                            "key": "capacitor",
+                            "value": "multi-byte",
+                            "namespace": "navigating"
+                          },
+                          {
+                            "key": "firewall",
+                            "value": "virtual",
+                            "namespace": "transmitting"
+                          },
+                          {
+                            "key": "capacitor",
+                            "value": "optical",
+                            "namespace": "calculating"
+                          },
+                          {
+                            "key": "sensor",
+                            "value": "online",
+                            "namespace": "compressing"
+                          }
+                        ],
+                        "type": "system",
+                        "os_major_version": 8,
+                        "os_minor_version": 0,
+                        "policies": [
+                          {
+                            "id": "974b9afa-eeb3-4afb-ae0b-53db24417183",
+                            "title": "Recusandae accusamus voluptatum illo."
+                          }
+                        ]
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/system"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing System": {
+                    "value": {
+                      "errors": [
+                        "V2::System not found with ID 099f46c6-d2a7-42a7-b2c2-41500b5d0c88"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{policy_id}/tailorings": {
+      "get": {
+        "summary": "Request Tailorings",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "os_minor_version",
+                  "os_minor_version:asc",
+                  "os_minor_version:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Tailorings are searchable using attributes `os_minor_version`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Lists Tailorings",
+        "operationId": "Tailorings",
+        "responses": {
+          "200": {
+            "description": "Lists Tailorings",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Tailorings": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "13c289b9-4848-4eff-bcae-9000a3f8b41f",
+                          "profile_id": "680f0913-33cc-4f65-94c1-24b5d6bc37b8",
+                          "os_minor_version": 17,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "2e3edfdf-9dff-4407-89a5-e8b6c117fe2e",
+                          "security_guide_version": "100.95.43"
+                        },
+                        {
+                          "id": "1a2e33eb-5b1f-4c73-8fff-19534c1e9892",
+                          "profile_id": "67064728-737c-4d8a-9f0e-6290717083bf",
+                          "os_minor_version": 2,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "42e0caa2-bfa0-4627-8961-fe5fc83d997c",
+                          "security_guide_version": "100.95.28"
+                        },
+                        {
+                          "id": "1af4c767-b122-4c39-b65b-ad6c710eebc1",
+                          "profile_id": "dbed6486-8dba-4ea4-b0b3-e60d9f6e4e84",
+                          "os_minor_version": 15,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "f05b6372-6054-4c9b-8cb4-1f76115d5f5d",
+                          "security_guide_version": "100.95.41"
+                        },
+                        {
+                          "id": "2a7cc636-c7d8-4abf-8dc6-36564df66d07",
+                          "profile_id": "3754362a-0485-49d7-8de6-87d75ccd5f10",
+                          "os_minor_version": 10,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "d463fa1e-1753-47dc-9573-6d0686c0ba08",
+                          "security_guide_version": "100.95.36"
+                        },
+                        {
+                          "id": "33d39a8a-79cf-48b7-a06c-324781a98b05",
+                          "profile_id": "06d27019-b54e-4ae6-8214-1b0b904792f8",
+                          "os_minor_version": 12,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "043f2c5a-2768-4a39-98b6-f59579dea7a7",
+                          "security_guide_version": "100.95.38"
+                        },
+                        {
+                          "id": "472e271f-6a4a-4343-87a6-b4f34a5f1dd0",
+                          "profile_id": "c4d14284-0b7f-4bfc-9ddc-c74b5d435a0c",
+                          "os_minor_version": 23,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "0ae13a5c-4c78-4ac8-a3c8-d31dc6e296f2",
+                          "security_guide_version": "100.95.49"
+                        },
+                        {
+                          "id": "57ec7048-9c21-40cf-94fd-ede0030acdaf",
+                          "profile_id": "2dd6065b-b84d-4eeb-95a7-1c2b78d3d6dc",
+                          "os_minor_version": 7,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "0d5501c1-8202-49a0-a89d-1112460ca62f",
+                          "security_guide_version": "100.95.33"
+                        },
+                        {
+                          "id": "600487b6-45ba-4a90-956b-4cbae3e99161",
+                          "profile_id": "46bb726f-d663-4730-944c-86beccace335",
+                          "os_minor_version": 19,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "e2ec53bc-9425-451b-8275-1ffe9a16ae7a",
+                          "security_guide_version": "100.95.45"
+                        },
+                        {
+                          "id": "66871b35-a0b7-47fa-8632-44bc6475bc92",
+                          "profile_id": "f6ea5f95-1d22-47b9-a93f-7f47d77016f8",
+                          "os_minor_version": 4,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "bd449859-5e63-4ee2-88d7-9398c20d0d84",
+                          "security_guide_version": "100.95.30"
+                        },
+                        {
+                          "id": "68bc8cc1-eb6c-4035-9370-d207e88082e7",
+                          "profile_id": "df2df6f6-20db-4449-88f2-c60412926bbd",
+                          "os_minor_version": 20,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "ebf9abc0-1ef5-448b-a23c-227456b666d8",
+                          "security_guide_version": "100.95.46"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/9f686a37-ab3b-4223-8b7b-62de6edb50e6/tailorings?limit=10&offset=0",
+                        "last": "/api/compliance/v2/policies/9f686a37-ab3b-4223-8b7b-62de6edb50e6/tailorings?limit=10&offset=20",
+                        "next": "/api/compliance/v2/policies/9f686a37-ab3b-4223-8b7b-62de6edb50e6/tailorings?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Tailorings sorted by \"os_minor_version:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "31dbeaa9-7b19-4464-862d-e4c5225463f2",
+                          "profile_id": "1648e6e5-2731-4f21-9446-a82c540a3b43",
+                          "os_minor_version": 0,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "58856db1-f0b2-4295-b5c5-59842ff5e0a9",
+                          "security_guide_version": "100.96.1"
+                        },
+                        {
+                          "id": "6680c3c1-c38f-451d-ba5f-bd3960da65b7",
+                          "profile_id": "dcf93faf-d62d-477e-b3af-868a2f6efd05",
+                          "os_minor_version": 1,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "46c9d8f8-0364-4076-bf0a-520b75679192",
+                          "security_guide_version": "100.96.2"
+                        },
+                        {
+                          "id": "45cabd85-453f-4e02-bb02-f3d673204570",
+                          "profile_id": "df8c3b2d-ab8b-4e46-a66d-32fa7cfc63a2",
+                          "os_minor_version": 2,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "86e17a85-1f77-41a4-a567-d26684883d2a",
+                          "security_guide_version": "100.96.3"
+                        },
+                        {
+                          "id": "ec7dc140-02cc-4114-9887-b8abbdf85e9a",
+                          "profile_id": "31b434f9-0033-4b53-98f3-583f0cf312b5",
+                          "os_minor_version": 3,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "98833801-a623-42f0-9f5e-d1f4d5ec1180",
+                          "security_guide_version": "100.96.4"
+                        },
+                        {
+                          "id": "59dbb7df-62c3-400d-b443-849da275caee",
+                          "profile_id": "83bb6dc2-0b9c-4eae-9437-f705ebc37a7f",
+                          "os_minor_version": 4,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "7fcee433-563d-49da-aa1f-3bd9f6fd4d5f",
+                          "security_guide_version": "100.96.5"
+                        },
+                        {
+                          "id": "b81fb89a-b6ad-45b8-8384-a143cadb0612",
+                          "profile_id": "ceaa9fbd-bb3d-452f-8333-d314c84744b8",
+                          "os_minor_version": 5,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "5bd45ce9-9b68-4934-beee-83fb256a3d48",
+                          "security_guide_version": "100.96.6"
+                        },
+                        {
+                          "id": "5e9ed795-ceb7-4f35-9ed5-670ad1b808a8",
+                          "profile_id": "6dd2b099-3646-417a-b8d4-5b722b1af542",
+                          "os_minor_version": 6,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "554f02d0-4190-4f2c-b304-d0b66941b04e",
+                          "security_guide_version": "100.96.7"
+                        },
+                        {
+                          "id": "8fbd3f19-3bc9-44be-9c79-28b17020baa3",
+                          "profile_id": "3b2d4e3a-a967-417f-9010-2c2868061e44",
+                          "os_minor_version": 7,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "b54b4a32-c097-4439-83da-ecd825a18074",
+                          "security_guide_version": "100.96.8"
+                        },
+                        {
+                          "id": "6166c66e-8baf-4f19-b114-203d306faa58",
+                          "profile_id": "ed3843e2-a52e-40ba-a11b-784b562c6335",
+                          "os_minor_version": 8,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "df6f005a-8d0f-4c00-8676-1c0276022f18",
+                          "security_guide_version": "100.96.9"
+                        },
+                        {
+                          "id": "ec7d97f2-d745-4c4d-91a7-a39b012536dc",
+                          "profile_id": "2d6e186e-b29c-443e-a206-9cc5b580841d",
+                          "os_minor_version": 9,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "17662866-edaa-4365-95e3-b84fa67901ac",
+                          "security_guide_version": "100.96.10"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "os_minor_version"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/3743107a-9609-4915-b1db-e25d36cd5bf8/tailorings?limit=10&offset=0&sort_by=os_minor_version",
+                        "last": "/api/compliance/v2/policies/3743107a-9609-4915-b1db-e25d36cd5bf8/tailorings?limit=10&offset=20&sort_by=os_minor_version",
+                        "next": "/api/compliance/v2/policies/3743107a-9609-4915-b1db-e25d36cd5bf8/tailorings?limit=10&offset=10&sort_by=os_minor_version"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Tailorings filtered by '(os_minor_version=11)'": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "17021379-5f4b-47d8-9337-9ae03b6e3b01",
+                          "profile_id": "6ee0e465-6b50-4da0-9238-e756939751ea",
+                          "os_minor_version": 11,
+                          "value_overrides": {},
+                          "type": "tailoring",
+                          "os_major_version": 7,
+                          "security_guide_id": "75185d54-2d5d-4ecb-823f-53f2db6766ab",
+                          "security_guide_version": "100.96.37"
+                        }
+                      ],
+                      "meta": {
+                        "total": 1,
+                        "filter": "(os_minor_version=11)",
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/policies/90fd4c32-1038-4710-ae17-78d08e8bf532/tailorings?filter=%28os_minor_version%3D11%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/policies/90fd4c32-1038-4710-ae17-78d08e8bf532/tailorings?filter=%28os_minor_version%3D11%29&limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/tailoring"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{policy_id}/tailorings/{tailoring_id}": {
+      "get": {
+        "summary": "Request a Tailoring",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tailoring_id",
+            "in": "path",
+            "required": true,
+            "description": "UUID or OS minor version number",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Returns a Tailoring",
+        "operationId": "Tailoring",
+        "responses": {
+          "200": {
+            "description": "Returns a Tailoring",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Tailoring": {
+                    "value": {
+                      "data": {
+                        "id": "43e2cd42-4a7f-4cb0-8955-36ae047adbe0",
+                        "profile_id": "be097204-0923-4d9b-b065-edcb4aca0342",
+                        "os_minor_version": 1,
+                        "value_overrides": {},
+                        "type": "tailoring",
+                        "os_major_version": 7,
+                        "security_guide_id": "035ae9b5-3ca1-4744-b5dc-e8337046e667",
+                        "security_guide_version": "100.98.1"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/tailoring"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Tailoring": {
+                    "value": {
+                      "errors": [
+                        "V2::Tailoring not found with ID fe97fd55-fffd-4fc6-9dff-aff1eef56af7"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a Tailoring",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tailoring_id",
+            "in": "path",
+            "required": true,
+            "description": "UUID or OS minor version number",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Updates a Tailoring with the provided value_overrides",
+        "operationId": "UpdateTailoring",
+        "responses": {
+          "202": {
+            "description": "Updates a Tailoring",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns the updated Tailoring": {
+                    "value": {
+                      "data": {
+                        "id": "1e045fa6-42dc-4e70-b324-cfa91e8525b6",
+                        "profile_id": "c43d9d8d-50cb-46c6-a35e-d41c9c7d957c",
+                        "os_minor_version": 1,
+                        "value_overrides": {
+                          "040139bd-d7af-4ee6-846f-a0d420856b58": "123"
+                        },
+                        "type": "tailoring",
+                        "os_major_version": 7,
+                        "security_guide_id": "7d1ac2d0-59fc-40f0-b11f-977ba1f9c902",
+                        "security_guide_version": "100.98.2"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/tailoring"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "requestBody": {
+          "content": {
+            "application/vnd.api+json": {
+              "schema": {
+                "$ref": "#/components/schemas/tailoring"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/policies/{policy_id}/tailorings/{tailoring_id}/tailoring_file.json": {
+      "get": {
+        "summary": "Request a Tailoring file",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "policy_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "tailoring_id",
+            "in": "path",
+            "required": true,
+            "description": "UUID or OS minor version number",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Policies"
+        ],
+        "description": "Returns a Tailoring File",
+        "operationId": "TailoringFile",
+        "responses": {
+          "200": {
+            "description": "Returns a Tailoring File",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Tailoring File": {
+                    "value": {
+                      "profiles": [
+                        {
+                          "id": "xccdf_org.ssgproject.content_profile_c25f80c8d6ca4ba3cc5812f2eda5357e",
+                          "title": "Ab aliquid vero et.",
+                          "groups": {},
+                          "rules": {},
+                          "variables": {
+                            "foo_value_5eca917f-25f8-4705-b6bb-a7a45d9af965": {
+                              "value": "68184"
+                            },
+                            "foo_value_c2e981da-4745-4582-ba11-10ba068935ca": {
+                              "value": "311439"
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/tailoring_file"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{report_id}/test_results": {
+      "get": {
+        "summary": "Request Test Results under a Report",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "display_name",
+                  "security_guide_version",
+                  "groups",
+                  "score",
+                  "end_time",
+                  "failed_rule_count",
+                  "display_name:asc",
+                  "display_name:desc",
+                  "security_guide_version:asc",
+                  "security_guide_version:desc",
+                  "groups:asc",
+                  "groups:desc",
+                  "score:asc",
+                  "score:desc",
+                  "end_time:asc",
+                  "end_time:desc",
+                  "failed_rule_count:asc",
+                  "failed_rule_count:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Test Results are searchable using attributes `score`, `supported`, `system_id`, `display_name`, `os_minor_version`, `security_guide_version`, `compliant`, `group_name`, and `failed_rule_severity`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Lists Test Results under a Report",
+        "operationId": "ReportTestResults",
+        "responses": {
+          "200": {
+            "description": "Lists Test Results under a Report",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Test Results": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "0ddc8003-40a8-45aa-bbc5-d24e5ff94e2b",
+                          "end_time": "2024-09-03T18:21:10.231Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 44.12398974534694,
+                          "type": "test_result",
+                          "display_name": "watsica-hickle.test",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "array",
+                              "value": "mobile",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "card",
+                              "value": "open-source",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "array",
+                              "value": "online",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "multi-byte",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "auxiliary",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "f515c096-b697-4f9e-a01b-cadb8055921b",
+                          "security_guide_version": "100.99.15"
+                        },
+                        {
+                          "id": "10a0c93b-3699-4bf5-933b-c4bdacff3d9c",
+                          "end_time": "2024-09-03T18:21:10.375Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 68.21623130460861,
+                          "type": "test_result",
+                          "display_name": "brakus.test",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "pixel",
+                              "value": "haptic",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "program",
+                              "value": "digital",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "array",
+                              "value": "virtual",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "auxiliary",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "array",
+                              "value": "bluetooth",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "839e11f1-601b-4525-8590-033155d54651",
+                          "security_guide_version": "100.99.15"
+                        },
+                        {
+                          "id": "147c6c34-1d86-4a55-b36a-1cb9f3f99238",
+                          "end_time": "2024-09-03T18:21:10.306Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 30.1094133085474,
+                          "type": "test_result",
+                          "display_name": "christiansen.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "card",
+                              "value": "solid state",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "1080p",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "wireless",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "optical",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "neural",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "a3df7048-7f0c-48cd-b715-d6640da61dd6",
+                          "security_guide_version": "100.99.15"
+                        },
+                        {
+                          "id": "199468f3-11ff-4f35-bb3b-1e732c5ba8b8",
+                          "end_time": "2024-09-03T18:21:10.223Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 60.32838115118522,
+                          "type": "test_result",
+                          "display_name": "wiegand.test",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "circuit",
+                              "value": "1080p",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "back-end",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "multi-byte",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "optical",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "multi-byte",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "251daebd-a9c2-4f32-bdf7-9033bc960183",
+                          "security_guide_version": "100.99.15"
+                        },
+                        {
+                          "id": "1e826ae5-800c-4df8-88a5-062f05a70177",
+                          "end_time": "2024-09-03T18:21:10.360Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 79.39714482786336,
+                          "type": "test_result",
+                          "display_name": "kshlerin.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "hard drive",
+                              "value": "neural",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "optical",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "virtual",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "program",
+                              "value": "solid state",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "system",
+                              "value": "virtual",
+                              "namespace": "hacking"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "d2416a11-1076-4b1e-8a61-9167b881bfe3",
+                          "security_guide_version": "100.99.15"
+                        },
+                        {
+                          "id": "20e9914d-6e8d-441b-ae94-f9a9beee1720",
+                          "end_time": "2024-09-03T18:21:10.214Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 48.21038624580976,
+                          "type": "test_result",
+                          "display_name": "boyle-reinger.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "bandwidth",
+                              "value": "redundant",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "haptic",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "solid state",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "card",
+                              "value": "neural",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "protocol",
+                              "value": "haptic",
+                              "namespace": "connecting"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "83d57a00-8df0-43f2-be9a-ef583f86a212",
+                          "security_guide_version": "100.99.15"
+                        },
+                        {
+                          "id": "38aebb63-b38c-4b3d-a029-57e9ac9b8fc1",
+                          "end_time": "2024-09-03T18:21:10.248Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 31.77076735444214,
+                          "type": "test_result",
+                          "display_name": "schaden.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "bus",
+                              "value": "bluetooth",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "card",
+                              "value": "online",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "haptic",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "neural",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "system",
+                              "value": "open-source",
+                              "namespace": "generating"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "bca9333d-712a-45d4-ad8e-da3b5020bf18",
+                          "security_guide_version": "100.99.15"
+                        },
+                        {
+                          "id": "5c4ba269-6bc9-4036-9a13-ef76734ac047",
+                          "end_time": "2024-09-03T18:21:10.240Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 97.02665113486853,
+                          "type": "test_result",
+                          "display_name": "gibson-vandervort.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "program",
+                              "value": "online",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "auxiliary",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "primary",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "optical",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "open-source",
+                              "namespace": "synthesizing"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": true,
+                          "system_id": "81f3fd26-0a9f-48fc-b5da-2637a49afdc2",
+                          "security_guide_version": "100.99.15"
+                        },
+                        {
+                          "id": "5e77d6fb-c3a4-481e-808a-e09026ec7611",
+                          "end_time": "2024-09-03T18:21:10.368Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 2.197450204185913,
+                          "type": "test_result",
+                          "display_name": "ortiz-hodkiewicz.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "matrix",
+                              "value": "redundant",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "virtual",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "transmitter",
+                              "value": "open-source",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "back-end",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "virtual",
+                              "namespace": "quantifying"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "4a28d96f-5910-46f7-b7d3-f76cf010da39",
+                          "security_guide_version": "100.99.15"
+                        },
+                        {
+                          "id": "6921a45d-6165-4875-a7bd-b042bf9a8d7b",
+                          "end_time": "2024-09-03T18:21:10.315Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 38.65103512441833,
+                          "type": "test_result",
+                          "display_name": "conroy-jenkins.test",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "capacitor",
+                              "value": "optical",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "primary",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "array",
+                              "value": "bluetooth",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "open-source",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "redundant",
+                              "namespace": "transmitting"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "80b8b579-0eff-4e4b-9800-05307f0cf703",
+                          "security_guide_version": "100.99.15"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports/82a4fa41-e363-461a-870d-60304634df2d/test_results?limit=10&offset=0",
+                        "last": "/api/compliance/v2/reports/82a4fa41-e363-461a-870d-60304634df2d/test_results?limit=10&offset=20",
+                        "next": "/api/compliance/v2/reports/82a4fa41-e363-461a-870d-60304634df2d/test_results?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Test Results sorted by \"score:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "0d68b38d-354f-421b-a151-33a54e0af466",
+                          "end_time": "2024-09-03T18:21:10.803Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 4.52856140954877,
+                          "type": "test_result",
+                          "display_name": "lindgren-stanton.test",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "circuit",
+                              "value": "neural",
+                              "namespace": "navigating"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "neural",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "bluetooth",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "neural",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "solid state",
+                              "namespace": "programming"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "17233d2d-71ac-4104-939a-389f10e00938",
+                          "security_guide_version": "100.100.20"
+                        },
+                        {
+                          "id": "dd7a2698-b235-442c-9c75-056d134e27a7",
+                          "end_time": "2024-09-03T18:21:10.832Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 13.67803371230789,
+                          "type": "test_result",
+                          "display_name": "dicki.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "port",
+                              "value": "back-end",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "array",
+                              "value": "auxiliary",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "application",
+                              "value": "digital",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "multi-byte",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "protocol",
+                              "value": "redundant",
+                              "namespace": "bypassing"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "6b8d0809-32d2-4084-90f8-c66f1c86b874",
+                          "security_guide_version": "100.100.20"
+                        },
+                        {
+                          "id": "18ffd6fd-30a6-4fe7-98cf-1bc366bd5898",
+                          "end_time": "2024-09-03T18:21:10.765Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 13.76716982633508,
+                          "type": "test_result",
+                          "display_name": "batz.test",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "bandwidth",
+                              "value": "1080p",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "circuit",
+                              "value": "wireless",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "optical",
+                              "namespace": "compressing"
+                            },
+                            {
+                              "key": "panel",
+                              "value": "open-source",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "redundant",
+                              "namespace": "overriding"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "5eb4e472-cd5a-4235-899b-6cfd834bda3b",
+                          "security_guide_version": "100.100.20"
+                        },
+                        {
+                          "id": "1dc20ca0-4f2e-4911-89bf-9096bfce52fb",
+                          "end_time": "2024-09-03T18:21:10.906Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 23.80600413836979,
+                          "type": "test_result",
+                          "display_name": "effertz.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "driver",
+                              "value": "open-source",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "program",
+                              "value": "neural",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "interface",
+                              "value": "digital",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "haptic",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "optical",
+                              "namespace": "overriding"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "a260d5cd-c169-4f2a-8455-3d1675ae7909",
+                          "security_guide_version": "100.100.20"
+                        },
+                        {
+                          "id": "43a10146-c074-4f73-961c-8672a963f27e",
+                          "end_time": "2024-09-03T18:21:10.757Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 29.9536665734804,
+                          "type": "test_result",
+                          "display_name": "hahn.test",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "monitor",
+                              "value": "mobile",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "microchip",
+                              "value": "online",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "back-end",
+                              "namespace": "indexing"
+                            },
+                            {
+                              "key": "protocol",
+                              "value": "virtual",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "card",
+                              "value": "bluetooth",
+                              "namespace": "generating"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "317ad7d2-6479-4f83-a095-f4b10d3a55c5",
+                          "security_guide_version": "100.100.20"
+                        },
+                        {
+                          "id": "1c548978-4171-45a8-b9f7-4a75b9392ef9",
+                          "end_time": "2024-09-03T18:21:10.899Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 35.01129142282799,
+                          "type": "test_result",
+                          "display_name": "botsford-howe.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "program",
+                              "value": "open-source",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "pixel",
+                              "value": "optical",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "feed",
+                              "value": "redundant",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "firewall",
+                              "value": "digital",
+                              "namespace": "copying"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "bluetooth",
+                              "namespace": "copying"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "ec797e6a-963d-4c68-bc0c-a32643d533d3",
+                          "security_guide_version": "100.100.20"
+                        },
+                        {
+                          "id": "3589f9c5-483c-419e-8057-928eb94b64a3",
+                          "end_time": "2024-09-03T18:21:10.742Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 36.63022987688126,
+                          "type": "test_result",
+                          "display_name": "homenick-wehner.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "capacitor",
+                              "value": "neural",
+                              "namespace": "calculating"
+                            },
+                            {
+                              "key": "card",
+                              "value": "haptic",
+                              "namespace": "generating"
+                            },
+                            {
+                              "key": "capacitor",
+                              "value": "redundant",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "hard drive",
+                              "value": "back-end",
+                              "namespace": "bypassing"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "primary",
+                              "namespace": "hacking"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "d8bff5f9-a3c6-4139-a3cc-642ef88b7e20",
+                          "security_guide_version": "100.100.20"
+                        },
+                        {
+                          "id": "8230aa83-d0cd-4b8c-9ece-83f085e10b8f",
+                          "end_time": "2024-09-03T18:21:10.750Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 37.29411362572155,
+                          "type": "test_result",
+                          "display_name": "hills-sanford.test",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "panel",
+                              "value": "solid state",
+                              "namespace": "overriding"
+                            },
+                            {
+                              "key": "bandwidth",
+                              "value": "solid state",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "port",
+                              "value": "primary",
+                              "namespace": "synthesizing"
+                            },
+                            {
+                              "key": "application",
+                              "value": "wireless",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "driver",
+                              "value": "multi-byte",
+                              "namespace": "parsing"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "8282fb97-6fd9-407a-b69d-b3d421929c31",
+                          "security_guide_version": "100.100.20"
+                        },
+                        {
+                          "id": "1105497f-772d-41da-8b90-502fc728e957",
+                          "end_time": "2024-09-03T18:21:10.727Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 37.38830447816892,
+                          "type": "test_result",
+                          "display_name": "okeefe.example",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "hard drive",
+                              "value": "neural",
+                              "namespace": "quantifying"
+                            },
+                            {
+                              "key": "sensor",
+                              "value": "neural",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "monitor",
+                              "value": "redundant",
+                              "namespace": "connecting"
+                            },
+                            {
+                              "key": "bus",
+                              "value": "solid state",
+                              "namespace": "backing up"
+                            },
+                            {
+                              "key": "application",
+                              "value": "virtual",
+                              "namespace": "calculating"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "653c19a6-2cb4-4220-8ea8-494d60739323",
+                          "security_guide_version": "100.100.20"
+                        },
+                        {
+                          "id": "4f15c8f8-bf56-4b76-8090-b261840c0f2b",
+                          "end_time": "2024-09-03T18:21:10.849Z",
+                          "failed_rule_count": 0,
+                          "supported": true,
+                          "score": 39.04757682538054,
+                          "type": "test_result",
+                          "display_name": "bayer-mueller.test",
+                          "groups": [],
+                          "tags": [
+                            {
+                              "key": "card",
+                              "value": "optical",
+                              "namespace": "parsing"
+                            },
+                            {
+                              "key": "port",
+                              "value": "open-source",
+                              "namespace": "transmitting"
+                            },
+                            {
+                              "key": "matrix",
+                              "value": "solid state",
+                              "namespace": "hacking"
+                            },
+                            {
+                              "key": "alarm",
+                              "value": "primary",
+                              "namespace": "programming"
+                            },
+                            {
+                              "key": "port",
+                              "value": "open-source",
+                              "namespace": "copying"
+                            }
+                          ],
+                          "os_major_version": 8,
+                          "os_minor_version": 0,
+                          "compliant": false,
+                          "system_id": "b4024906-cbc8-416c-8127-2a6c5be1f07c",
+                          "security_guide_version": "100.100.20"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "score"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports/60690e73-53ea-47f7-a260-ac20a44e0210/test_results?limit=10&offset=0&sort_by=score",
+                        "last": "/api/compliance/v2/reports/60690e73-53ea-47f7-a260-ac20a44e0210/test_results?limit=10&offset=20&sort_by=score",
+                        "next": "/api/compliance/v2/reports/60690e73-53ea-47f7-a260-ac20a44e0210/test_results?limit=10&offset=10&sort_by=score"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Test Results filtered by \"(os_minor_version=8)\"": {
+                    "value": {
+                      "data": [],
+                      "meta": {
+                        "total": 0,
+                        "filter": "(os_minor_version=8)",
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/reports/3c5496ac-0648-4691-9341-2f62adeb3eb4/test_results?filter=%28os_minor_version%3D8%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/reports/3c5496ac-0648-4691-9341-2f62adeb3eb4/test_results?filter=%28os_minor_version%3D8%29&limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/test_result"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{report_id}/test_results/os_versions": {
+      "get": {
+        "summary": "Request the list of available OS versions",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Test Results are searchable using attributes `score`, `supported`, `system_id`, `display_name`, `os_minor_version`, `security_guide_version`, `compliant`, `group_name`, and `failed_rule_severity`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "This feature is exclusively used by the frontend",
+        "operationId": "ReportTestResultsOS",
+        "deprecated": true,
+        "responses": {
+          "200": {
+            "description": "Lists available OS versions",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of available OS versions": {
+                    "value": [
+                      "8.0"
+                    ],
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/reports/{report_id}/test_results/{test_result_id}": {
+      "get": {
+        "summary": "Request a Test Result",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "test_result_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "report_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Reports"
+        ],
+        "description": "Returns a Test Result under a Report",
+        "operationId": "ReportTestResult",
+        "responses": {
+          "200": {
+            "description": "Returns a Test Result under a Report",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Test Result under a Report": {
+                    "value": {
+                      "data": {
+                        "id": "682f1cba-bf70-4482-9c59-58bc82aa8fca",
+                        "end_time": "2024-09-03T18:21:13.210Z",
+                        "failed_rule_count": 0,
+                        "supported": true,
+                        "score": 95.48061344609253,
+                        "type": "test_result",
+                        "display_name": "sauer.example",
+                        "groups": [],
+                        "tags": [
+                          {
+                            "key": "bandwidth",
+                            "value": "redundant",
+                            "namespace": "compressing"
+                          },
+                          {
+                            "key": "port",
+                            "value": "optical",
+                            "namespace": "navigating"
+                          },
+                          {
+                            "key": "array",
+                            "value": "wireless",
+                            "namespace": "connecting"
+                          },
+                          {
+                            "key": "monitor",
+                            "value": "online",
+                            "namespace": "copying"
+                          },
+                          {
+                            "key": "bus",
+                            "value": "online",
+                            "namespace": "calculating"
+                          }
+                        ],
+                        "os_major_version": 8,
+                        "os_minor_version": 0,
+                        "compliant": true,
+                        "system_id": "091c9322-3b9a-40cc-a87b-2531b8015547",
+                        "security_guide_version": "100.106.25"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/system"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Test Result": {
+                    "value": {
+                      "errors": [
+                        "V2::TestResult not found with ID 03187193-0708-484e-a330-9ddb13d37810"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/value_definitions": {
+      "get": {
+        "summary": "Request Value Definitions",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "description": "Number of items to return per page",
+            "schema": {
+              "type": "number",
+              "maximum": 100,
+              "minimum": 1,
+              "default": 10
+            }
+          },
+          {
+            "name": "offset",
+            "in": "query",
+            "required": false,
+            "description": "Offset of first item of paginated response",
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "default": 0
+            }
+          },
+          {
+            "name": "sort_by",
+            "in": "query",
+            "required": false,
+            "description": "Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "title",
+                  "title:asc",
+                  "title:desc"
+                ]
+              }
+            }
+          },
+          {
+            "name": "filter",
+            "in": "query",
+            "required": false,
+            "description": "Query string to filter items by their attributes. Compliant with <a href=\"https://github.com/wvanbergen/scoped_search/wiki/Query-language\" target=\"_blank\" title=\"github.com/wvanbergen/scoped_search\">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Value Definitions are searchable using attributes `title` and `ref_id`<br><br>(e.g.: `(field_1=something AND field_2!=\"something else\") OR field_3>40`)",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Lists Value Definitions",
+        "operationId": "ValueDefinitions",
+        "responses": {
+          "200": {
+            "description": "Lists Value Definitions",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "List of Value Definitions": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "045a8d6e-c3ed-4dae-96bc-df8e5921d5a3",
+                          "ref_id": "foo_value_3cd15cc2-cd41-4d1d-9b61-3946409e8010",
+                          "title": "Labore porro deleniti et.",
+                          "description": "Autem saepe quia. Corrupti sit alias. At sit officiis.",
+                          "value_type": "number",
+                          "default_value": "0.974387439024744",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "05e1796d-b642-4cd8-9dd6-5dc22cbee1a8",
+                          "ref_id": "foo_value_6f0a4086-6e4b-4846-b693-885dc96c220e",
+                          "title": "Aut rerum culpa et.",
+                          "description": "Placeat deleniti quaerat. Quo excepturi unde. Minus molestiae quia.",
+                          "value_type": "number",
+                          "default_value": "0.0886420771580605",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "087b6fad-088d-4e65-9270-d6e906b87780",
+                          "ref_id": "foo_value_bbea9418-0a15-47df-a9a2-7798f8308792",
+                          "title": "Ab illo molestiae at.",
+                          "description": "Voluptas sunt soluta. Et rem omnis. Voluptate corporis odit.",
+                          "value_type": "number",
+                          "default_value": "0.5026535014719153",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "136b95c5-b7ee-42c8-8535-e5935eeb4481",
+                          "ref_id": "foo_value_f83811a1-10bd-4e62-b4d2-c5f38c4705b5",
+                          "title": "Voluptas nobis consequatur tenetur.",
+                          "description": "Ut saepe numquam. Minima odio ad. Similique accusantium eius.",
+                          "value_type": "number",
+                          "default_value": "0.9537009666128158",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "1bd37aea-f69b-4540-8cae-32ca1cfdbb9d",
+                          "ref_id": "foo_value_21c93f87-cd50-473b-8f60-14ef3980d518",
+                          "title": "Id aut dolorem expedita.",
+                          "description": "Sequi architecto quo. Necessitatibus voluptas unde. Rerum laudantium inventore.",
+                          "value_type": "number",
+                          "default_value": "0.44098088759091003",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "2fe74529-df89-41cf-a144-f469a48e039b",
+                          "ref_id": "foo_value_4ee6a9ca-d589-4fb8-8e4e-dfba4e53b964",
+                          "title": "Doloribus est quas qui.",
+                          "description": "Aut occaecati quia. Atque aut ut. Est aspernatur tempora.",
+                          "value_type": "number",
+                          "default_value": "0.05767159240804831",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "36884c21-c7e1-4d79-bdae-47b4b87d7065",
+                          "ref_id": "foo_value_4d368cf5-60b1-4b40-b3c3-6d8bea9af908",
+                          "title": "Soluta officia vero quisquam.",
+                          "description": "Totam delectus veniam. Velit rerum exercitationem. Praesentium rerum voluptatem.",
+                          "value_type": "number",
+                          "default_value": "0.7971751772792739",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "632c407a-35fd-49a9-802e-88a44dfccfba",
+                          "ref_id": "foo_value_62e51bf9-8b2e-4d37-a4aa-5bfc833310b0",
+                          "title": "Quos enim fugiat eius.",
+                          "description": "Architecto quos sint. Soluta voluptatum exercitationem. Adipisci et officia.",
+                          "value_type": "number",
+                          "default_value": "0.015196838905169319",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "65c004e3-b7c9-4983-83b4-67a2615ee7bd",
+                          "ref_id": "foo_value_6c5c997d-1288-4129-a1bd-998ebb85ed32",
+                          "title": "Nemo facilis ab et.",
+                          "description": "Voluptatem voluptas nam. Rerum adipisci a. Ratione sint non.",
+                          "value_type": "number",
+                          "default_value": "0.6201029036972276",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "7c61449b-6372-47d1-a81b-0512f669b5ab",
+                          "ref_id": "foo_value_707227de-fb31-4c5a-ba7c-1b5162bcd5dd",
+                          "title": "Harum sit illo ducimus.",
+                          "description": "Quam magni enim. Laboriosam placeat similique. Debitis fugiat dolores.",
+                          "value_type": "number",
+                          "default_value": "0.43271293460824123",
+                          "type": "value_definition"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/a9ccf77e-5a1f-4fcb-b52f-424bd9cdea4a/value_definitions?limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides/a9ccf77e-5a1f-4fcb-b52f-424bd9cdea4a/value_definitions?limit=10&offset=20",
+                        "next": "/api/compliance/v2/security_guides/a9ccf77e-5a1f-4fcb-b52f-424bd9cdea4a/value_definitions?limit=10&offset=10"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Value Definitions sorted by \"title:asc\"": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "d080191e-1a6f-4b66-a9a1-78acb8060c74",
+                          "ref_id": "foo_value_8a7b2258-de10-4856-83e0-afc53e33f66e",
+                          "title": "Accusantium beatae exercitationem rerum.",
+                          "description": "Et tempore asperiores. Vero delectus voluptatem. Omnis deserunt illum.",
+                          "value_type": "number",
+                          "default_value": "0.5634580391978025",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "3062e244-aedf-432a-b3ab-c481117f64f9",
+                          "ref_id": "foo_value_eab3d48f-b9cc-4491-b7f8-22edfeb3eb00",
+                          "title": "Asperiores dolorum perspiciatis nihil.",
+                          "description": "Debitis deleniti pariatur. Eos ut et. Eius repellat neque.",
+                          "value_type": "number",
+                          "default_value": "0.1322318471796321",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "b683425a-3a83-43f3-927a-e118fd1d3661",
+                          "ref_id": "foo_value_034f6eb0-ccba-4639-98a1-9d71b42392ce",
+                          "title": "Dicta fugiat dolore vitae.",
+                          "description": "Et suscipit praesentium. Et autem iure. Vel numquam voluptas.",
+                          "value_type": "number",
+                          "default_value": "0.47861757280460293",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "837fb62d-754b-475f-9099-427e44469236",
+                          "ref_id": "foo_value_0fc13a5c-de53-40fa-90d8-ac0235021e5d",
+                          "title": "Dolor voluptatem soluta corrupti.",
+                          "description": "Laudantium accusamus nemo. Et voluptas aperiam. Sunt aut dolorem.",
+                          "value_type": "number",
+                          "default_value": "0.38464356320967674",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "c0bea172-b587-4146-a91d-b3b624970be4",
+                          "ref_id": "foo_value_abf192f6-37b1-4484-a7f7-77dda2adea8a",
+                          "title": "Dolore aut voluptate nostrum.",
+                          "description": "Rem facilis accusantium. Ut id ea. Dolor autem libero.",
+                          "value_type": "number",
+                          "default_value": "0.08606213884116831",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "6eb7c4ec-7cc6-4a9d-8e4f-57a3e36cc369",
+                          "ref_id": "foo_value_fde425c5-fe7e-48c6-942f-2779b787be73",
+                          "title": "Dolores suscipit dolor quia.",
+                          "description": "Vero ut aspernatur. Minima nihil unde. Placeat beatae molestiae.",
+                          "value_type": "number",
+                          "default_value": "0.0027940783366476873",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "24c3074f-bf61-49f8-aa41-df044804c250",
+                          "ref_id": "foo_value_6de82a59-d432-4a29-9f16-d3b0578e020f",
+                          "title": "Eius ut perferendis possimus.",
+                          "description": "Totam aspernatur aliquam. Eius sit alias. Sit et illum.",
+                          "value_type": "number",
+                          "default_value": "0.17621899436346",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "119434c7-29cb-4273-ba02-236cf2c1d822",
+                          "ref_id": "foo_value_88d1450d-da50-455c-a65f-114fc23909d9",
+                          "title": "Eos soluta sed quibusdam.",
+                          "description": "Aliquid ab quisquam. Libero porro nesciunt. Aut est doloribus.",
+                          "value_type": "number",
+                          "default_value": "0.3344595532009389",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "daa2c756-d247-4393-b617-b2c3076161ea",
+                          "ref_id": "foo_value_36d9f243-b9b1-4668-b6ff-bf5a3b88c8c2",
+                          "title": "Esse temporibus sunt similique.",
+                          "description": "Repudiandae qui molestias. Labore est et. Provident rerum vitae.",
+                          "value_type": "number",
+                          "default_value": "0.01589024557990726",
+                          "type": "value_definition"
+                        },
+                        {
+                          "id": "69dcbdb2-0381-426d-8a7c-f9869c0c0fce",
+                          "ref_id": "foo_value_0d067524-baf5-4c05-8731-01a923c3b0d4",
+                          "title": "Et rerum ut autem.",
+                          "description": "Ea veniam non. Adipisci et molestiae. Sint voluptatem repudiandae.",
+                          "value_type": "number",
+                          "default_value": "0.4970261157099378",
+                          "type": "value_definition"
+                        }
+                      ],
+                      "meta": {
+                        "total": 25,
+                        "limit": 10,
+                        "offset": 0,
+                        "sort_by": "title"
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/7d9d7f44-f4c4-49ae-bfca-c3dfc941facf/value_definitions?limit=10&offset=0&sort_by=title",
+                        "last": "/api/compliance/v2/security_guides/7d9d7f44-f4c4-49ae-bfca-c3dfc941facf/value_definitions?limit=10&offset=20&sort_by=title",
+                        "next": "/api/compliance/v2/security_guides/7d9d7f44-f4c4-49ae-bfca-c3dfc941facf/value_definitions?limit=10&offset=10&sort_by=title"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "List of Value Definitions filtered by '(title=Delectus fugit ab aliquam.)'": {
+                    "value": {
+                      "data": [
+                        {
+                          "id": "02680697-816a-4fc7-b727-99aafcab557e",
+                          "ref_id": "foo_value_da2d8528-2213-42ca-a597-6ab46af08ad9",
+                          "title": "Delectus fugit ab aliquam.",
+                          "description": "Consequuntur magni nisi. Libero quaerat ab. Sunt sapiente dolor.",
+                          "value_type": "number",
+                          "default_value": "0.8374982048965653",
+                          "type": "value_definition"
+                        }
+                      ],
+                      "meta": {
+                        "total": 1,
+                        "filter": "(title=\"Delectus fugit ab aliquam.\")",
+                        "limit": 10,
+                        "offset": 0
+                      },
+                      "links": {
+                        "first": "/api/compliance/v2/security_guides/7ac04656-8ecc-4c29-a890-4d3d0e7ba14f/value_definitions?filter=%28title%3D%22Delectus+fugit+ab+aliquam.%22%29&limit=10&offset=0",
+                        "last": "/api/compliance/v2/security_guides/7ac04656-8ecc-4c29-a890-4d3d0e7ba14f/value_definitions?filter=%28title%3D%22Delectus+fugit+ab+aliquam.%22%29&limit=10&offset=0"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "meta": {
+                      "$ref": "#/components/schemas/metadata"
+                    },
+                    "links": {
+                      "$ref": "#/components/schemas/links"
+                    },
+                    "data": {
+                      "type": "array",
+                      "items": {
+                        "properties": {
+                          "schema": {
+                            "$ref": "#/components/schemas/value_definition"
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Returns with Unprocessable Content",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when sorting by incorrect parameter": {
+                    "value": {
+                      "errors": [
+                        "Result cannot be sorted by the 'description' column."
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  },
+                  "Description of an error when requesting higher limit than supported": {
+                    "value": {
+                      "errors": [
+                        "Invalid parameter: limit must be less than or equal to 100"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/security_guides/{security_guide_id}/value_definitions/{value_definition_id}": {
+      "get": {
+        "summary": "Request a Value Definition",
+        "parameters": [
+          {
+            "name": "X-RH-IDENTITY",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "description": "For internal use only"
+          },
+          {
+            "name": "security_guide_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "value_definition_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "tags": [
+          "Content"
+        ],
+        "description": "Returns a Value Definition",
+        "operationId": "ValueDefinition",
+        "responses": {
+          "200": {
+            "description": "Returns a Value Definition",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Returns a Value Definition": {
+                    "value": {
+                      "data": {
+                        "id": "258be45f-1fa2-4ec8-b581-bea56c9a0a05",
+                        "ref_id": "foo_value_437f8557-a4ea-4062-bbe7-7ba74d53d74e",
+                        "title": "Ipsam et aut dignissimos.",
+                        "description": "Enim minima dignissimos. Quia non unde. Et laborum expedita.",
+                        "value_type": "number",
+                        "default_value": "0.9570867166087534",
+                        "type": "value_definition"
+                      }
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "data": {
+                      "type": "object",
+                      "properties": {
+                        "schema": {
+                          "$ref": "#/components/schemas/value_definition"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Returns with Not Found",
+            "content": {
+              "application/vnd.api+json": {
+                "examples": {
+                  "Description of an error when requesting a non-existing Value Definition": {
+                    "value": {
+                      "errors": [
+                        "V2::ValueDefinition not found with ID 6ee3532a-ed3b-4113-b5b0-2a2da32e4338"
+                      ]
+                    },
+                    "summary": "",
+                    "description": ""
+                  }
+                },
+                "schema": {
+                  "$ref": "#/components/schemas/errors"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "errors": {
+        "type": "object",
+        "required": [
+          "errors"
+        ],
+        "properties": {
+          "errors": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "examples": [
+                "V2::SecurityGuide not found with ID a4708198-9d00-4035-bf57-1e7aaad217c5"
+              ]
+            }
+          }
+        }
+      },
+      "id": {
+        "type": "string",
+        "format": "uuid",
+        "readOnly": true
+      },
+      "links": {
+        "type": "object",
+        "properties": {
+          "first": {
+            "type": "string",
+            "format": "uri",
+            "readOnly": true,
+            "description": "Link to first page"
+          },
+          "last": {
+            "type": "string",
+            "format": "uri",
+            "readOnly": true,
+            "description": "Link to last page"
+          },
+          "previous": {
+            "type": "string",
+            "format": "uri",
+            "readOnly": true,
+            "description": "Link to previous page"
+          },
+          "next": {
+            "type": "string",
+            "format": "uri",
+            "readOnly": true,
+            "description": "Link to next page"
+          }
+        }
+      },
+      "metadata": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "number",
+            "examples": [
+              1,
+              42,
+              770
+            ],
+            "readOnly": true,
+            "description": "Total number of items"
+          },
+          "limit": {
+            "type": "number",
+            "maximum": 100,
+            "minimum": 1,
+            "default": 10,
+            "examples": [
+              10,
+              100
+            ],
+            "readOnly": true,
+            "description": "Number of items returned per page"
+          },
+          "offset": {
+            "type": "number",
+            "minimum": 0,
+            "default": 0,
+            "examples": [
+              15,
+              90
+            ],
+            "readOnly": true,
+            "description": "Offset of the first item of paginated response"
+          },
+          "sort_by": {
+            "type": "string",
+            "examples": [
+              "version:asc"
+            ],
+            "description": "Attribute and direction the items are sorted by"
+          },
+          "filter": {
+            "type": "string",
+            "default": "",
+            "examples": [
+              "title='Standard System Security Profile for Fedora'"
+            ],
+            "description": "Query string used to filter items by their attributes"
+          }
+        }
+      },
+      "policy": {
+        "type": "object",
+        "required": [
+          "compliance_threshold",
+          "profile_id"
+        ],
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "policy"
+            ],
+            "readOnly": true
+          },
+          "title": {
+            "type": "string",
+            "examples": [
+              "CIS Red Hat Enterprise Linux 7 Benchmark"
+            ],
+            "description": "Short title of the Policy"
+          },
+          "description": {
+            "type": "string",
+            "examples": [
+              "This profile defines a baseline that aligns to the Center for Internet Security®Red Hat Enterprise Linux 7 Benchmark™, v2.2.0, released 12-27-2017."
+            ],
+            "description": "Longer description of the Policy"
+          },
+          "business_objective": {
+            "type": "string",
+            "examples": [
+              "Guide to the Secure Configuration of Red Hat Enterprise Linux 7"
+            ],
+            "description": "The Business Objective associated to the Policy"
+          },
+          "compliance_threshold": {
+            "type": "number",
+            "examples": [
+              90
+            ],
+            "maximum": 100,
+            "minimum": 0,
+            "description": "The percentage above which the Policy meets compliance requirements"
+          },
+          "profile_id": {
+            "type": "string",
+            "format": "uuid",
+            "writeOnly": true,
+            "examples": [
+              "9c4bccad-eb1f-473f-bd3d-2de6e125f725"
+            ],
+            "description": "Identifier of the underlying Profile"
+          },
+          "os_major_version": {
+            "type": "number",
+            "minimum": 6,
+            "examples": [
+              7
+            ],
+            "description": "Major version of the Operating System that the Policy covers",
+            "readOnly": true
+          },
+          "ref_id": {
+            "type": "string",
+            "examples": [
+              "xccdf_org.ssgproject.content_profile_pci-dss"
+            ],
+            "description": "Identificator of the Profile",
+            "readOnly": true
+          },
+          "profile_title": {
+            "type": "string",
+            "examples": [
+              "CIS Red Hat Enterprise Linux 7 Benchmark"
+            ],
+            "description": "Title of the associated Policy",
+            "readOnly": true
+          },
+          "total_system_count": {
+            "type": "number",
+            "minium": 0,
+            "examples": [
+              3
+            ],
+            "description": "The number of Systems assigned to this Policy",
+            "readOnly": true
+          }
+        }
+      },
+      "policy_update": {
+        "type": "object",
+        "properties": {
+          "description": {
+            "type": "string",
+            "examples": [
+              "This profile defines a baseline that aligns to the Center for Internet Security®Red Hat Enterprise Linux 7 Benchmark™, v2.2.0, released 12-27-2017."
+            ],
+            "description": "Longer description of the Policy"
+          },
+          "business_objective": {
+            "type": "string",
+            "examples": [
+              "Guide to the Secure Configuration of Red Hat Enterprise Linux 7"
+            ],
+            "description": "The Business Objective associated to the Policy"
+          },
+          "compliance_threshold": {
+            "type": "number",
+            "examples": [
+              90
+            ],
+            "maximum": 100,
+            "minimum": 0,
+            "description": "The percentage above which the Policy meets compliance requirements"
+          }
+        }
+      },
+      "profile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "profile"
+            ]
+          },
+          "ref_id": {
+            "type": "string",
+            "examples": [
+              "xccdf_org.ssgproject.content_profile_pci-dss"
+            ],
+            "readOnly": true,
+            "description": "Identificator of the Profile"
+          },
+          "title": {
+            "type": "string",
+            "examples": [
+              "CIS Red Hat Enterprise Linux 7 Benchmark"
+            ],
+            "readOnly": true,
+            "description": "Short title of the Profile"
+          },
+          "description": {
+            "type": "string",
+            "examples": [
+              "This profile defines a baseline that aligns to the Center for Internet Security®Red Hat Enterprise Linux 7 Benchmark™, v2.2.0, released 12-27-2017."
+            ],
+            "readOnly": true,
+            "description": "Longer description of the Profile"
+          },
+          "value_overrides": {
+            "type": "object",
+            "readOnly": true,
+            "description": "Pair of keys and values for Value Definition customizations"
+          }
+        }
+      },
+      "report": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "report"
+            ],
+            "readOnly": true
+          },
+          "title": {
+            "type": "string",
+            "examples": [
+              "CIS Red Hat Enterprise Linux 7 Benchmark"
+            ],
+            "description": "Short title of the Report",
+            "readOnly": true
+          },
+          "business_objective": {
+            "type": "string",
+            "examples": [
+              "Guide to the Secure Configuration of Red Hat Enterprise Linux 7"
+            ],
+            "description": "The Business Objective associated to the Policy",
+            "readOnly": true
+          },
+          "compliance_threshold": {
+            "type": "number",
+            "examples": [
+              90
+            ],
+            "maximum": 100,
+            "minimum": 0,
+            "description": "The percentage above which the Policy meets compliance requirements",
+            "readOnly": true
+          },
+          "os_major_version": {
+            "type": "number",
+            "minimum": 6,
+            "examples": [
+              7
+            ],
+            "description": "Major version of the Operating System that the Report covers",
+            "readOnly": true
+          },
+          "ref_id": {
+            "type": "string",
+            "examples": [
+              "xccdf_org.ssgproject.content_profile_pci-dss"
+            ],
+            "description": "Identificator of the Profile",
+            "readOnly": true
+          },
+          "profile_title": {
+            "type": "string",
+            "examples": [
+              "CIS Red Hat Enterprise Linux 7 Benchmark"
+            ],
+            "description": "Title of the associated Profile",
+            "readOnly": true
+          },
+          "percent_compliant": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100,
+            "examples": [
+              68
+            ],
+            "description": "Describes percentage of compliant systems",
+            "readOnly": true
+          },
+          "assigned_system_count": {
+            "type": "number",
+            "minium": 1,
+            "examples": [
+              42
+            ],
+            "description": "The number of Systems assigned to this Report. Not visible under the Systems endpoint.",
+            "readOnly": true
+          },
+          "compliant_system_count": {
+            "type": "number",
+            "minium": 0,
+            "examples": [
+              21
+            ],
+            "description": "The number of compliant Systems in this Report. Inconsistent under the Systems endpoint.",
+            "readOnly": true
+          },
+          "all_systems_exposed": {
+            "type": "boolean",
+            "description": "Informs if the user has access to all the Systems under the Report. \\\n                            Inconsistent under the Systems endpoint.",
+            "examples": [
+              false
+            ],
+            "readOnly": true
+          },
+          "unsupported_system_count": {
+            "type": "number",
+            "minium": 0,
+            "examples": [
+              3
+            ],
+            "description": "The number of unsupported Systems in this Report. \\\n                            Inconsistent under the Systems endpoint.",
+            "readOnly": true
+          },
+          "reported_system_count": {
+            "type": "number",
+            "minium": 0,
+            "examples": [
+              3
+            ],
+            "description": "The number of Systems in this Report that have Test Results available. \\\n                            Inconsistent under the Systems endpoint.",
+            "readOnly": true
+          }
+        }
+      },
+      "report_stats": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "examples": [
+                "Remove tftp"
+              ],
+              "readOnly": true,
+              "description": "Short title of the Rule"
+            },
+            "ref_id": {
+              "type": "string",
+              "examples": [
+                "xccdf_org.ssgproject.content_rule_package_tftp_removed"
+              ],
+              "readOnly": true,
+              "description": "Identificator of the Rule"
+            },
+            "identifier": {
+              "type": "object",
+              "readOnly": true,
+              "description": "Identifier of the Rule",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "CCE-80798-2"
+                  ]
+                },
+                "system": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "https://nvd.nist.gov/cce/index.cfm"
+                  ]
+                }
+              },
+              "examples": [
+                "CEE-1234-123"
+              ]
+            },
+            "severity": {
+              "type": "string",
+              "examples": [
+                "low"
+              ],
+              "readOnly": true,
+              "description": "The severity of the Rule"
+            },
+            "count": {
+              "type": "integer",
+              "examples": [
+                102
+              ],
+              "readOnly": true,
+              "description": "Number of failures"
+            }
+          }
+        }
+      },
+      "rule": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "rule"
+            ]
+          },
+          "ref_id": {
+            "type": "string",
+            "examples": [
+              "xccdf_org.ssgproject.content_rule_package_tftp_removed"
+            ],
+            "readOnly": true,
+            "description": "Identificator of the Rule"
+          },
+          "title": {
+            "type": "string",
+            "examples": [
+              "Remove tftp"
+            ],
+            "readOnly": true,
+            "description": "Short title of the Rule"
+          },
+          "rationale": {
+            "type": "string",
+            "examples": [
+              "It is recommended that TFTP be remvoed, unless there is a specific need for TFTP (such as a boot server). In that case, use extreme caution when configuring the services."
+            ],
+            "readOnly": true,
+            "description": "Rationale of the Rule"
+          },
+          "description": {
+            "type": "string",
+            "examples": [
+              "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot files between machines. TFTP does not support authentication and can be easily hacked. The package tftp is a client program that allows for connections to a tftp server."
+            ],
+            "readOnly": true,
+            "description": "Longer description of the Rule"
+          },
+          "precedence": {
+            "type": "integer",
+            "examples": [
+              3
+            ],
+            "readOnly": true,
+            "description": "The original sorting precedence of the Rule in the Security Guide"
+          },
+          "severity": {
+            "type": "string",
+            "examples": [
+              "low"
+            ],
+            "readOnly": true,
+            "description": "The severity of the Rule"
+          },
+          "identifier": {
+            "type": "object",
+            "readOnly": true,
+            "description": "Identifier of the Rule",
+            "properties": {
+              "label": {
+                "type": "string",
+                "readOnly": true,
+                "examples": [
+                  "CCE-80798-2"
+                ]
+              },
+              "system": {
+                "type": "string",
+                "readOnly": true,
+                "examples": [
+                  "https://nvd.nist.gov/cce/index.cfm"
+                ]
+              }
+            },
+            "examples": [
+              "CEE-1234-123"
+            ]
+          },
+          "references": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "readOnly": true,
+              "description": "List of Tags assigned to the System",
+              "properties": {
+                "label": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "APO01.06"
+                  ]
+                },
+                "href": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "https://www.isaca.org/resources/cobit"
+                  ]
+                }
+              }
+            },
+            "readOnly": true,
+            "description": "Array of the Rule References"
+          },
+          "remediation_available": {
+            "type": "boolean",
+            "examples": [
+              true,
+              false
+            ],
+            "readOnly": true,
+            "description": "Whether or not a remediation is available for the given rule."
+          },
+          "remediation_issue_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "ssg:rhel6|rht-ccp|xccdf_org.ssgproject.content_rule_sshd_disable_rhosts"
+            ],
+            "readOnly": true,
+            "description": "The idenfitier of the remediation associated to this rule, only available under profiles."
+          }
+        }
+      },
+      "rule_group": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "rule_group"
+            ]
+          },
+          "ref_id": {
+            "type": "string",
+            "examples": [
+              "xccdf_org.ssgproject.content_group_locking_out_password_attempts"
+            ],
+            "readOnly": true,
+            "description": "Identificator of the Rule Group"
+          },
+          "title": {
+            "type": "string",
+            "examples": [
+              "Set Lockouts for Failed Password Attempt"
+            ],
+            "readOnly": true,
+            "description": "Short title of the Rule Group"
+          },
+          "rationale": {
+            "type": "string",
+            "examples": [
+              "By limiting the number of failed logon attempts, the risk of unauthorized system access via user password guessing, otherwise known as brute-forcing, is reduced. Limits are imposed by locking the account."
+            ],
+            "readOnly": true,
+            "description": "Rationale of the Rule Group"
+          },
+          "description": {
+            "type": "string",
+            "examples": [
+              "The pam_faillock PAM module provides the capability to lock out user accounts after a number of failed login attempts. Its documentation is available in /usr/share/doc/pam-VERSION/txts/README.pam_faillock."
+            ],
+            "readOnly": true,
+            "description": "Longer description of the Rule Group"
+          },
+          "precedence": {
+            "type": "integer",
+            "examples": [
+              3
+            ],
+            "readOnly": true,
+            "description": "The original sorting precedence of the Rule Group in the Security Guide"
+          }
+        }
+      },
+      "rule_result": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "rule"
+            ]
+          },
+          "result": {
+            "type": "string",
+            "enum": [
+              "pass",
+              "fail",
+              "error",
+              "unknown",
+              "fixed",
+              "notapplicable",
+              "notchecked",
+              "informational",
+              "notselected"
+            ],
+            "readOnly": true,
+            "description": "Status of the Rule Result"
+          },
+          "rule_id": {
+            "type": "string",
+            "format": "uuid",
+            "examples": [
+              "ac0475d7-043c-439b-abef-606f02531e10"
+            ],
+            "readOnly": true,
+            "description": "UUID of the affected Rule"
+          },
+          "system_id": {
+            "type": "string",
+            "format": "uuid",
+            "examples": [
+              "e6ba5c79-48af-4899-bb1d-964116b58c7a"
+            ],
+            "readOnly": true,
+            "description": "UUID of the affected System"
+          },
+          "ref_id": {
+            "type": "string",
+            "examples": [
+              "xccdf_org.ssgproject.content_rule_package_tftp_removed"
+            ],
+            "readOnly": true,
+            "description": "Identificator of the Rule"
+          },
+          "title": {
+            "type": "string",
+            "examples": [
+              "Remove tftp"
+            ],
+            "readOnly": true,
+            "description": "Short title of the Rule"
+          },
+          "rationale": {
+            "type": "string",
+            "examples": [
+              "It is recommended that TFTP be remvoed, unless there is a specific need for TFTP (such as a boot server). In that case, use extreme caution when configuring the services."
+            ],
+            "readOnly": true,
+            "description": "Rationale of the Rule"
+          },
+          "description": {
+            "type": "string",
+            "examples": [
+              "Trivial File Transfer Protocol (TFTP) is a simple file transfer protocol, typically used to automatically transfer configuration or boot files between machines. TFTP does not support authentication and can be easily hacked. The package tftp is a client program that allows for connections to a tftp server."
+            ],
+            "readOnly": true,
+            "description": "Longer description of the Rule"
+          },
+          "precedence": {
+            "type": "integer",
+            "examples": [
+              3
+            ],
+            "readOnly": true,
+            "description": "The original sorting precedence of the Rule in the Security Guide"
+          },
+          "severity": {
+            "type": "string",
+            "examples": [
+              "low"
+            ],
+            "readOnly": true,
+            "description": "The severity of the Rule"
+          },
+          "remediation_issue_id": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "examples": [
+              "ssg:rhel6|rht-ccp|xccdf_org.ssgproject.content_rule_sshd_disable_rhosts"
+            ],
+            "readOnly": true,
+            "description": "The idenfitier of the remediation associated to this rule, only available under profiles."
+          }
+        }
+      },
+      "rule_tree": {
+        "type": "array",
+        "items": {
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/id"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "rule_group"
+                  ]
+                },
+                "children": {
+                  "$ref": "#/components/schemas/rule_tree"
+                }
+              }
+            },
+            {
+              "type": "object",
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/id"
+                },
+                "type": {
+                  "type": "string",
+                  "enum": [
+                    "rule"
+                  ]
+                }
+              }
+            }
+          ]
+        }
+      },
+      "security_guide": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "security_guide"
+            ]
+          },
+          "ref_id": {
+            "type": "string",
+            "examples": [
+              "xccdf_org.ssgproject.content_benchmark_RHEL-7"
+            ],
+            "readOnly": true,
+            "description": "Identificator of the Security Guide"
+          },
+          "title": {
+            "type": "string",
+            "examples": [
+              "Guide to the Secure Configuration of Red Hat Enterprise Linux 7"
+            ],
+            "readOnly": true,
+            "description": "Short title of the Security Guide"
+          },
+          "version": {
+            "type": "string",
+            "examples": [
+              "0.1.46"
+            ],
+            "readOnly": true,
+            "description": "Version of the Security Guide"
+          },
+          "description": {
+            "type": "string",
+            "examples": [
+              "This guide presents a catalog of security-relevant configuration settings for Red Hat Enterprise Linux 7."
+            ],
+            "readOnly": true,
+            "description": "Longer description of the Security Guide"
+          },
+          "os_major_version": {
+            "type": "number",
+            "minimum": 6,
+            "examples": [
+              7
+            ],
+            "readOnly": true,
+            "description": "Major version of the Operating System that the Security Guide covers"
+          }
+        }
+      },
+      "supported_profile": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "supported_profile"
+            ]
+          },
+          "ref_id": {
+            "type": "string",
+            "examples": [
+              "xccdf_org.ssgproject.content_profile_cis"
+            ],
+            "readOnly": true,
+            "description": "Identificator of the latest supported Profile"
+          },
+          "title": {
+            "type": "string",
+            "examples": [
+              "CIS Red Hat Enterprise Linux 7 Benchmark"
+            ],
+            "readOnly": true,
+            "description": "Short title of the Profile"
+          },
+          "security_guide_id": {
+            "type": "string",
+            "format": "uuid",
+            "examples": [
+              "e6ba5c79-48af-4899-bb1d-964116b58c7a"
+            ],
+            "readOnly": true,
+            "description": "UUID of the latest Security Guide supporting this Profile"
+          },
+          "security_guide_version": {
+            "type": "string",
+            "examples": [
+              "0.1.72"
+            ],
+            "readOnly": true,
+            "description": "Version of the latest Security Guide supporting this Profile"
+          },
+          "os_major_version": {
+            "type": "number",
+            "examples": [
+              7
+            ],
+            "readOnly": true,
+            "description": "Major version of the Operating System that the Profile covers"
+          },
+          "os_minor_versions": {
+            "type": "array",
+            "items": {
+              "type": "number",
+              "examples": [
+                1
+              ]
+            },
+            "readOnly": true,
+            "description": "List of the supported Operating System minor versions that the Profile covers"
+          }
+        }
+      },
+      "system": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "system"
+            ],
+            "readOnly": true
+          },
+          "display_name": {
+            "type": "string",
+            "readOnly": true,
+            "examples": [
+              "localhost"
+            ],
+            "description": "Display Name of the System"
+          },
+          "groups": {
+            "type": "array",
+            "readOnly": true,
+            "items": {
+              "type": "object",
+              "description": "List of Inventory Groups the System belongs to",
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/id"
+                },
+                "name": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "production"
+                  ]
+                }
+              }
+            }
+          },
+          "culled_timestamp": {
+            "type": "string",
+            "readOnly": true,
+            "examples": [
+              "2020-06-04T19:31:55Z"
+            ]
+          },
+          "stale_timestamp": {
+            "type": "string",
+            "readOnly": true,
+            "examples": [
+              "2020-06-04T19:31:55Z"
+            ]
+          },
+          "stale_warning_timestamp": {
+            "type": "string",
+            "readOnly": true,
+            "examples": [
+              "2020-06-04T19:31:55Z"
+            ]
+          },
+          "updated": {
+            "type": "string",
+            "readOnly": true,
+            "examples": [
+              "2020-06-04T19:31:55Z"
+            ]
+          },
+          "insights_id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "tags": {
+            "type": "array",
+            "readOnly": true,
+            "items": {
+              "type": "object",
+              "readOnly": true,
+              "description": "List of Tags assigned to the System",
+              "properties": {
+                "namespace": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "insights"
+                  ]
+                },
+                "key": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "environment"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "production"
+                  ]
+                }
+              }
+            }
+          },
+          "os_major_version": {
+            "type": "number",
+            "examples": [
+              7
+            ],
+            "readOnly": true,
+            "description": "Major version of the Operating System"
+          },
+          "os_minor_version": {
+            "type": "number",
+            "examples": [
+              1
+            ],
+            "readOnly": true,
+            "description": "Minor version of the Operating System"
+          },
+          "policies": {
+            "type": "array",
+            "readOnly": true,
+            "description": "List of Policies assigned to the System, visible only when not listing Systems under a given Policy",
+            "items": {
+              "type": "object",
+              "readOnly": true,
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/id"
+                },
+                "title": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "CIS Red Hat Enterprise Linux 7 Benchmark"
+                  ],
+                  "description": "Short title of the Policy"
+                }
+              }
+            }
+          }
+        }
+      },
+      "tailoring": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "readOnly": true,
+            "enum": [
+              "tailoring"
+            ]
+          },
+          "profile_id": {
+            "type": "string",
+            "examples": [
+              "cde8be06-74bc-4a2d-9e7f-11d30c5ea588"
+            ],
+            "readOnly": true,
+            "description": "Identificator of the Profile from which the Tailoring was cloned"
+          },
+          "security_guide_id": {
+            "type": "string",
+            "examples": [
+              "8800e1d8-70da-4e62-8cf0-16e8cee784c7"
+            ],
+            "readOnly": true,
+            "description": "Identificator of the Security Guide that contains the parent Profile"
+          },
+          "security_guide_version": {
+            "type": "string",
+            "examples": [
+              "0.1.210"
+            ],
+            "readOnly": true,
+            "description": "Version of the Security Guide that contains the parent Profile"
+          },
+          "os_major_version": {
+            "type": "number",
+            "examples": [
+              7
+            ],
+            "readOnly": true,
+            "description": "Major version of the Operating System that the Tailoring covers"
+          },
+          "os_minor_version": {
+            "type": "number",
+            "examples": [
+              1
+            ],
+            "readOnly": true,
+            "description": "Minor version of the Operating System that the Tailoring covers"
+          },
+          "value_overrides": {
+            "type": "object",
+            "description": "Pair of keys and values for Value Definition customizations",
+            "examples": [
+              {
+                "f663edbd-884f-4ef6-b8e4-37f285dd9354": "foo",
+                "3fc135b2-48c9-40f3-8261-04acdc49f41a": "123",
+                "75798415-7594-47b4-8cdf-a05d1744c864": "false"
+              }
+            ]
+          }
+        }
+      },
+      "tailoring_file": {
+        "title": "Tailoring File",
+        "description": "Defines customizations of rules and variables for a set of profiles",
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "profiles": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "title": "Profile",
+              "description": "A new tailored profile with modifications",
+              "additionalProperties": true,
+              "anyOf": [
+                {
+                  "required": [
+                    "id",
+                    "base_profile_id"
+                  ]
+                },
+                {
+                  "required": [
+                    "id",
+                    "title"
+                  ]
+                }
+              ],
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "description": "New profile identifier, can be same as 'base_profile_id', to 'shadow' the origin"
+                },
+                "base_profile_id": {
+                  "type": "string",
+                  "description": "Original profile identifier, the base for modifications"
+                },
+                "title": {
+                  "type": "string",
+                  "description": "Title for the new profile, inherited from base profile if not given, required if there is no base profile"
+                },
+                "groups": {
+                  "type": "object",
+                  "description": "Group modifications, keys are identifiers",
+                  "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "anyOf": [
+                      {
+                        "required": [
+                          "evaluate"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "evaluate": {
+                        "type": "boolean",
+                        "description": "Includes or excludes a group of rules from evaluation"
+                      }
+                    }
+                  }
+                },
+                "rules": {
+                  "type": "object",
+                  "description": "Rule modifications, keys are identifiers",
+                  "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "anyOf": [
+                      {
+                        "required": [
+                          "evaluate"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "severity"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "role"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "evaluate": {
+                        "type": "boolean",
+                        "description": "Includes or excludes a rule from evaluation"
+                      },
+                      "severity": {
+                        "type": "string",
+                        "enum": [
+                          "unknown",
+                          "info",
+                          "low",
+                          "medium",
+                          "high"
+                        ],
+                        "description": "Overrides severity level of the rule"
+                      },
+                      "role": {
+                        "type": "string",
+                        "enum": [
+                          "full",
+                          "unscored",
+                          "unchecked"
+                        ],
+                        "description": "Overrides role of the rule"
+                      }
+                    }
+                  }
+                },
+                "variables": {
+                  "type": "object",
+                  "description": "Variables modifications, keys are identifiers",
+                  "additionalProperties": {
+                    "type": "object",
+                    "additionalProperties": true,
+                    "oneOf": [
+                      {
+                        "required": [
+                          "value"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "option_id"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "value": {
+                        "type": [
+                          "string",
+                          "integer",
+                          "boolean"
+                        ],
+                        "description": "Directly overrides variable's value with a given value"
+                      },
+                      "option_id": {
+                        "type": "string",
+                        "description": "Overrides variable's value with a predefined value identified by 'option_id'"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "test_result": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "test_result"
+            ],
+            "readOnly": true
+          },
+          "display_name": {
+            "type": "string",
+            "readOnly": true,
+            "examples": [
+              "localhost"
+            ],
+            "description": "Display Name of the System"
+          },
+          "groups": {
+            "type": "array",
+            "readOnly": true,
+            "items": {
+              "type": "object",
+              "description": "List of Inventory Groups the System belongs to",
+              "properties": {
+                "id": {
+                  "$ref": "#/components/schemas/id"
+                },
+                "name": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "production"
+                  ]
+                }
+              }
+            }
+          },
+          "tags": {
+            "type": "array",
+            "readOnly": true,
+            "items": {
+              "type": "object",
+              "readOnly": true,
+              "description": "List of Tags assigned to the System",
+              "properties": {
+                "namespace": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "insights"
+                  ]
+                },
+                "key": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "environment"
+                  ]
+                },
+                "value": {
+                  "type": "string",
+                  "readOnly": true,
+                  "examples": [
+                    "production"
+                  ]
+                }
+              }
+            }
+          },
+          "system_id": {
+            "type": "string",
+            "format": "uuid",
+            "examples": [
+              "e6ba5c79-48af-4899-bb1d-964116b58c7a"
+            ],
+            "readOnly": true,
+            "description": "UUID of the underlying System"
+          },
+          "os_major_version": {
+            "type": "number",
+            "examples": [
+              7
+            ],
+            "readOnly": true,
+            "description": "Major version of the Operating System"
+          },
+          "os_minor_version": {
+            "type": "number",
+            "examples": [
+              1
+            ],
+            "readOnly": true,
+            "description": "Minor version of the Operating System"
+          },
+          "compliant": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "examples": [
+              false,
+              true
+            ],
+            "readOnly": true,
+            "description": "Whether the Test Result is compliant or not within a given Report."
+          },
+          "score": {
+            "type": "number",
+            "examples": [
+              99.99
+            ],
+            "readOnly": true,
+            "description": "Compliance Score of the System within a given Report."
+          },
+          "supported": {
+            "type": [
+              "boolean",
+              "null"
+            ],
+            "examples": [
+              false,
+              true
+            ],
+            "readOnly": true,
+            "description": "Whether the System is supported or not by a Profile within a given Policy."
+          },
+          "failed_rule_count": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "examples": [
+              3
+            ],
+            "readOnly": true,
+            "description": "Number of failed rules in the Test Result"
+          },
+          "last_scanned": {
+            "type": "string",
+            "examples": [
+              "2020-06-04T19:31:55Z"
+            ],
+            "readOnly": true,
+            "description": "The date when the System has been reported a Test Result for the last time."
+          }
+        }
+      },
+      "value_definition": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "$ref": "#/components/schemas/id"
+          },
+          "type": {
+            "type": "string",
+            "enum": [
+              "value_definition"
+            ]
+          },
+          "ref_id": {
+            "type": "string",
+            "examples": [
+              "xccdf_org.ssgproject.content_value_var_rekey_limit_size"
+            ],
+            "readOnly": true,
+            "description": "Identificator of the Value Definition"
+          },
+          "title": {
+            "type": "string",
+            "examples": [
+              "SSH RekeyLimit - size"
+            ],
+            "readOnly": true,
+            "description": "Short title of the Value Definition"
+          },
+          "value_type": {
+            "type": "string",
+            "examples": [
+              "string"
+            ],
+            "readOnly": true,
+            "description": "Type of the Value Definition"
+          },
+          "description": {
+            "type": "string",
+            "examples": [
+              "Specify the size component of the rekey limit."
+            ],
+            "readOnly": true,
+            "description": "Longer description of the Value Definition"
+          },
+          "default_value": {
+            "type": "string",
+            "examples": [
+              "512M"
+            ],
+            "readOnly": true,
+            "description": "Default value of the Value Definition"
+          }
+        }
+      }
+    }
+  }
+}

--- a/api/schema/imageBuilder.yaml
+++ b/api/schema/imageBuilder.yaml
@@ -1575,8 +1575,9 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/User'
-          description:
-            "list of users that a customer can add, also specifying their respective groups and SSH keys"
+          description: |
+            List of users that a customer can add,
+            also specifying their respective groups and SSH keys and/or password
         services:
             $ref: '#/components/schemas/Services'
         hostname:
@@ -1882,7 +1883,10 @@ components:
       type: object
       required:
         - name
-        - ssh_key
+      description: |
+        At least one of password, ssh_key must be set, validator takes care of it.
+        On update empty string can be used to remove password or ssh_key,
+        but at least one of them still must be present.
       properties:
         name:
           type: string
@@ -1890,6 +1894,14 @@ components:
         ssh_key:
           type: string
           example: "ssh-rsa AAAAB3NzaC1"
+        password:
+          type: string
+          format: password
+          example: "$6$G91SvTj7uVp3xhqj$zVa8nqnJTlewniDII5dmvsBJnj3kloL3CXWdPDu9.e677VoRQd5zB6GKwkDvfGLoRR7NTl5nXLnJywk6IPIvS."
+          description: |
+            Plaintext passwords are also supported, they will be hashed and stored using the SHA-512 algorithm.
+            The password is never returned in the response.
+            Empty string can be used to remove the password during update but only with ssh_key set.
     Filesystem:
       type: object
       required:
@@ -1935,6 +1947,23 @@ components:
           description: |
             Optional flag to use rhc to register the system, which also always enables Insights.
     OpenSCAP:
+      oneOf:
+        - $ref: '#/components/schemas/OpenSCAPProfile'
+        - $ref: '#/components/schemas/OpenSCAPCompliance'
+    OpenSCAPCompliance:
+      type: object
+      required:
+        - policy_id
+      properties:
+        policy_id:
+          type: string
+          format: uuid
+          example: 'fef25b3c-b970-46da-a4e1-cc4d855b98dc'
+          description: |
+            Apply a compliance policy which is defined in the Red Hat Insights Compliance
+            service. This policy can include tailorings. This only works for RHEL images, and the
+            policy needs to be available for the specific RHEL version.
+    OpenSCAPProfile:
       type: object
       required:
         - profile_id
@@ -1942,13 +1971,14 @@ components:
         profile_id:
           type: string
           example: "xccdf_org.ssgproject.content_profile_cis"
-          description: "The policy reference ID"
+          description: |
+            Uses the OpenSCAP tooling directly to apply a pre-defined profile without tailorings.
         profile_name:
           type: string
-          description: "The policy type"
+          description: "The profile type"
         profile_description:
           type: string
-          description: "The longform policy description"
+          description: "The longform profile description"
     CustomRepository:
       type: object
       required:

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -150,7 +150,10 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
 
   // =========================TO REMOVE=======================
 
+  // Feature flags
   const isFirstBootEnabled = useFlag('image-builder.firstboot.enabled');
+  const complianceEnabled = useFlag('image-builder.compliance.enabled');
+
   // IMPORTANT: Ensure the wizard starts with a fresh initial state
   useEffect(() => {
     dispatch(initializeWizard());
@@ -354,7 +357,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 <RegistrationStep />
               </WizardStep>,
               <WizardStep
-                name="OpenSCAP"
+                name={complianceEnabled ? 'Compliance' : 'OpenSCAP'}
                 id="step-oscap"
                 key="step-oscap"
                 footer={

--- a/src/Components/CreateImageWizard/steps/FileSystem/FileSystemPartition.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/FileSystemPartition.tsx
@@ -6,7 +6,7 @@ import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
   changeFileSystemConfigurationType,
   selectFileSystemConfigurationType,
-  selectProfile,
+  selectComplianceProfileID,
 } from '../../../../store/wizardSlice';
 
 const FileSystemPartition = () => {
@@ -14,7 +14,7 @@ const FileSystemPartition = () => {
   const fileSystemConfigurationType = useAppSelector(
     selectFileSystemConfigurationType
   );
-  const hasOscapProfile = useAppSelector(selectProfile);
+  const hasOscapProfile = useAppSelector(selectComplianceProfileID);
 
   if (hasOscapProfile) {
     return undefined;

--- a/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
@@ -22,6 +22,7 @@ import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
   DistributionProfileItem,
   Filesystem,
+  OpenScapProfile,
   useGetOscapCustomizationsQuery,
   useGetOscapProfilesQuery,
   useLazyGetOscapCustomizationsQuery,
@@ -279,9 +280,10 @@ const OScapSelectOption = ({
     distribution: release,
     profile: profile_id,
   });
+  const oscapProfile = data?.openscap as OpenScapProfile;
   if (
     filter &&
-    !data?.openscap?.profile_name?.toLowerCase().includes(filter.toLowerCase())
+    !oscapProfile?.profile_name?.toLowerCase().includes(filter.toLowerCase())
   ) {
     return null;
   }
@@ -296,8 +298,8 @@ const OScapSelectOption = ({
   return (
     <SelectOption
       key={profile_id}
-      value={selectObject(profile_id, data?.openscap?.profile_name)}
-      description={data?.openscap?.profile_description}
+      value={selectObject(profile_id, oscapProfile?.profile_name)}
+      description={oscapProfile?.profile_description}
     />
   );
 };

--- a/src/Components/CreateImageWizard/steps/Oscap/OscapProfileInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/OscapProfileInformation.tsx
@@ -124,7 +124,10 @@ export const OscapProfileInformation = ({
               >
                 Reference ID:
               </TextListItem>
-              <TextListItem component={TextListItemVariants.dd}>
+              <TextListItem
+                data-testid="oscap-profile-info-ref-id"
+                component={TextListItemVariants.dd}
+              >
                 {oscapProfile?.profile_id}
               </TextListItem>
               <TextListItem

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -37,9 +37,11 @@ import { useAppSelector } from '../../../../store/hooks';
 import {
   selectBlueprintDescription,
   selectBlueprintName,
+  selectComplianceType,
+  selectCompliancePolicyID,
+  selectComplianceProfileID,
   selectDistribution,
   selectImageTypes,
-  selectProfile,
   selectRegistrationType,
 } from '../../../../store/wizardSlice';
 
@@ -50,7 +52,9 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
   const blueprintDescription = useAppSelector(selectBlueprintDescription);
   const distribution = useAppSelector(selectDistribution);
   const environments = useAppSelector(selectImageTypes);
-  const oscapProfile = useAppSelector(selectProfile);
+  const complianceType = useAppSelector(selectComplianceType);
+  const complianceProfile = useAppSelector(selectComplianceProfileID);
+  const compliancePolicy = useAppSelector(selectCompliancePolicyID);
   const registrationType = useAppSelector(selectRegistrationType);
 
   const [isExpandedImageOutput, setIsExpandedImageOutput] = useState(true);
@@ -60,6 +64,8 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
   const [isExpandedRegistration, setIsExpandedRegistration] = useState(true);
   const [isExpandedImageDetail, setIsExpandedImageDetail] = useState(true);
   const [isExpandedOscapDetail, setIsExpandedOscapDetail] = useState(true);
+  const [isExpandedComplianceDetail, setIsExpandedComplianceDetail] =
+    useState(true);
   const [isExpandableFirstBoot, setIsExpandedFirstBoot] = useState(true);
 
   const onToggleImageOutput = (isExpandedImageOutput: boolean) =>
@@ -76,6 +82,8 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
     setIsExpandedImageDetail(isExpandedImageDetail);
   const onToggleOscapDetails = (isExpandedOscapDetail: boolean) =>
     setIsExpandedOscapDetail(isExpandedOscapDetail);
+  const onToggleComplianceDetails = (isExpandedComplianceDetail: boolean) =>
+    setIsExpandedComplianceDetail(isExpandedComplianceDetail);
   const onToggleFirstBoot = (isExpandableFirstBoot: boolean) =>
     setIsExpandedFirstBoot(isExpandableFirstBoot);
 
@@ -227,7 +235,7 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
           {registrationType.startsWith('register-now') && <RegisterNowList />}
         </ExpandableSection>
       )}
-      {oscapProfile && (
+      {complianceProfile && complianceType === 'openscap' && (
         <ExpandableSection
           toggleContent={composeExpandable(
             'OpenSCAP',
@@ -240,6 +248,23 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
           isExpanded={isExpandedOscapDetail}
           isIndented
           data-testid="oscap-detail-expandable"
+        >
+          <OscapList />
+        </ExpandableSection>
+      )}
+      {compliancePolicy && complianceType === 'compliance' && (
+        <ExpandableSection
+          toggleContent={composeExpandable(
+            'Compliance',
+            'revisit-compliance',
+            'step-oscap'
+          )}
+          onToggle={(_event, isExpandedComplianceDetail) =>
+            onToggleComplianceDetails(isExpandedComplianceDetail)
+          }
+          isExpanded={isExpandedComplianceDetail}
+          isIndented
+          data-testid="compliance-detail-expandable"
         >
           <OscapList />
         </ExpandableSection>

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -738,7 +738,7 @@ export const DetailsList = () => {
 };
 
 export const OscapList = () => {
-  return <OscapProfileInformation />;
+  return <OscapProfileInformation allowChangingCompliancePolicy={true} />;
 };
 
 export const FirstBootList = () => {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,10 @@ export const RELEASE_LIFECYCLE_URL =
   'https://access.redhat.com/support/policy/updates/errata';
 export const AZURE_AUTH_URL =
   'https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow';
+export const COMPLIANCE_PROD_URL =
+  'https://console.redhat.com/insights/compliance/scappolicies';
+export const COMPLIANCE_STAGE_URL =
+  'https://console.stage.redhat.com/insights/compliance/scappolicies';
 export const ACTIVATION_KEYS_PROD_URL =
   'https://console.redhat.com/insights/connector/activation-keys';
 export const ACTIVATION_KEYS_STAGE_URL =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -5,6 +5,7 @@ export const RHSM_API = '/api/rhsm/v2';
 export const EDGE_API = '/api/edge/v1';
 export const CONTENT_SOURCES_API = '/api/content-sources/v1';
 export const PROVISIONING_API = '/api/provisioning/v1';
+export const COMPLIANCE_API = '/api/compliance/v2';
 export const CREATE_BLUEPRINT = `${IMAGE_BUILDER_API}/blueprints`;
 export const EDIT_BLUEPRINT = `${IMAGE_BUILDER_API}/blueprints`;
 

--- a/src/store/complianceApi.ts
+++ b/src/store/complianceApi.ts
@@ -1,0 +1,7 @@
+import { emptyComplianceApi as api } from './emptyComplianceApi';
+const injectedRtkApi = api.injectEndpoints({
+  endpoints: (build) => ({}),
+  overrideExisting: false,
+});
+export { injectedRtkApi as complianceApi };
+export const {} = injectedRtkApi;

--- a/src/store/complianceApi.ts
+++ b/src/store/complianceApi.ts
@@ -1,7 +1,149 @@
-import { emptyComplianceApi as api } from './emptyComplianceApi';
+import { emptyComplianceApi as api } from "./emptyComplianceApi";
 const injectedRtkApi = api.injectEndpoints({
-  endpoints: (build) => ({}),
+  endpoints: (build) => ({
+    policies: build.query<PoliciesApiResponse, PoliciesApiArg>({
+      query: (queryArg) => ({
+        url: `/policies`,
+        headers: { "X-RH-IDENTITY": queryArg["X-RH-IDENTITY"] },
+        params: {
+          limit: queryArg.limit,
+          offset: queryArg.offset,
+          sort_by: queryArg.sortBy,
+          filter: queryArg.filter,
+        },
+      }),
+    }),
+    policy: build.query<PolicyApiResponse, PolicyApiArg>({
+      query: (queryArg) => ({
+        url: `/policies/${queryArg.policyId}`,
+        headers: { "X-RH-IDENTITY": queryArg["X-RH-IDENTITY"] },
+      }),
+    }),
+  }),
   overrideExisting: false,
 });
 export { injectedRtkApi as complianceApi };
-export const {} = injectedRtkApi;
+export type PoliciesApiResponse = /** status 200 Lists Policies */ {
+  meta?: MetadataRead;
+  links?: LinksRead;
+  data?: {
+    schema?: PolicyRead;
+  }[];
+};
+export type PoliciesApiArg = {
+  /** For internal use only */
+  "X-RH-IDENTITY"?: string;
+  /** Number of items to return per page */
+  limit?: number;
+  /** Offset of first item of paginated response */
+  offset?: number;
+  /** Attribute and direction to sort the items by. Represented by an array of fields with an optional direction (`<key>:asc` or `<key>:desc`).<br><br>If no direction is selected, `<key>:asc` is used by default. */
+  sortBy?: (
+    | "title"
+    | "os_major_version"
+    | "total_system_count"
+    | "business_objective"
+    | "compliance_threshold"
+    | "title:asc"
+    | "title:desc"
+    | "os_major_version:asc"
+    | "os_major_version:desc"
+    | "total_system_count:asc"
+    | "total_system_count:desc"
+    | "business_objective:asc"
+    | "business_objective:desc"
+    | "compliance_threshold:asc"
+    | "compliance_threshold:desc"
+  )[];
+  /** Query string to filter items by their attributes. Compliant with <a href="https://github.com/wvanbergen/scoped_search/wiki/Query-language" target="_blank" title="github.com/wvanbergen/scoped_search">scoped_search query language</a>. However, only `=` or `!=` (resp. `<>`) operators are supported.<br><br>Policies are searchable using attributes `title`, `os_major_version`, and `os_minor_version`<br><br>(e.g.: `(field_1=something AND field_2!="something else") OR field_3>40`) */
+  filter?: string;
+};
+export type PolicyApiResponse = /** status 200 Returns a Policy */ {
+  data?: {
+    schema?: PolicyRead;
+  };
+};
+export type PolicyApiArg = {
+  /** For internal use only */
+  "X-RH-IDENTITY"?: string;
+  policyId: string;
+};
+export type Metadata = {
+  /** Attribute and direction the items are sorted by */
+  sort_by?: string;
+  /** Query string used to filter items by their attributes */
+  filter?: string;
+};
+export type MetadataRead = {
+  /** Total number of items */
+  total?: number;
+  /** Number of items returned per page */
+  limit?: number;
+  /** Offset of the first item of paginated response */
+  offset?: number;
+  /** Attribute and direction the items are sorted by */
+  sort_by?: string;
+  /** Query string used to filter items by their attributes */
+  filter?: string;
+};
+export type Links = {};
+export type LinksRead = {
+  /** Link to first page */
+  first?: string;
+  /** Link to last page */
+  last?: string;
+  /** Link to previous page */
+  previous?: string;
+  /** Link to next page */
+  next?: string;
+};
+export type Id = string;
+export type IdRead = string;
+export type Policy = {
+  id?: Id;
+  /** Short title of the Policy */
+  title?: string;
+  /** Longer description of the Policy */
+  description?: string;
+  /** The Business Objective associated to the Policy */
+  business_objective?: string;
+  /** The percentage above which the Policy meets compliance requirements */
+  compliance_threshold: number;
+};
+export type PolicyRead = {
+  id?: IdRead;
+  type?: "policy";
+  /** Short title of the Policy */
+  title?: string;
+  /** Longer description of the Policy */
+  description?: string;
+  /** The Business Objective associated to the Policy */
+  business_objective?: string;
+  /** The percentage above which the Policy meets compliance requirements */
+  compliance_threshold: number;
+  /** Major version of the Operating System that the Policy covers */
+  os_major_version?: number;
+  /** Identificator of the Profile */
+  ref_id?: string;
+  /** Title of the associated Policy */
+  profile_title?: string;
+  /** The number of Systems assigned to this Policy */
+  total_system_count?: number;
+};
+export type PolicyWrite = {
+  id?: Id;
+  /** Short title of the Policy */
+  title?: string;
+  /** Longer description of the Policy */
+  description?: string;
+  /** The Business Objective associated to the Policy */
+  business_objective?: string;
+  /** The percentage above which the Policy meets compliance requirements */
+  compliance_threshold: number;
+  /** Identifier of the underlying Profile */
+  profile_id: string;
+};
+export type Errors = {
+  errors: string[];
+};
+export const { usePoliciesQuery, usePolicyQuery } = injectedRtkApi;

--- a/src/store/emptyComplianceApi.ts
+++ b/src/store/emptyComplianceApi.ts
@@ -1,0 +1,12 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+import { COMPLIANCE_API } from '../constants';
+
+// initialize an empty api service that we'll inject endpoints into later as needed
+export const emptyComplianceApi = createApi({
+  reducerPath: 'complianceApi',
+  baseQuery: fetchBaseQuery({
+    baseUrl: window.location.origin + COMPLIANCE_API,
+  }),
+  endpoints: () => ({}),
+});

--- a/src/store/imageBuilderApi.ts
+++ b/src/store/imageBuilderApi.ts
@@ -579,14 +579,23 @@ export type CustomRepository = {
   ssl_verify?: boolean;
   module_hotfixes?: boolean;
 };
-export type OpenScap = {
-  /** The policy reference ID */
+export type OpenScapProfile = {
+  /** Uses the OpenSCAP tooling directly to apply a pre-defined profile without tailorings.
+   */
   profile_id: string;
-  /** The policy type */
+  /** The profile type */
   profile_name?: string;
-  /** The longform policy description */
+  /** The longform profile description */
   profile_description?: string;
 };
+export type OpenScapCompliance = {
+  /** Apply a compliance policy which is defined in the Red Hat Insights Compliance
+    service. This policy can include tailorings. This only works for RHEL images, and the
+    policy needs to be available for the specific RHEL version.
+     */
+  policy_id: string;
+};
+export type OpenScap = OpenScapProfile | OpenScapCompliance;
 export type Filesystem = {
   mountpoint: string;
   /** size of the filesystem in bytes */
@@ -594,7 +603,12 @@ export type Filesystem = {
 };
 export type User = {
   name: string;
-  ssh_key: string;
+  ssh_key?: string;
+  /** Plaintext passwords are also supported, they will be hashed and stored using the SHA-512 algorithm.
+    The password is never returned in the response.
+    Empty string can be used to remove the password during update but only with ssh_key set.
+     */
+  password?: string;
 };
 export type Services = {
   /** List of services to enable by default */
@@ -677,7 +691,9 @@ export type Customizations = {
   custom_repositories?: CustomRepository[];
   openscap?: OpenScap;
   filesystem?: Filesystem[];
-  /** list of users that a customer can add, also specifying their respective groups and SSH keys */
+  /** List of users that a customer can add,
+    also specifying their respective groups and SSH keys and/or password
+     */
   users?: User[];
   services?: Services;
   /** Configures the hostname */

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import { combineReducers, configureStore } from '@reduxjs/toolkit';
 import promiseMiddleware from 'redux-promise-middleware';
 
 import { blueprintsSlice } from './BlueprintSlice';
+import { complianceApi } from './complianceApi';
 import { contentSourcesApi } from './contentSourcesApi';
 import { edgeApi } from './edgeApi';
 import { imageBuilderApi } from './enhancedImageBuilderApi';
@@ -24,6 +25,7 @@ export const reducer = combineReducers({
   [imageBuilderApi.reducerPath]: imageBuilderApi.reducer,
   [rhsmApi.reducerPath]: rhsmApi.reducer,
   [provisioningApi.reducerPath]: provisioningApi.reducer,
+  [complianceApi.reducerPath]: complianceApi.reducer,
   notifications: notificationsReducer,
   wizard: wizardSlice,
   blueprints: blueprintsSlice.reducer,
@@ -94,7 +96,8 @@ export const middleware = (getDefaultMiddleware: Function) =>
       contentSourcesApi.middleware,
       imageBuilderApi.middleware,
       rhsmApi.middleware,
-      provisioningApi.middleware
+      provisioningApi.middleware,
+      complianceApi.middleware
     );
 
 export const store = configureStore({ reducer, middleware });

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -4,7 +4,6 @@ import { v4 as uuidv4 } from 'uuid';
 import { ApiRepositoryResponseRead } from './contentSourcesApi';
 import {
   CustomRepository,
-  DistributionProfileItem,
   Distributions,
   ImageRequest,
   ImageTypes,
@@ -40,6 +39,8 @@ export type RegistrationType =
   | 'register-now-insights'
   | 'register-now-rhc';
 
+export type ComplianceType = 'openscap' | 'compliance';
+
 export type wizardState = {
   env: {
     serverUrl: string;
@@ -72,8 +73,11 @@ export type wizardState = {
     registrationType: RegistrationType;
     activationKey: ActivationKeys['name'];
   };
-  openScap: {
-    profile: DistributionProfileItem | undefined;
+  compliance: {
+    complianceType: ComplianceType;
+    policyID: string | undefined;
+    profileID: string | undefined;
+    policyTitle: string | undefined;
   };
   fileSystem: {
     mode: FileSystemConfigurationType;
@@ -141,8 +145,11 @@ export const initialState: wizardState = {
     registrationType: 'register-now-rhc',
     activationKey: undefined,
   },
-  openScap: {
-    profile: undefined,
+  compliance: {
+    complianceType: 'openscap',
+    policyID: undefined,
+    profileID: undefined,
+    policyTitle: undefined,
   },
   fileSystem: {
     mode: 'automatic',
@@ -254,8 +261,20 @@ export const selectActivationKey = (state: RootState) => {
   return state.wizard.registration.activationKey;
 };
 
-export const selectProfile = (state: RootState) => {
-  return state.wizard.openScap.profile;
+export const selectComplianceProfileID = (state: RootState) => {
+  return state.wizard.compliance.profileID;
+};
+
+export const selectCompliancePolicyID = (state: RootState) => {
+  return state.wizard.compliance.policyID;
+};
+
+export const selectCompliancePolicyTitle = (state: RootState) => {
+  return state.wizard.compliance.policyTitle;
+};
+
+export const selectComplianceType = (state: RootState) => {
+  return state.wizard.compliance.complianceType;
 };
 
 export const selectFileSystemConfigurationType = (state: RootState) => {
@@ -427,11 +446,20 @@ export const wizardSlice = createSlice({
     ) => {
       state.registration.activationKey = action.payload;
     },
-    changeOscapProfile: (
+    changeComplianceType: (state, action: PayloadAction<ComplianceType>) => {
+      state.compliance.complianceType = action.payload;
+    },
+    changeCompliance: (
       state,
-      action: PayloadAction<DistributionProfileItem | undefined>
+      action: PayloadAction<{
+        policyID: string | undefined;
+        profileID: string | undefined;
+        policyTitle: string | undefined;
+      }>
     ) => {
-      state.openScap.profile = action.payload;
+      state.compliance.policyID = action.payload.policyID;
+      state.compliance.profileID = action.payload.profileID;
+      state.compliance.policyTitle = action.payload.policyTitle;
     },
 
     changeFileSystemConfiguration: (
@@ -668,7 +696,8 @@ export const {
   reinitializeGcp,
   changeRegistrationType,
   changeActivationKey,
-  changeOscapProfile,
+  changeCompliance,
+  changeComplianceType,
   changeFileSystemConfiguration,
   changeFileSystemConfigurationType,
   clearPartitions,

--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -271,7 +271,7 @@ describe('Blueprints', () => {
       user.click(button);
 
       await waitFor(() => {
-        expect(screen.getAllByRole('checkbox')).toHaveLength(8);
+        expect(screen.getAllByRole('checkbox')).toHaveLength(9);
       });
     });
   });

--- a/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
@@ -1,0 +1,162 @@
+import { screen, waitFor, within } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+
+import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
+import { CreateBlueprintRequest } from '../../../../../store/imageBuilderApi';
+import { mockBlueprintIds } from '../../../../fixtures/blueprints';
+import { complianceCreateBlueprintRequest } from '../../../../fixtures/editMode';
+import { clickNext } from '../../wizardTestUtils';
+import {
+  clickRegisterLater,
+  enterBlueprintName,
+  interceptBlueprintRequest,
+  interceptEditBlueprintRequest,
+  openAndDismissSaveAndBuildModal,
+  renderCreateMode,
+  renderEditMode,
+} from '../../wizardTestUtils';
+
+// Overwrite
+vi.mock('@unleash/proxy-client-react', () => ({
+  useUnleashContext: () => vi.fn(),
+  useFlag: vi.fn((flag) => {
+    switch (flag) {
+      case 'image-builder.compliance.enabled':
+        return true;
+      default:
+        return false;
+    }
+  }),
+}));
+
+const goToComplianceStep = async () => {
+  const user = userEvent.setup();
+  const guestImageCheckBox = await screen.findByRole('checkbox', {
+    name: /virtualization guest image checkbox/i,
+  });
+  await waitFor(() => user.click(guestImageCheckBox));
+  await clickNext(); // Registration
+  await clickRegisterLater();
+  await clickNext(); // Compliance
+  await screen.findByRole('heading', { name: /Compliance/ });
+  const button = await screen.findByLabelText('Insights compliance');
+  await waitFor(() => user.click(button));
+  // wait until all policies are loaded
+  await screen.findByText('None');
+};
+
+const goToReviewStep = async () => {
+  await clickNext(); // File system configuration
+  await clickNext(); // Custom repositories
+  await clickNext(); // Additional packages
+  await clickNext(); // Details
+  await enterBlueprintName('Compliance test');
+  await clickNext(); // Review
+};
+
+const selectPolicy = async () => {
+  const user = userEvent.setup();
+
+  const policyMenu = await screen.findByRole('button', {
+    name: /options menu/i,
+  });
+  await waitFor(() => user.click(policyMenu));
+
+  const cisl2 = await screen.findByRole('option', {
+    name: /CIS workstation l2/i,
+  });
+  await waitFor(() => user.click(cisl2));
+
+  const profile_id = await screen.findByTestId('oscap-profile-info-ref-id');
+  expect(profile_id).toHaveTextContent('content_profile_cis_workstation_l2');
+};
+
+const clickRevisitButton = async () => {
+  const user = userEvent.setup();
+  const expandable = await screen.findByTestId('compliance-detail-expandable');
+  const revisitButton = await within(expandable).findByTestId(
+    'revisit-compliance'
+  );
+  await waitFor(() => user.click(revisitButton));
+};
+
+describe('Compliance', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('add a policy', async () => {
+    await renderCreateMode();
+    await goToComplianceStep();
+    await selectPolicy();
+    await goToReviewStep();
+    await openAndDismissSaveAndBuildModal();
+
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+    const expectedRequest: CreateBlueprintRequest = {
+      ...complianceCreateBlueprintRequest,
+      name: 'Compliance test',
+    };
+
+    await waitFor(() => {
+      expect(receivedRequest).toEqual(expectedRequest);
+    });
+  });
+
+  test('revisit step button on Review works', async () => {
+    await renderCreateMode();
+    await goToComplianceStep();
+    await selectPolicy();
+    await goToReviewStep();
+    await screen.findByRole('heading', { name: /Review/ });
+    await clickRevisitButton();
+    await screen.findByRole('heading', { name: /Compliance/ });
+  });
+});
+
+describe('Compliance edit mode', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('edit mode works', async () => {
+    const id = mockBlueprintIds['compliance'];
+    await renderEditMode(id);
+    await screen.findByRole('heading', { name: /Review/ });
+
+    // starts on review step
+    const receivedRequest = await interceptEditBlueprintRequest(
+      `${EDIT_BLUEPRINT}/${id}`
+    );
+    const expectedRequest = complianceCreateBlueprintRequest;
+    expect(receivedRequest).toEqual(expectedRequest);
+  });
+
+  test('fsc and packages get populated on edit', async () => {
+    const user = userEvent.setup();
+    const id = mockBlueprintIds['compliance'];
+    await renderEditMode(id);
+
+    // check that the FSC contains a /tmp partition
+    const fscBtns = await screen.findAllByRole('button', {
+      name: /file system configuration/i,
+    });
+    user.click(fscBtns[0]);
+    await screen.findByRole('heading', { name: /file system configuration/i });
+    await screen.findByText('/tmp');
+    // check that the Packages contain neovim package
+    const packagesNavBtn = await screen.findByRole('button', {
+      name: /additional packages/i,
+    });
+    user.click(packagesNavBtn);
+    await screen.findByRole('heading', {
+      name: /Additional packages/i,
+    });
+    const selectedBtn = await screen.findByRole('button', {
+      name: /Selected/i,
+    });
+    user.click(selectedBtn);
+    await screen.findByText('aide');
+    await screen.findByText('emacs');
+  });
+});

--- a/src/test/fixtures/blueprints.ts
+++ b/src/test/fixtures/blueprints.ts
@@ -35,6 +35,7 @@ export const mockBlueprintIds = {
   packages: 'b3437c4e-f6f8-4270-8d32-323ac60bc929',
   firstBoot: 'd0a8376e-e44e-47b3-845d-30f5199a35b6',
   details: '58991b91-4b98-47e0-b26d-8d908678ddb3',
+  compliance: '21571945-fe23-45e9-8afb-4aa073b8d735',
 };
 
 export const mockBlueprintNames = {
@@ -55,6 +56,7 @@ export const mockBlueprintNames = {
   packages: 'packages',
   firstBoot: 'firstBoot',
   details: 'details',
+  compliance: 'compliance',
 };
 
 export const mockBlueprintDescriptions = {
@@ -75,6 +77,7 @@ export const mockBlueprintDescriptions = {
   packages: '',
   firstBoot: '',
   details: 'This is a test description for the Details step.',
+  compliance: '',
 };
 
 export const mockGetBlueprints: GetBlueprintsApiResponse = {
@@ -274,6 +277,13 @@ export const mockGetBlueprints: GetBlueprintsApiResponse = {
       id: mockBlueprintIds['details'],
       name: mockBlueprintNames['details'],
       description: mockBlueprintDescriptions['details'],
+      version: 1,
+      last_modified_at: '2021-09-08T21:00:00.000Z',
+    },
+    {
+      id: mockBlueprintIds['compliance'],
+      name: mockBlueprintNames['compliance'],
+      description: mockBlueprintDescriptions['compliance'],
       version: 1,
       last_modified_at: '2021-09-08T21:00:00.000Z',
     },

--- a/src/test/fixtures/compliance.ts
+++ b/src/test/fixtures/compliance.ts
@@ -1,0 +1,43 @@
+export const mockPolicies = {
+  data: [
+    {
+      id: '393bca7e-5d2b-4646-a86c-373fc5c50d8b',
+      title: 'CIS workstation l1',
+      description: 'Fancy description',
+      business_objective: null,
+      compliance_threshold: 100,
+      total_system_count: 0,
+      type: 'policy',
+      os_major_version: 8,
+      profile_title:
+        'CIS Red Hat Enterprise Linux 8 Benchmark for Level 1 - Workstation',
+      ref_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
+    },
+    {
+      id: '0ee9a781-b53f-4d9e-91e1-d75aed088c44',
+      title: 'CIS workstation l2',
+      description: 'Fancy description',
+      compliance_threshold: 100,
+      total_system_count: 100,
+      type: 'policy',
+      os_major_version: 8,
+      profile_title:
+        'CIS Red Hat Enterprise Linux 8 Benchmark for Level 2 - Workstation',
+      ref_id: 'xccdf_org.ssgproject.content_profile_cis_workstation_l2',
+    },
+    {
+      id: '88359aa5-ba7e-44d9-9048-02c7918ff58c',
+      title: 'STIG GUI',
+      description: 'Fancy description',
+      compliance_threshold: 100,
+      total_system_count: 30,
+      type: 'policy',
+      os_major_version: 8,
+      profile_title: 'DISA STIG with GUI for Red Hat Enterprise Linux 8',
+      ref_id: 'xccdf_org.ssgproject.content_profile_stig_gui',
+    },
+  ],
+  meta: {
+    total: 3,
+  },
+};

--- a/src/test/fixtures/editMode.ts
+++ b/src/test/fixtures/editMode.ts
@@ -447,6 +447,27 @@ export const detailsBlueprintResponse: BlueprintResponse = {
   description: mockBlueprintDescriptions['details'],
 };
 
+export const complianceCreateBlueprintRequest: CreateBlueprintRequest = {
+  ...baseCreateBlueprintRequest,
+  name: mockBlueprintNames['compliance'],
+  description: mockBlueprintDescriptions['compliance'],
+  customizations: {
+    packages: expectedPackagesCisL2,
+    openscap: {
+      policy_id: '0ee9a781-b53f-4d9e-91e1-d75aed088c44',
+    },
+    services: expectedServicesCisL2,
+    kernel: expectedKernelCisL2,
+    filesystem: expectedFilesystemCisL2,
+  },
+};
+
+export const complianceBlueprintResponse: BlueprintResponse = {
+  ...complianceCreateBlueprintRequest,
+  id: mockBlueprintIds['compliance'],
+  description: mockBlueprintDescriptions['compliance'],
+};
+
 export const getMockBlueprintResponse = (id: string) => {
   switch (id) {
     case mockBlueprintIds['darkChocolate']:
@@ -485,6 +506,8 @@ export const getMockBlueprintResponse = (id: string) => {
       return firstBootBlueprintResponse;
     case mockBlueprintIds['details']:
       return detailsBlueprintResponse;
+    case mockBlueprintIds['compliance']:
+      return complianceBlueprintResponse;
     default:
       return;
   }

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -1,6 +1,7 @@
 import { http, HttpResponse } from 'msw';
 
 import {
+  COMPLIANCE_API,
   CONTENT_SOURCES_API,
   CREATE_BLUEPRINT,
   IMAGE_BUILDER_API,
@@ -19,6 +20,7 @@ import {
   mockEmptyBlueprintsComposes,
   mockGetBlueprints,
 } from '../fixtures/blueprints';
+import { mockPolicies } from '../fixtures/compliance';
 import {
   composesEndpoint,
   mockClones,
@@ -211,5 +213,17 @@ export const handlers = [
   }),
   http.post(`${IMAGE_BUILDER_API}/experimental/recommendations`, () => {
     return HttpResponse.json(mockPkgRecommendations);
+  }),
+  http.get(`${COMPLIANCE_API}/policies`, () => {
+    return HttpResponse.json(mockPolicies);
+  }),
+  http.get(`${COMPLIANCE_API}/policies/:id`, ({ params }) => {
+    const id = params['id'];
+    for (const p of mockPolicies.data) {
+      if (p.id === id) {
+        return HttpResponse.json({ data: p });
+      }
+    }
+    return HttpResponse.error();
   }),
 ];


### PR DESCRIPTION
The current state: 

[webm](https://github.com/user-attachments/assets/6b7d0973-473e-4bc5-9748-67d598999552)



One thing worth discussing is how we want to expose the compliance step. Should we show it alongside the existing openscap step? Should the steps be merged?


Since it would only be in preview, how about we just show both steps for now, knowing that they might conflict?