### PR TITLE
Wizard: use oscap profiles from major version for beta versions

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
@@ -18,9 +18,11 @@ import { v4 as uuidv4 } from 'uuid';
 
 import OscapProfileInformation from './OscapProfileInformation';
 
+import { RHEL_9_BETA, RHEL_9 } from '../../../../constants';
 import { usePoliciesQuery, PolicyRead } from '../../../../store/complianceApi';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
+  Distributions,
   DistributionProfileItem,
   Filesystem,
   OpenScapProfile,
@@ -82,7 +84,7 @@ const ProfileSelector = () => {
   const policyID = useAppSelector(selectCompliancePolicyID);
   const policyTitle = useAppSelector(selectCompliancePolicyTitle);
   const profileID = useAppSelector(selectComplianceProfileID);
-  const release = useAppSelector(selectDistribution);
+  const release = removeBetaFromRelease(useAppSelector(selectDistribution));
   const majorVersion = release.split('-')[1];
   const hasWslTargetOnly = useHasSpecificTargetOnly('wsl');
   const dispatch = useAppDispatch();
@@ -452,6 +454,17 @@ const ComplianceSelectOption = ({ policy }: ComplianceSelectOptionPropType) => {
       description={descr}
     />
   );
+};
+
+// The beta releases won't have any oscap profiles associated with them,
+// so just use the ones from the major release.
+export const removeBetaFromRelease = (dist: Distributions): Distributions => {
+  switch (dist) {
+    case RHEL_9_BETA:
+      return RHEL_9;
+    default:
+      return dist;
+  }
 };
 
 export const Oscap = () => {

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -11,7 +11,7 @@ import {
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { useFlag } from '@unleash/proxy-client-react';
 
-import { Oscap } from './Oscap';
+import { Oscap, removeBetaFromRelease } from './Oscap';
 
 import {
   COMPLIANCE_AND_VULN_SCANNING_URL,
@@ -47,7 +47,7 @@ const OscapStep = () => {
     {}
   );
   const { isProd } = useGetEnvironment();
-  const release = useAppSelector(selectDistribution);
+  const release = removeBetaFromRelease(useAppSelector(selectDistribution));
   const { data: currentProfileData } = useGetOscapCustomizationsQuery(
     {
       distribution: release,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/9cee36a8-ed93-4dd0-9357-95a1f4a4c18a)
