### PR TITLE
pr_check: Skip unit tests

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -11,6 +11,8 @@ export WORKSPACE=${WORKSPACE:-$APP_ROOT} # if running in jenkins, use the build'
 export APP_ROOT=$(pwd)
 #16 is the default Node version. Change this to override it.
 export NODE_BUILD_VERSION=20
+# skip unit tests on frontend-build
+export SKIP_VERIFY=True
 COMMON_BUILDER=https://raw.githubusercontent.com/RedHatInsights/insights-frontend-builder-common/master
 
 # --------------------------------------------


### PR DESCRIPTION
We can now skip unit tests (running npn verify) in the pr_check to speed up the whole process and reduce flakiness. The unit tests are ran separately in a github action so this is fine.