### PR TITLE
ImageBuildStatus.css: Add version to status colors

### DIFF
--- a/src/Components/ImagesTable/ImageBuildStatus.scss
+++ b/src/Components/ImagesTable/ImageBuildStatus.scss
@@ -1,14 +1,14 @@
 .error {
-  color: var(--pf-global--danger-color--100);
+  color: var(--pf-v5-global--danger-color--100);
 }
 .success {
-  color: var(--pf-global--success-color--100);
+  color: var(--pf-v5-global--success-color--100);
 }
 .pending {
-  color: var(--pf-global--info-color--100);
+  color: var(--pf-v5-global--info-color--100);
 }
 .expiring {
-  color: var(--pf-global--warning-color--100);
+  color: var(--pf-v5-global--warning-color--100);
 }
 
 .failure-button {


### PR DESCRIPTION
Add the v5 slug to the status colors as the unversioned colors don't seem to be defined in PatternFly anymore. I haven't looked at the history, but I presume this was done at some point during v6 development, as the upstream colors now contain the v6 slug: https://www.patternfly.org/components/banner/design-guidelines/#usage

Fixes #2611

Before:
![image](https://github.com/user-attachments/assets/cbdd3a54-b969-4c3f-a1c1-b36ee2ac908b)
After:
![image](https://github.com/user-attachments/assets/c0b92e56-8134-4a3d-a113-095d2239be0c)
