### PR TITLE
fec.config: prefix paths

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -61,6 +61,7 @@ if (process.env.SENTRY_AUTH_TOKEN) {
       authToken: process.env.SENTRY_AUTH_TOKEN,
       org: process.env.SENTRY_ORG,
       project: process.env.SENTRY_PROJECT,
+      urlPrefix: '~/apps/image-builder',
       _experiments: {
         moduleMetadata: ({ release }) => ({
           dsn: process.env.SENTRY_DSN,


### PR DESCRIPTION
The paths of each artefact needs to be prefixed to reflect where the static resources are hosted on consoledot (which is under /apps/image-builder).