### PR TITLE
Wizard: Default to Included repos in package search

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -808,10 +808,12 @@ const Packages = () => {
     selection: string
   ) => {
     setSearchTerm(selection);
+    setToggleSourceRepos(RepoToggle.INCLUDED);
   };
 
   const handleClear = async () => {
     setSearchTerm('');
+    setToggleSourceRepos(RepoToggle.INCLUDED);
   };
 
   const handleSelect = (


### PR DESCRIPTION
Previously when you searched for package from repositories recommendations and switched to "Other repos", new search left you in Other repos and didn't show results even if they were found in "Included". Since we search for recommendations only when no matches were found in distro and custom repos, the results will be always empty.

This solves the problem by defaulting to "Included repos" toggle with every new search, limiting clicks required from the user.

How to reproduce previous behaviour:
1. search for 'gnuplot' packages
2. no results should be found, switch to "Other repos"
3. search for a distro/custom repo package like "vim"

Previous behaviour - the "Other repos" toggle is still selected, showing no results. When switching to "Included repos" manually, the results can be found there.

New behaviour - "Included repos" gets automatically selected, showing results for packages found in distro and custom repos.