### PR TITLE
Wizard: OpenSCAP profile is not a mandatory field

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
@@ -296,7 +296,6 @@ const ProfileSelector = () => {
 
   return (
     <FormGroup
-      isRequired={true}
       data-testid="profiles-form-group"
       label={complianceType === 'openscap' ? <OpenSCAPFGLabel /> : <>Policy</>}
     >


### PR DESCRIPTION
OpenSCAP profile was marked as a mandatory field, this removes the red asterisk as the profile is optional.