### PR TITLE
deps: Bump PatternFly dependencies to version 5.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,10 @@
       "version": "1.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@patternfly/patternfly": "5.4.1",
-        "@patternfly/react-code-editor": "5.4.1",
-        "@patternfly/react-core": "5.4.1",
-        "@patternfly/react-table": "5.4.1",
+        "@patternfly/patternfly": "5.4.2",
+        "@patternfly/react-code-editor": "5.4.2",
+        "@patternfly/react-core": "5.4.2",
+        "@patternfly/react-table": "5.4.2",
         "@redhat-cloud-services/frontend-components": "4.2.22",
         "@redhat-cloud-services/frontend-components-notifications": "4.1.0",
         "@redhat-cloud-services/frontend-components-utilities": "4.0.17",
@@ -34,7 +34,7 @@
         "@babel/preset-env": "7.26.0",
         "@babel/preset-react": "7.25.7",
         "@babel/preset-typescript": "7.25.7",
-        "@patternfly/react-icons": "5.4.0",
+        "@patternfly/react-icons": "5.4.2",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "2.0.4",
         "@redhat-cloud-services/frontend-components-config": "6.3.1",
         "@redhat-cloud-services/tsc-transform-imports": "1.0.17",
@@ -3580,19 +3580,19 @@
       }
     },
     "node_modules/@patternfly/patternfly": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.4.1.tgz",
-      "integrity": "sha512-0+KxsQJrFzOMANALW82BHAO7bSm9tEbG1RrOlGT23ME1CaBoetGSMRLymutvojn/b/EKfJIr5rLzQa+14Lvg2g==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/patternfly/-/patternfly-5.4.2.tgz",
+      "integrity": "sha512-+BaokNR8/AmTYMESxby9UtQXPGACg449BXQd0KejAvW/uGxlgO6mY1X1205DeBEHoK3e/vXkYXjvZPpv/tcxSA==",
       "license": "MIT"
     },
     "node_modules/@patternfly/react-code-editor": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-5.4.1.tgz",
-      "integrity": "sha512-i1OqW+NPFPxn/BZYp1T9GUGM1du4REqFq6nURLvD2s0/rjb4Guu9pILWHMxOZASdBrlRXBRFcJUUhXdYrpf7pg==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-code-editor/-/react-code-editor-5.4.2.tgz",
+      "integrity": "sha512-w3YluTRTttbtmXaLNRTZTf37Opk3q3Kay68XNsgp+HjHqqQku4byDxP46yt2TjNKt2nmtrswf0FP1DkWALlygA==",
       "license": "MIT",
       "dependencies": {
         "@monaco-editor/react": "^4.6.0",
-        "@patternfly/react-core": "^5.4.0",
+        "@patternfly/react-core": "^5.4.1",
         "@patternfly/react-icons": "^5.4.0",
         "@patternfly/react-styles": "^5.4.0",
         "react-dropzone": "14.2.3",
@@ -3621,9 +3621,9 @@
       }
     },
     "node_modules/@patternfly/react-core": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.4.1.tgz",
-      "integrity": "sha512-PJjwN4OCR7jTdWKi0RzuFdtlSQ8gBR+0REczuDHHPW8ky0bs1cIcqGsn5p/b6OgPlztl3UaXqRYLsroiEMasOw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-5.4.2.tgz",
+      "integrity": "sha512-YpynAUvka9atgrggEporp0S1oxtoAkdtFM5guM3T2zYqs8ww2TKfpn4ThxVgomwyt57zt5KOUKIAwcWWQrYTVQ==",
       "license": "MIT",
       "dependencies": {
         "@patternfly/react-icons": "^5.4.0",
@@ -3639,9 +3639,9 @@
       }
     },
     "node_modules/@patternfly/react-icons": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.4.0.tgz",
-      "integrity": "sha512-2M3qN/naultvRHeG2laJMmoIroFCGAyfwTVrnCjSkG6/KnRoXV0+dqd+Xrh7xzpzvIJB1klvifC0oX42cEkDrA==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-5.4.2.tgz",
+      "integrity": "sha512-CMQ5oHYzW6TPVTs2jpNJmP2vGCAKR/YeTPwHGO9dLkAUej1IcIxtCCWK2Fdo2UJsnBjuZihasyw2b6ehvbUm9Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^17 || ^18",
@@ -3655,12 +3655,12 @@
       "license": "MIT"
     },
     "node_modules/@patternfly/react-table": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.4.1.tgz",
-      "integrity": "sha512-T05djy6YPqjbGWjpnwUs9oqup8oqqIOBnDOcThnHukgzlwnZvLNywgdoMR5XAKxTcIx/iBE1cu8ieETlITOGLw==",
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-5.4.2.tgz",
+      "integrity": "sha512-SN59a5m2RNGXA3imm1OZf3C5fa9gj4rCvd5aj5GM2BuzhF+9kMM7T6xc6d2eJudoPY4U77CSa4n//K1UeJTj4w==",
       "license": "MIT",
       "dependencies": {
-        "@patternfly/react-core": "^5.4.1",
+        "@patternfly/react-core": "^5.4.2",
         "@patternfly/react-icons": "^5.4.0",
         "@patternfly/react-styles": "^5.4.0",
         "@patternfly/react-tokens": "^5.4.0",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
     "npm": ">=7.0.0"
   },
   "dependencies": {
-    "@patternfly/patternfly": "5.4.1",
-    "@patternfly/react-code-editor": "5.4.1",
-    "@patternfly/react-core": "5.4.1",
-    "@patternfly/react-table": "5.4.1",
+    "@patternfly/patternfly": "5.4.2",
+    "@patternfly/react-code-editor": "5.4.2",
+    "@patternfly/react-core": "5.4.2",
+    "@patternfly/react-table": "5.4.2",
     "@redhat-cloud-services/frontend-components": "4.2.22",
     "@redhat-cloud-services/frontend-components-notifications": "4.1.0",
     "@redhat-cloud-services/frontend-components-utilities": "4.0.17",
@@ -32,7 +32,7 @@
     "@babel/preset-env": "7.26.0",
     "@babel/preset-react": "7.25.7",
     "@babel/preset-typescript": "7.25.7",
-    "@patternfly/react-icons": "5.4.0",
+    "@patternfly/react-icons": "5.4.2",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "2.0.4",
     "@redhat-cloud-services/frontend-components-config": "6.3.1",
     "@redhat-cloud-services/tsc-transform-imports": "1.0.17",


### PR DESCRIPTION
While trying to resolve the release blocking issue PF versions were reverted to 5.4.1 which was one patch version larger jump than needed.

This uses the latest 5.4.2 release, we should stick to it and not update to version 6.x before the platform migrates to avoid possible problems.