### PR TITLE
Wizard: Add min size check

### DIFF
--- a/src/Components/CreateImageWizard/utilities/parseSizeUnit.ts
+++ b/src/Components/CreateImageWizard/utilities/parseSizeUnit.ts
@@ -2,7 +2,7 @@ import { UNIT_GIB, UNIT_KIB, UNIT_MIB } from '../../../constants';
 import { Units } from '../steps/FileSystem/FileSystemTable';
 
 export const parseSizeUnit = (bytesize: string) => {
-  let size;
+  let size: number = 10;
   let unit: Units = 'GiB';
 
   if (parseInt(bytesize) % UNIT_GIB === 0) {


### PR DESCRIPTION
Partition's minsize is uint64 in backend, which maps to `any`. Therefore, it is sometimes possible that we let in different types there if we import the blueprint with such value.
This should fix it, let me know what you think. We can also put an empty string as a default.