### PR TITLE
src: Add on prem blueprints import support (HMS-4683)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "react-redux": "9.1.2",
         "react-router-dom": "6.27.0",
         "redux": "5.0.1",
-        "redux-promise-middleware": "6.2.0"
+        "redux-promise-middleware": "6.2.0",
+        "toml": "^3.0.0"
       },
       "devDependencies": {
         "@babel/core": "7.26.0",
@@ -19620,6 +19621,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/toml": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-3.0.0.tgz",
+      "integrity": "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==",
+      "license": "MIT"
     },
     "node_modules/toposort": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "react-redux": "9.1.2",
     "react-router-dom": "6.27.0",
     "redux": "5.0.1",
-    "redux-promise-middleware": "6.2.0"
+    "redux-promise-middleware": "6.2.0",
+    "toml": "3.0.0"
   },
   "devDependencies": {
     "@babel/core": "7.26.0",

--- a/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
+++ b/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
@@ -1,0 +1,155 @@
+import {
+  BlueprintExportResponse,
+  Container,
+  Directory,
+  Distributions,
+  Fdo,
+  File,
+  FirewallCustomization,
+  Ignition,
+  Installer,
+  Kernel,
+  Locale,
+  OpenScap,
+  Services,
+  Timezone,
+} from '../../../store/imageBuilderApi';
+
+export type BlueprintOnPrem = {
+  name: string;
+  description?: string;
+  packages?: PackagesOnPrem[];
+  groups?: GroupsPackagesOnPrem[];
+  distro: Distributions;
+  customizations?: CustomizationsOnPrem;
+  containers?: Container[];
+};
+
+export type PackagesOnPrem = {
+  name: string;
+  version?: string;
+};
+
+export type GroupsPackagesOnPrem = {
+  name: string;
+};
+
+export type FileSystemOnPrem = {
+  mountpoint: string;
+  minsize: number | undefined;
+};
+
+export type CustomRepositoryOnPrem = {
+  id: string;
+  name?: string;
+  filename?: string;
+  baseurls?: string[];
+  mirrorlist?: string;
+  metalink?: string;
+  gpgkey?: string[];
+  check_gpg?: boolean;
+  check_repo_gpg?: boolean;
+  enabled?: boolean;
+  priority?: number;
+  ssl_verify?: boolean;
+  module_hotfixes?: boolean;
+};
+
+export type CustomizationsOnPrem = {
+  directories?: Directory[];
+  files?: File[];
+  repositories?: CustomRepositoryOnPrem[];
+  openscap?: OpenScap;
+  filesystem?: FileSystemOnPrem[];
+  services?: Services;
+  ssh_key?: SshKeyOnPrem[];
+  hostname?: string;
+  kernel?: Kernel;
+  user?: UserOnPrem[];
+  groups?: GroupOnPrem[];
+  timezone?: Timezone;
+  locale?: Locale;
+  firewall?: FirewallCustomization;
+  installation_device?: string;
+  fdo?: Fdo;
+  ignition?: Ignition;
+  partitioning_mode?: 'raw' | 'lvm' | 'auto-lvm';
+  fips?: boolean;
+  installer?: Installer;
+};
+
+export type UserOnPrem = {
+  name: string;
+  key: string;
+};
+
+export type GroupOnPrem = {
+  name: string;
+  gid: number;
+};
+
+export type SshKeyOnPrem = {
+  user: string;
+  key: string;
+};
+
+export const mapOnPremToHosted = (
+  blueprint: BlueprintOnPrem
+): BlueprintExportResponse => {
+  const users = blueprint.customizations?.user?.map((u) => ({
+    name: u.name,
+    ssh_key: u.key,
+  }));
+  const user_keys = blueprint.customizations?.ssh_key?.map((k) => ({
+    name: k.user,
+    ssh_key: k.key,
+  }));
+  const packages =
+    blueprint.packages !== undefined
+      ? blueprint.packages.map((p) => p.name)
+      : undefined;
+  const groups =
+    blueprint.customizations?.groups !== undefined
+      ? blueprint.customizations.groups.map((p) => `@${p.name}`)
+      : undefined;
+  return {
+    name: blueprint.name,
+    description: blueprint.description || '',
+    distribution: blueprint.distro,
+    customizations: {
+      ...blueprint.customizations,
+      containers: blueprint.containers,
+      custom_repositories: blueprint.customizations?.repositories?.map(
+        ({ baseurls, ...fs }) => ({
+          baseurl: baseurls,
+          ...fs,
+        })
+      ),
+      packages:
+        packages !== undefined || groups !== undefined
+          ? [...(packages ? packages : []), ...(groups ? groups : [])]
+          : undefined,
+      users:
+        users !== undefined || user_keys !== undefined
+          ? [...(users ? users : []), ...(user_keys ? user_keys : [])]
+          : undefined,
+      groups: blueprint.customizations?.groups,
+      filesystem: blueprint.customizations?.filesystem?.map(
+        ({ minsize, ...fs }) => ({
+          min_size: minsize,
+          ...fs,
+        })
+      ),
+      fips:
+        blueprint.customizations?.fips !== undefined
+          ? {
+              enabled: blueprint.customizations?.fips,
+            }
+          : undefined,
+    },
+    metadata: {
+      parent_id: null,
+      exported_at: '',
+    },
+  };
+};


### PR DESCRIPTION
This pull request relates to [#4683](https://issues.redhat.com/browse/HMS-4683).
We want to support import on prem blueprints in our import feature. This enables importing toml blueprints that get automatically detected, and parsed.
A lot of fields we need to ignore, a lot of fields from our blueprints are not in the on-prem blueprint structure. This is our first attempt to allow on-prem blueprint, and it will get us more information whether users would use it or not. We also need to add a method to measure the usage of this feature. This is not here yet, and I would like to do it as a follow up, as it can raise discussions, and we do not want to block this feature on it.

We will bring a different solution, so eventually, we will get rid of this mapper. But the other solution that should be more "bulletproof" will take time, in the meantime we can use this one. :)

I know, that on-prem blueprints can also come in json, this will be quite easy to do, we will adjust the UI a bit for that, so that users would be able to import even on-prem json.

Feel free to ask any questions, and find bugs!