### PR TITLE
Wizard: fix editing RHEL 9 beta blueprints

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -9,6 +9,7 @@ import {
   FIRST_BOOT_SERVICE_DATA,
   RHEL_8,
   RHEL_9,
+  RHEL_9_BETA,
 } from '../../../constants';
 import { RootState } from '../../../store';
 import {
@@ -132,7 +133,9 @@ const convertFilesystemToPartition = (filesystem: Filesystem): Partition => {
  * @param distribution blueprint distribution
  */
 const getLatestRelease = (distribution: Distributions) => {
-  return distribution.startsWith('rhel-9')
+  return distribution === RHEL_9_BETA
+    ? (RHEL_9_BETA as Distributions)
+    : distribution.startsWith('rhel-9')
     ? RHEL_9
     : distribution.startsWith('rhel-8')
     ? RHEL_8


### PR DESCRIPTION
It would default to RHEL 9 instead of the beta.