### PR TITLE
Blueprints: Set `blueprintSearchInput` as undefined with empty string

### DIFF
--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -168,7 +168,11 @@ const BlueprintSearch = ({ blueprintsTotal }: blueprintSearchProps) => {
     };
   }, [debouncedSearch]);
   const onChange = (value: string) => {
-    debouncedSearch(value);
+    if (value.length === 0) {
+      dispatch(setBlueprintSearchInput(undefined));
+    } else {
+      debouncedSearch(value);
+    }
   };
 
   return (

--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -59,7 +59,11 @@ const BlueprintsSidebar = () => {
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
   const blueprintsOffset = useAppSelector(selectOffset);
   const blueprintsLimit = useAppSelector(selectLimit);
-  const { data: blueprintsData, isLoading } = useGetBlueprintsQuery({
+  const {
+    data: blueprintsData,
+    isLoading,
+    isFetching,
+  } = useGetBlueprintsQuery({
     search: blueprintSearchInput,
     limit: blueprintsLimit,
     offset: blueprintsOffset,
@@ -77,7 +81,11 @@ const BlueprintsSidebar = () => {
     );
   }
 
-  if (blueprintsTotal === 0 && blueprintSearchInput === undefined) {
+  if (
+    blueprintsTotal === 0 &&
+    blueprintSearchInput === undefined &&
+    !isFetching
+  ) {
     return (
       <EmptyBlueprintState
         icon={PlusCircleIcon}
@@ -103,7 +111,9 @@ const BlueprintsSidebar = () => {
   return (
     <>
       <Stack hasGutter>
-        {(blueprintsTotal > 0 || blueprintSearchInput !== undefined) && (
+        {(blueprintsTotal > 0 ||
+          blueprintSearchInput !== undefined ||
+          isFetching) && (
           <>
             <StackItem>
               <BlueprintSearch blueprintsTotal={blueprintsTotal} />


### PR DESCRIPTION
This dispatches changes to `blueprintSearchInput` and sets it as `undefined` when the value is an empty string.