### PR TITLE
Wizard: Fix VMware select and unselect

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
@@ -216,6 +216,7 @@ const TargetEnvironment = () => {
                       name="vsphere-radio"
                       aria-label="VMware vSphere radio button OVA"
                       id="vsphere-radio-ova"
+                      data-testid="radio-vsphere-ova"
                       label={
                         <>
                           Open virtualization format (.ova)
@@ -264,6 +265,7 @@ const TargetEnvironment = () => {
                     name="vsphere-radio"
                     aria-label="VMware vSphere radio button VMDK"
                     id="vsphere-radio-vmdk"
+                    data-testid="radio-vsphere-vmdk"
                     label={
                       <>
                         Virtual disk (.vmdk)

--- a/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 
 import {
   Button,
@@ -44,7 +44,8 @@ const TargetEnvironment = () => {
   // TODO: Handle isFetching state (add skeletons)
   // TODO: Handle isError state (very unlikely...)
 
-  const [hasVSphere, setHasVSphere] = useState(false);
+  const hasVsphere =
+    environments.includes('vsphere') || environments.includes('vsphere-ova');
 
   const dispatch = useAppDispatch();
   const prefetchSources = provisioningApi.usePrefetch('getSourceList');
@@ -191,13 +192,18 @@ const TargetEnvironment = () => {
           >
             <Checkbox
               label="VMware vSphere"
-              isChecked={
-                environments.includes('vsphere') ||
-                environments.includes('vsphere-ova')
-              }
+              isChecked={hasVsphere}
               onChange={() => {
-                setHasVSphere(!hasVSphere);
-                handleToggleEnvironment('vsphere-ova');
+                if (!hasVsphere) {
+                  dispatch(addImageType('vsphere-ova'));
+                } else {
+                  if (environments.includes('vsphere')) {
+                    dispatch(removeImageType('vsphere'));
+                  }
+                  if (environments.includes('vsphere-ova')) {
+                    dispatch(removeImageType('vsphere-ova'));
+                  }
+                }
               }}
               aria-label="VMware checkbox"
               id="checkbox-vmware"

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -121,6 +121,12 @@ const selectGuestImageTarget = async () => {
   await waitFor(() => user.click(guestImageCheckBox));
 };
 
+const selectVMwareTarget = async () => {
+  const user = userEvent.setup();
+  const vmwareImageCheckBox = await screen.findByTestId('checkbox-vmware');
+  await waitFor(() => user.click(vmwareImageCheckBox));
+};
+
 const goToReviewStep = async () => {
   await clickNext();
   await clickRegisterLater();
@@ -253,6 +259,43 @@ describe('Step Image output', () => {
     await screen.findByText(
       'CentOS Stream builds are intended for the development of future versions of RHEL and are not supported for production workloads or other use cases.'
     );
+  });
+
+  test('VMware checkbox select and unselect works', async () => {
+    await renderCreateMode();
+    await selectVMwareTarget();
+
+    let vmwareCheckbox = await screen.findByTestId('checkbox-vmware');
+    let ovaFileRadio = await screen.findByTestId('radio-vsphere-ova');
+    let vmdkFileRadio = await screen.findByTestId('radio-vsphere-vmdk');
+
+    expect(await screen.findByTestId('checkbox-vmware')).toBeChecked();
+    expect(ovaFileRadio).toBeChecked();
+    expect(vmdkFileRadio).not.toBeChecked();
+
+    // switch to VMDK
+    user.click(vmdkFileRadio);
+
+    // refresh values
+    vmwareCheckbox = await screen.findByTestId('checkbox-vmware');
+    ovaFileRadio = await screen.findByTestId('radio-vsphere-ova');
+    vmdkFileRadio = await screen.findByTestId('radio-vsphere-vmdk');
+
+    expect(vmwareCheckbox).toBeChecked();
+    expect(ovaFileRadio).not.toBeChecked();
+    expect(vmdkFileRadio).toBeChecked();
+
+    // unselect VMware
+    user.click(vmwareCheckbox);
+
+    // refresh values
+    vmwareCheckbox = await screen.findByTestId('checkbox-vmware');
+    ovaFileRadio = await screen.findByTestId('radio-vsphere-ova');
+    vmdkFileRadio = await screen.findByTestId('radio-vsphere-vmdk');
+
+    expect(vmwareCheckbox).not.toBeChecked();
+    expect(ovaFileRadio).not.toBeChecked();
+    expect(vmdkFileRadio).not.toBeChecked();
   });
 
   test('revisit step button on Review works', async () => {


### PR DESCRIPTION
This updates the behaviour of VMware checkbox to make it possible to unselect VMware as a target.

How to reproduce:
1. select VMware vSphere checkbox
2. click on Virtual disk radio
3. try to unselect VMware vSphere checkbox

Previous behaviour - the checkbox can't be unselected New behaviour - the checkbox can be unselected, removing relevant type of VMware target from imageTypes