### PR TITLE
ImagesTable: Fix image name spacing

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -484,6 +484,7 @@ const Row = ({
         <Td dataLabel="Image name">
           {compose.blueprint_id ? (
             <Button
+              component="a"
               variant="link"
               isInline
               onClick={() =>


### PR DESCRIPTION
This adds a component value to the image name, making the spacing work correctly.

Before:
![image](https://github.com/user-attachments/assets/8067a0bf-91c2-49ab-9a65-d23786a29a64)

After:
![image](https://github.com/user-attachments/assets/831a60a9-3bcb-487c-877c-c27c0aa16a6e)
