### PR TITLE
ci.sh: export sentry variables before calling build

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -16,6 +16,8 @@ else
     source build_app_info.sh
     mv ${DIST_FOLDER} stable
     export BETA=true
+    # export sentry specific variables
+    export SENTRY_AUTH_TOKEN SENTRY_DSN SENTRY_ORG SENTRY_PROJECT
     build
     source build_app_info.sh
     mv ${DIST_FOLDER} preview


### PR DESCRIPTION
Otherwise fec doesn't pick them up.