### PR TITLE
ImagesTable: Unify pagination format with Repositories

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -241,7 +241,6 @@ const ImagesTable = () => {
               onPerPageSelect={onPerPageSelect}
               widgetId="compose-pagination-bottom"
               data-testid="images-pagination-bottom"
-              isCompact
             />
           </ToolbarItem>
         </ToolbarContent>


### PR DESCRIPTION
This makes bottom pagination format on ImagesTable consistent with the format being used in Repositories service.

Repositories: 
![image](https://github.com/user-attachments/assets/9cffaf44-60d9-4386-b392-4d69bf87609a)
