### PR TITLE
Wizard: Ensure wizard footer remains visible in repo step

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -76,16 +76,13 @@ div.pf-v5-c-alert.pf-m-inline.pf-m-plain.pf-m-warning {
 }
 
 .pf-v5-c-wizard__main {
-    /* TO DO: This part of the code is responsible for the Wizard footer being fixed
-    at the bottom of the page. Unfortunately there's a new bug that's at least
-    partially caused by this styling: when zooming in or out while in Wizard,
-    the Wizard shrunks it's height to an unusable value.
+    flex: 1 1 auto;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
 
-    Temporarily commenting out this code, until we figure out how the handle
-    this bug.
-    */
-    // flex: 1 1 0
-    
-    // TO DO: Remove after the fix
-    min-height: 800px;
+.pf-v5-c-wizard__footer {
+    position: sticky;
+    bottom: 0;
 }


### PR DESCRIPTION
- Improved the layout of the repository step in the wizard to prevent the "Next" button from being hidden behind a scroll.
- Adjusted the wizard size to ensure a better user experience without needing to scroll in the repository selection step.
- Ensured consistent button positioning across varying screen resolutions.
- Attached is a video demo showcasing how this change resolves it.
- This is my approach to solving the issue, and I'm happy to consider alternative suggestions if anyone has a different idea.

[Screencast from 2024-10-22 11-59-24.webm](https://github.com/user-attachments/assets/c93ce198-bc93-4b7a-8bc4-c87e5f9db26b)
