### PR TITLE
Wizard: handle dos scripts in first boot (HMS-4966)

### DIFF
--- a/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
@@ -73,7 +73,10 @@ const FirstBootStep = () => {
           isCopyEnabled
           isLanguageLabelVisible
           language={language}
-          onCodeChange={(code) => dispatch(setFirstBootScript(code))}
+          onCodeChange={(code) => {
+            // In case the user is on windows
+            dispatch(setFirstBootScript(code.replace('\r\n', '\n')));
+          }}
           code={selectedScript}
           height="35vh"
           emptyStateButton={<span data-testid="firstboot_browse">Browse</span>}

--- a/src/test/fixtures/editMode.ts
+++ b/src/test/fixtures/editMode.ts
@@ -114,7 +114,8 @@ export const expectedCustomRepositories: CustomRepository[] = [
 ];
 
 // First Boot
-export const SCRIPT = `#!/bin/bash 
+export const SCRIPT_DOS = `#!/bin/bash\r\nsystemctl enable cockpit.socket`;
+export const SCRIPT = `#!/bin/bash
 systemctl enable cockpit.socket`;
 export const BASE64_SCRIPT = btoa(SCRIPT);
 export const SCRIPT_WITHOUT_SHEBANG = `echo "Hello, world!"`;


### PR DESCRIPTION
Scripts in which lines are terminated by CRLF break the first boot service, so let's make sure the line termination is correct.