### PR TITLE
Wizard: Add bytes to min_size partitioning <HMS-4981>

### DIFF
--- a/src/Components/CreateImageWizard/ValidatedTextInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedTextInput.tsx
@@ -34,6 +34,7 @@ export const HookValidatedInput = ({
   ouiaId,
   ariaLabel,
   value,
+  isDisabled,
   placeholder,
   onChange,
   stepValidation,
@@ -67,6 +68,7 @@ export const HookValidatedInput = ({
         aria-label={ariaLabel}
         onBlur={handleBlur}
         placeholder={placeholder}
+        isDisabled={isDisabled}
       />
       {validated === 'error' && (
         <HelperText>

--- a/src/Components/CreateImageWizard/steps/Details/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/index.tsx
@@ -69,6 +69,7 @@ const DetailsStep = () => {
           ariaLabel="blueprint name"
           dataTestId="blueprint"
           value={blueprintName}
+          isDisabled={false}
           onChange={handleNameChange}
           placeholder="Add blueprint name"
           stepValidation={stepValidation}
@@ -92,6 +93,7 @@ const DetailsStep = () => {
           ariaLabel="blueprint description"
           dataTestId="blueprint description"
           value={blueprintDescription || ''}
+          isDisabled={false}
           onChange={handleDescriptionChange}
           placeholder="Add description"
           stepValidation={stepValidation}

--- a/src/Components/CreateImageWizard/steps/FileSystem/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/FileSystemTable.tsx
@@ -233,10 +233,12 @@ type MinimumSizePropTypes = {
   partition: Partition;
 };
 
-export type Units = 'KiB' | 'MiB' | 'GiB';
+export type Units = 'B' | 'KiB' | 'MiB' | 'GiB';
 
 export const getConversionFactor = (units: Units) => {
   switch (units) {
+    case 'B':
+      return 1;
     case 'KiB':
       return UNIT_KIB;
     case 'MiB':
@@ -254,6 +256,7 @@ const MinimumSize = ({ partition }: MinimumSizePropTypes) => {
     <HookValidatedInput
       ariaLabel="minimum partition size"
       value={partition.min_size}
+      isDisabled={partition.unit === 'B'}
       type="text"
       ouiaId="size"
       stepValidation={stepValidation}
@@ -287,7 +290,17 @@ const SizeUnit = ({ partition }: SizeUnitPropTypes) => {
     setIsOpen(isOpen);
   };
 
+  const initialValue = useRef(partition).current;
+
   const onSelect = (event: React.MouseEvent, selection: Units) => {
+    if (initialValue.unit === 'B' && selection === 'B') {
+      dispatch(
+        changePartitionMinSize({
+          id: partition.id,
+          min_size: initialValue.min_size,
+        })
+      );
+    }
     dispatch(changePartitionUnit({ id: partition.id, unit: selection }));
     setIsOpen(false);
   };
@@ -303,6 +316,7 @@ const SizeUnit = ({ partition }: SizeUnitPropTypes) => {
       <SelectOption value={'KiB'} />
       <SelectOption value={'MiB'} />
       <SelectOption value={'GiB'} />
+      <>{initialValue.unit === 'B' && <SelectOption value={'B'} />}</>
     </Select>
   );
 };

--- a/src/Components/CreateImageWizard/utilities/parseSizeUnit.ts
+++ b/src/Components/CreateImageWizard/utilities/parseSizeUnit.ts
@@ -14,6 +14,12 @@ export const parseSizeUnit = (bytesize: string) => {
   } else if (parseInt(bytesize) % UNIT_KIB === 0) {
     size = parseInt(bytesize) / UNIT_KIB;
     unit = 'KiB';
+  } else if (parseInt(bytesize)) {
+    size = parseInt(bytesize);
+    unit = 'B';
+  } else {
+    size = 10;
+    unit = 'GiB';
   }
 
   return [String(size), unit];


### PR DESCRIPTION
Some people might define a minsize of their blueprints that is not a certain number of KiB, MiB, GiB. In case we import such blueprint, we would prefill "undefined" string, which is not a valid value.
I think that the same would eventually happen if we created a blueprint using API, I do not think we check for minimal value.
Because we probably do not want to suggest that users should create blueprints with partitioning with minimal size in bytes, I did the following:
If the value is such, that we cannot display it in KiB, MiB or GiB, we have a new unit - Bytes - in the dropdown, and if it is selected, the text field is not editable. In case users click on different units, they can change it, but if they click back on 'B', they have their initial value in bytes again. Does that make sense?
In case we parse an incorrect value from the imported file, we default to 10 GiB. This would be good to mention in the future, but that is not in the blueprints MVP.
![image](https://github.com/user-attachments/assets/cb025556-5fdc-4cbf-89f0-9762d8f31692)
