### PR TITLE
Wizard: Fix package recommendations

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
@@ -88,7 +88,12 @@ const PackageRecommendations = () => {
           },
         });
 
-        if (response && response.data && response.data.packages.length > 0) {
+        if (
+          response &&
+          response.data &&
+          response.data.packages &&
+          response.data.packages.length > 0
+        ) {
           analytics.track(
             `${AMPLITUDE_MODULE_NAME}-packageRecommendationsShown`,
             {
@@ -104,7 +109,7 @@ const PackageRecommendations = () => {
   }, [fetchRecommendedPackages, packages, isExpanded]);
 
   useEffect(() => {
-    if (isSuccess && data.packages.length > 0) {
+    if (isSuccess && data.packages && data.packages.length > 0) {
       fetchRecommendationDescriptions({
         apiContentUnitSearchRequest: {
           exact_names: data?.packages,


### PR DESCRIPTION
Previously the Wizard crashed when looking for recommendations for packages that had none.

How to reproduce the crash:
- go to the Packages step
- search for and select `tmux` package

After fix:
- when selecting a `tmux` package or any other package without recommendations, the recommendations stay empty, but the Wizard doesn't crash