### PR TITLE
On-prem: read blueprints from disk (COMPOSER-2413)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ cockpit/public/main*
 
 # Sentry Config File
 .sentryclirc
+
+# cockpit lib dir
+pkg/lib

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,52 @@
-INSTALL_DIR := ~/.local/share/cockpit/image-builder-frontend
+PACKAGE_NAME = image-builder-frontend
+INSTALL_DIR = /share/cockpit/$(PACKAGE_NAME)
 
-cockpit/all: devel-uninstall devel-install build
+# TODO: figure out a strategy for keeping this updated
+COCKPIT_REPO_COMMIT = b0e82161b4afcb9f0a6fddd8ff94380e983b2238
+COCKPIT_REPO_URL = https://github.com/cockpit-project/cockpit.git
+COCKPIT_REPO_TREE = '$(strip $(COCKPIT_REPO_COMMIT))^{tree}'
 
-devel-install:
-	mkdir -p ~/.local/share/cockpit
-	ln -s $(shell pwd)/cockpit/public $(INSTALL_DIR)
+# checkout common files from Cockpit repository required to build this project;
+# this has no API stability guarantee, so check out a stable tag when you start
+# a new project, use the latest release, and update it from time to time
+COCKPIT_REPO_FILES = \
+	pkg/lib \
+	$(NULL)
 
-build:
+help:
+	@cat Makefile
+
+#
+# Cockpit related targets
+#
+
+.PHONY: cockpit/clean
+cockpit/clean:
+	rm -f cockpit/public/*.css
+	rm -f cockpit/public/*.js
+
+.PHONY: cockpit/devel-uninstall
+cockpit/devel-uninstall: PREFIX=~/.local
+cockpit/devel-uninstall:
+	rm -rf $(PREFIX)$(INSTALL_DIR)
+
+.PHONY: cockpit/devel-install
+cockpit/devel-install: PREFIX=~/.local
+cockpit/devel-install:
+	PREFIX="~/.local"
+	mkdir -p $(PREFIX)$(INSTALL_DIR)
+	ln -s $(shell pwd)/cockpit/public $(PREFIX)$(INSTALL_DIR)
+
+.PHONY: cockpit/download
+cockpit/download: Makefile
+	@git rev-list --quiet --objects $(COCKPIT_REPO_TREE) -- 2>/dev/null || \
+	    git fetch --no-tags --no-write-fetch-head --depth=1 $(COCKPIT_REPO_URL) $(COCKPIT_REPO_COMMIT)
+	git archive $(COCKPIT_REPO_TREE) -- $(COCKPIT_REPO_FILES) | tar x
+
+.PHONY: cockpit/build
+cockpit/build: cockpit/download
+	npm ci
 	npm run build:cockpit
 
-devel-uninstall:
-	rm -rf $(INSTALL_DIR)
-	rm cockpit/public/*.css
-	rm cockpit/public/*.js
-
-.PHONY: cockpit/all devel-install build devel-uninstall
+.PHONY: cockpit/devel
+cockpit/devel: cockpit/devel-uninstall cockpit/build cockpit/devel-install

--- a/ci.sh
+++ b/ci.sh
@@ -2,8 +2,8 @@
 
 # Workaround needed for Konflux pipeline to pass
 
-find -name "cockpit" -type d
-find -name "cockpit" -type d | xargs rm -rf -
+find -name "cockpit" -type d -maxdepth 1
+find -name "cockpit" -type d -maxdepth 1 | xargs rm -rf -
 
 setNpmOrYarn
 install

--- a/cockpit/tsconfig.json
+++ b/cockpit/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        // this allows us to pull in the `cockpit` and
+        // `cockpit/fsinfo` modules from the `pkg/lib`
+        // directory
+        "../pkg/lib/*"
+      ]
+    }
+  }
+}

--- a/cockpit/webpack.config.ts
+++ b/cockpit/webpack.config.ts
@@ -27,16 +27,24 @@ module.exports = {
   mode,
   devtool,
   plugins,
-  externals: { cockpit: 'cockpit' },
   resolve: {
-    modules: ['node_modules'],
+    modules: [
+      'node_modules',
+      // this tells webpack to check `node_modules`
+      // and `pkg/lib` for modules. This allows us
+      // to import `cockpit` and `cockpit/fsinfo`
+      path.resolve(__dirname, '../pkg/lib'),
+    ],
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
   },
   module: {
     rules: [
       {
         test: /\.(ts|tsx)$/,
-        include: [path.resolve('src')],
+        include: [
+          path.resolve(__dirname, '../src'),
+          path.resolve(__dirname, '../pkg/lib'),
+        ],
         use: {
           loader: 'babel-loader',
           options: {

--- a/fec.config.js
+++ b/fec.config.js
@@ -2,7 +2,7 @@
 const path = require('path');
 
 const CopyPlugin = require('copy-webpack-plugin');
-const { sentryWebpackPlugin } = require("@sentry/webpack-plugin");
+const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 const webpack = require('webpack');
 
 const plugins = [];
@@ -105,6 +105,15 @@ module.exports = {
   useAgent: true,
   bounceProd: false,
   proxyVerbose: true,
+  resolve: {
+    alias: {
+      // we don't wan't these packages bundled with
+      // the service frontend, so we can set the aliases
+      // to false
+      cockpit: false,
+      'cockpit/fsinfo': false,
+    },
+  },
   routes: {
     ...(process.env.CONFIG_PORT && {
       [`${process.env.BETA ? '/beta' : ''}/config`]: {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -263,3 +263,6 @@ export const PAGINATION_OFFSET = 0;
 export const PAGINATION_LIMIT = 10;
 export const PAGINATION_COUNT = 0;
 export const SEARCH_INPUT = '';
+
+export const BLUEPRINTS_DIR =
+  '.local/share/cockpit/image-builder-frontend/blueprints';

--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -1,17 +1,10 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
-
+import { emptyCockpitApi } from './emptyCockpitApi';
 import {
   GetArchitecturesApiResponse,
   GetArchitecturesApiArg,
   GetBlueprintsApiArg,
   GetBlueprintsApiResponse,
 } from './imageBuilderApi';
-
-const emptyCockpitApi = createApi({
-  reducerPath: 'cockpitApi',
-  baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
-  endpoints: () => ({}),
-});
 
 export const cockpitApi = emptyCockpitApi.injectEndpoints({
   endpoints: (builder) => {

--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -17,6 +17,7 @@ import {
   BlueprintItem,
 } from './imageBuilderApi';
 
+import { mapOnPremToHosted } from '../Components/Blueprints/helpers/onPremToHostedBlueprintMapper';
 import { BLUEPRINTS_DIR } from '../constants';
 
 const getBlueprintsPath = async () => {
@@ -61,12 +62,12 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
                 const parsed = toml.parse(contents);
                 file.close();
 
-                // TODO: using the existing blueprint converter
+                const blueprint = mapOnPremToHosted(parsed);
+                const version = (parsed.version as number) ?? 1;
                 return {
-                  name: parsed.name as string,
+                  ...blueprint,
                   id: filename as string,
-                  version: parsed.version as number,
-                  description: parsed.description as string,
+                  version: Math.floor(version),
                   last_modified_at: Date.now().toString(),
                 };
               })

--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -1,3 +1,13 @@
+// Note: for the on-prem version of the frontend we have configured
+// this so that we check `node_modules` and `pkg/lib` for packages.
+// To get around this for the hosted service, we have configured
+// the `tsconfig` to stubs of the `cockpit` and `cockpit/fsinfo`
+// modules. These stubs are in the `src/test/mocks/cockpit` directory.
+// We also needed to create an alias in vitest to make this work.
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import cockpit from 'cockpit';
+import { fsinfo } from 'cockpit/fsinfo';
+
 import { emptyCockpitApi } from './emptyCockpitApi';
 import {
   GetArchitecturesApiResponse,

--- a/src/store/emptyCockpitApi.ts
+++ b/src/store/emptyCockpitApi.ts
@@ -1,0 +1,7 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+
+export const emptyCockpitApi = createApi({
+  reducerPath: 'cockpitApi',
+  baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
+  endpoints: () => ({}),
+});

--- a/src/test/mocks/cockpit/fsinfo.ts
+++ b/src/test/mocks/cockpit/fsinfo.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+type fileinfo = {
+  entries?: Record<string, fileinfo>;
+};
+
+export const fsinfo = (
+  path: string,
+  attributes: (keyof fileinfo)[],
+  options: object
+): Promise<fileinfo> => {
+  return new Promise((resolve) => {
+    resolve({
+      entries: {},
+    });
+  });
+};

--- a/src/test/mocks/cockpit/index.ts
+++ b/src/test/mocks/cockpit/index.ts
@@ -1,0 +1,25 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+
+type userinfo = {
+  home: string;
+};
+
+export default {
+  user: (): Promise<userinfo> => {
+    return new Promise((resolve) => {
+      resolve({
+        home: '',
+      });
+    });
+  },
+  file: (path: string) => {
+    return {
+      read: (): Promise<string> => {
+        return new Promise((resolve) => {
+          resolve('');
+        });
+      },
+      close: () => {},
+    };
+  },
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,6 +15,14 @@
     ],
     "exactOptionalPropertyTypes": true,
     "strictNullChecks": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "paths": {
+      "*": [
+        // Needed so we can resolve `cockpit` & `cockpit/fsinfo`
+        // types. We have stubbed those functions out for the
+        // as this is the tsconfig file for the service.
+        "./src/test/mocks/*"
+      ]
+    }
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,5 @@
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 const config = {
   plugins: [react()],
@@ -16,6 +17,7 @@ const config = {
     },
     testTimeout: 10000,
     fileParallelism: false,
+    exclude: ['./pkg/lib/**', '**/node_modules/**', '**/dist/**'],
   },
   reporters: ['default', 'junit'],
   outputFile: {
@@ -23,6 +25,16 @@ const config = {
   },
   resolve: {
     mainFields: ['module'],
+    alias: {
+      // we have to point vitest to the mocks for `cockpit` and `cockpit/fsinfo`
+      // by using aliases. This allows vitest to resolve these two packages
+      // and allows the tests to pass
+      cockpit: path.resolve(__dirname, 'src/test/mocks/cockpit'),
+      'cockpit/fsinfo': path.resolve(
+        __dirname,
+        'src/test/mocks/cockpit/fsinfo'
+      ),
+    },
   },
   esbuild: {
     loader: 'tsx',


### PR DESCRIPTION
We can use the cockpit files api to read in blueprints from disk.

This PR adds commits to bring in the required dependencies, some convenience scripts and an initial commit using an RTK query function to read blueprints from file and pull the details into the store.