### PR TITLE
chore: drop unused Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,4 @@
-FISTBOOT_SERVICE := $(shell base64 -w0 < aux/custom-first-boot.service)
 INSTALL_DIR := ~/.local/share/cockpit/image-builder-frontend
-
-help:
-	@cat Makefiles
-
-.PHONY: prep
-prep: src/constants.ts
-
-.PHONY: install
-install:
-	npm install
-
-.PHONY: start
-start: prep
-	npm start
 
 cockpit/all: devel-uninstall devel-install build
 
@@ -30,4 +15,3 @@ devel-uninstall:
 	rm cockpit/public/*.js
 
 .PHONY: cockpit/all devel-install build devel-uninstall
-


### PR DESCRIPTION
Ah I wanted to do a checker but it is now gone, no need for base64 encoding. Nice.

Well, then the Makefile I introduced solely for this purpose can go away. There is `npm` for those who want to build stuff.