### PR TITLE
vitest/test: Inline `@monaco-editor` and enable "First boot request generated correctly" test

### DIFF
--- a/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { screen, waitFor, within } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 
@@ -16,7 +15,7 @@ import {
 import {
   clickNext,
   clickReviewAndFinish,
-  getNextButton,
+  //getNextButton,
 } from '../../wizardTestUtils';
 import {
   blueprintRequest,
@@ -115,38 +114,38 @@ describe('First Boot step', () => {
   //   expect(await getNextButton()).toBeEnabled();
   // });
 
-  //  describe('validate first boot request ', () => {
-  //    test('should validate first boot request', async () => {
-  //      await renderCreateMode();
-  //      await goToFirstBootStep();
-  //      await openCodeEditor();
-  //      await uploadFile();
-  //      await goToReviewStep();
-  //      // informational modal pops up in the first test only as it's tied
-  //      // to a 'imageBuilder.saveAndBuildModalSeen' variable in localStorage
-  //      await openAndDismissSaveAndBuildModal();
-  //      const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
-  //
-  //      const expectedRequest = {
-  //        ...blueprintRequest,
-  //        customizations: {
-  //          files: firstBootData,
-  //          services: { enabled: [FIRST_BOOT_SERVICE] },
-  //        },
-  //      };
-  //
-  //      await waitFor(() => {
-  //        expect(receivedRequest).toEqual(expectedRequest);
-  //      });
-  //    });
-  //  });
-
   test('revisit step button on Review works', async () => {
     await renderCreateMode();
     await goToFirstBootStep();
     await goToReviewStep();
     await clickRevisitButton();
     await screen.findByRole('heading', { name: /First boot/ });
+  });
+});
+
+describe('First boot request generated correctly', () => {
+  test('with no OpenSCAP profile selected', async () => {
+    await renderCreateMode();
+    await goToFirstBootStep();
+    await openCodeEditor();
+    await uploadFile();
+    await goToReviewStep();
+    // informational modal pops up in the first test only as it's tied
+    // to a 'imageBuilder.saveAndBuildModalSeen' variable in localStorage
+    await openAndDismissSaveAndBuildModal();
+    const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
+
+    const expectedRequest = {
+      ...blueprintRequest,
+      customizations: {
+        files: firstBootData,
+        services: { enabled: [FIRST_BOOT_SERVICE] },
+      },
+    };
+
+    await waitFor(() => {
+      expect(receivedRequest).toEqual(expectedRequest);
+    });
   });
 });
 

--- a/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
@@ -13,9 +13,12 @@ import {
   expectedServicesCisL2,
   oscapCreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
-import { clickNext, clickReviewAndFinish } from '../../wizardTestUtils';
 import {
-  clickRegisterLater,
+  clickNext,
+  clickReviewAndFinish,
+  goToOscapStep,
+} from '../../wizardTestUtils';
+import {
   enterBlueprintName,
   interceptBlueprintRequest,
   interceptEditBlueprintRequest,
@@ -23,17 +26,6 @@ import {
   renderCreateMode,
   renderEditMode,
 } from '../../wizardTestUtils';
-
-const goToOscapStep = async () => {
-  const user = userEvent.setup();
-  const guestImageCheckBox = await screen.findByRole('checkbox', {
-    name: /virtualization guest image checkbox/i,
-  });
-  await waitFor(() => user.click(guestImageCheckBox));
-  await clickNext(); // Registration
-  await clickRegisterLater();
-  await clickNext(); // OpenSCAP
-};
 
 const selectProfile = async () => {
   const user = userEvent.setup();

--- a/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
@@ -107,6 +107,17 @@ export const clickRegisterLater = async () => {
   await waitFor(() => user.click(registrationCheckbox));
 };
 
+export const goToOscapStep = async () => {
+  const user = userEvent.setup();
+  const guestImageCheckBox = await screen.findByRole('checkbox', {
+    name: /virtualization guest image checkbox/i,
+  });
+  await waitFor(() => user.click(guestImageCheckBox));
+  await clickNext(); // Registration
+  await clickRegisterLater();
+  await clickNext(); // OpenSCAP
+};
+
 export const selectCustomRepo = async () => {
   const user = userEvent.setup();
   await clickBack();

--- a/src/test/fixtures/oscap.ts
+++ b/src/test/fixtures/oscap.ts
@@ -7,6 +7,7 @@ export const distributionOscapProfiles = (): GetOscapProfilesApiResponse => {
   return [
     'xccdf_org.ssgproject.content_profile_cis_workstation_l1',
     'xccdf_org.ssgproject.content_profile_cis_workstation_l2',
+    'xccdf_org.ssgproject.content_profile_standard',
     'xccdf_org.ssgproject.content_profile_stig_gui',
   ];
 };
@@ -57,6 +58,19 @@ export const oscapCustomizations = (
       },
       services: {
         masked: ['nfs-server', 'neovim-service'],
+        enabled: ['crond', 'emacs-service'],
+      },
+    };
+  }
+  if (profile === 'xccdf_org.ssgproject.content_profile_standard') {
+    return {
+      openscap: {
+        profile_id: 'content_profile_standard',
+        profile_name: 'Simplified profile',
+        profile_description:
+          'This is a mocked profile description. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean posuere velit enim, tincidunt porttitor nisl elementum eu.',
+      },
+      services: {
         enabled: ['crond', 'emacs-service'],
       },
     };

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ const config = {
     },
     server: {
       deps: {
-        inline: ['vitest-canvas-mock', '@patternfly'],
+        inline: ['vitest-canvas-mock', '@patternfly', '@monaco-editor'],
       },
     },
     testTimeout: 10000,


### PR DESCRIPTION
This inlines a dependency that was causing problem in test runs and re-enables a test checking request generated when adding first boot script to the blueprint.