### PR TITLE
CreateImageWizard/requestMapper: fix enabling firstboot

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -497,7 +497,8 @@ const getServices = (state: RootState): Services | undefined => {
   if (
     services.enabled.length === 0 &&
     services.masked.length === 0 &&
-    services.disabled.length === 0
+    services.disabled.length === 0 &&
+    !selectFirstBootScript(state)
   ) {
     return undefined;
   }

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -494,21 +494,19 @@ const getCustomizations = (state: RootState, orgID: string): Customizations => {
 
 const getServices = (state: RootState): Services | undefined => {
   const services = selectServices(state);
-  if (
-    services.enabled.length === 0 &&
-    services.masked.length === 0 &&
-    services.disabled.length === 0 &&
-    !selectFirstBootScript(state)
-  ) {
-    return undefined;
-  }
-
   let enabledSvcs = services.enabled || [];
   const includeFBSvc: boolean =
     !!selectFirstBootScript(state) &&
     !services.enabled?.includes(FIRST_BOOT_SERVICE);
   if (includeFBSvc) {
     enabledSvcs = [...enabledSvcs, FIRST_BOOT_SERVICE];
+  }
+  if (
+    enabledSvcs.length === 0 &&
+    services.masked.length === 0 &&
+    services.disabled.length === 0
+  ) {
+    return undefined;
   }
 
   return {


### PR DESCRIPTION
when there none of `service.{enabled|masked|disabled}` firstboot also is not enabled (if requested)
this patch fixes this bug