### PR TITLE
Wizard: add support for other input type in`HookValidatedInput`

### DIFF
--- a/src/Components/CreateImageWizard/ValidatedTextInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedTextInput.tsx
@@ -38,6 +38,7 @@ export const HookValidatedInput = ({
   onChange,
   stepValidation,
   fieldName,
+  type = 'text',
 }: HookValidatedTextInputPropTypes) => {
   const [isPristine, setIsPristine] = useState(!value ? true : false);
   // Do not surface validation on pristine state components
@@ -60,7 +61,7 @@ export const HookValidatedInput = ({
         value={value}
         data-testid={dataTestId}
         ouiaId={ouiaId}
-        type="text"
+        type={type}
         onChange={onChange}
         validated={validated}
         aria-label={ariaLabel}


### PR DESCRIPTION
adds `type` prop to `HookValidatedInput` with a default of 'text', to be able to support other types input like 'password'