### PR TITLE
Wizard: remove no repos selected message

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -466,8 +466,6 @@ export const ContentList = ({
 
   const snapshottingText = useMemo(() => {
     switch (true) {
-      case noRepositoriesSelected:
-        return 'No repositories selected';
       case isLoading:
         return '';
       case useLatest:
@@ -477,7 +475,7 @@ export const ContentList = ({
       default:
         return '';
     }
-  }, [noRepositoriesSelected, isLoading, useLatest, snapshotDate]);
+  }, [isLoading, useLatest, snapshotDate]);
 
   return (
     <>

--- a/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
@@ -169,7 +169,7 @@ describe('repository snapshot tab - ', () => {
 
     const snapshotMethodElement = await getSnapshotMethodElement();
     // Check date was recorded correctly
-    expect(snapshotMethodElement).toHaveTextContent('No repositories selected');
+    expect(snapshotMethodElement).toHaveTextContent('State as of 2024-04-22');
     // Check that the button is clickable (has 1 repo selected)
     await waitFor(() => {
       expect(snapshotMethodElement).toHaveAttribute('aria-disabled', 'true');


### PR DESCRIPTION
This PR removes the "No repositories selected" message shown in the review step ("Content" > "Repository snapshot") instead of the picked date or the use latest option, if no custom repos are selected.

Related Ticket: [🔗HMS-4483](https://issues.redhat.com/browse/HMS-4483)