### PR TITLE
Konflux: Compare rpms-signature-scan with generated pipeline

### DIFF
--- a/.tekton/image-builder-frontend-pull-request.yaml
+++ b/.tekton/image-builder-frontend-pull-request.yaml
@@ -593,11 +593,11 @@ spec:
     - name: rpms-signature-scan
       params:
       - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       runAfter:
-      - build-container
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -607,6 +607,11 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/image-builder-frontend-pull-request.yaml
+++ b/.tekton/image-builder-frontend-pull-request.yaml
@@ -384,23 +384,6 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
-    - name: rpms-signature-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: rpms-signature-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:28aaf87d61078a0aeeeabcae455eda7d05c4f9b81d8995bdcf3dde95c1a7a77b
-        - name: kind
-          value: task
-        resolver: bundles
     - name: build-image-index
       params:
       - name: IMAGE
@@ -607,6 +590,23 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:28aaf87d61078a0aeeeabcae455eda7d05c4f9b81d8995bdcf3dde95c1a7a77b
+        - name: kind
+          value: task
+        resolver: bundles
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/image-builder-frontend-push.yaml
+++ b/.tekton/image-builder-frontend-push.yaml
@@ -590,11 +590,11 @@ spec:
     - name: rpms-signature-scan
       params:
       - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
+        value: $(tasks.build-image-index.results.IMAGE_DIGEST)
       - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
+        value: $(tasks.build-image-index.results.IMAGE_URL)
       runAfter:
-      - build-container
+      - build-image-index
       taskRef:
         params:
         - name: name
@@ -604,6 +604,11 @@ spec:
         - name: kind
           value: task
         resolver: bundles
+      when:
+      - input: $(params.skip-checks)
+        operator: in
+        values:
+        - "false"
     workspaces:
     - name: workspace
     - name: git-auth

--- a/.tekton/image-builder-frontend-push.yaml
+++ b/.tekton/image-builder-frontend-push.yaml
@@ -381,23 +381,6 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
-    - name: rpms-signature-scan
-      params:
-      - name: image-digest
-        value: $(tasks.build-container.results.IMAGE_DIGEST)
-      - name: image-url
-        value: $(tasks.build-container.results.IMAGE_URL)
-      runAfter:
-      - build-container
-      taskRef:
-        params:
-        - name: name
-          value: rpms-signature-scan
-        - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:28aaf87d61078a0aeeeabcae455eda7d05c4f9b81d8995bdcf3dde95c1a7a77b
-        - name: kind
-          value: task
-        resolver: bundles
     - name: build-image-index
       params:
       - name: IMAGE
@@ -604,6 +587,23 @@ spec:
       workspaces:
       - name: workspace
         workspace: workspace
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:28aaf87d61078a0aeeeabcae455eda7d05c4f9b81d8995bdcf3dde95c1a7a77b
+        - name: kind
+          value: task
+        resolver: bundles
     workspaces:
     - name: workspace
     - name: git-auth


### PR DESCRIPTION
I've noticed there was an auto-generarated rpms-signature-scan for the Konflux pipelines and it was disabled as it didn't work at the time of migration: https://github.com/osbuild/image-builder-frontend/pull/2524/commits/985c5d2b0f0add8b01fcda69180e2a94d608f326

Comparing it to what we have now, there are some small changes. Not sure if those are completely necessary, but thought they might alleviate hypothetical unpredictable behaviour in the future. :shrug: 

This PR is intentionally split into two commits, one just moves the rpms-signature-scan block lower in the pipeline and the second includes changes to the blocks, so it's hopefully nicer to review.