### PR TITLE
 Konflux: Add rpms-signature-scan task (HMS-4948) 

### DIFF
--- a/.tekton/image-builder-frontend-pull-request.yaml
+++ b/.tekton/image-builder-frontend-pull-request.yaml
@@ -384,6 +384,23 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+        - name: kind
+          value: task
+        resolver: bundles
     - name: build-image-index
       params:
       - name: IMAGE

--- a/.tekton/image-builder-frontend-push.yaml
+++ b/.tekton/image-builder-frontend-push.yaml
@@ -381,6 +381,23 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+        - name: kind
+          value: task
+        resolver: bundles
     - name: build-image-index
       params:
       - name: IMAGE


### PR DESCRIPTION
Resolves HMS-4948. This task is mandatory as of November 1, 2024.