### PR TITLE
Wizard: Fix repos toggle height

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -1309,6 +1309,7 @@ const Packages = () => {
                           aria-label="About included repositories"
                           component="span"
                           className="pf-u-p-0"
+                          size="sm"
                           isInline
                         >
                           <HelpIcon />
@@ -1339,6 +1340,7 @@ const Packages = () => {
                           aria-label="About other repositories"
                           component="span"
                           className="pf-u-p-0"
+                          size="sm"
                           isInline
                         >
                           <HelpIcon />


### PR DESCRIPTION
The repos toggle height was slightly bigger than the Available/Selected toggle. This was caused by the popover button. Changes its size to small to fix the issue.

![image](https://github.com/user-attachments/assets/e38d1159-794e-4a9a-a664-e6c49446251c)