### PR TITLE
store/enhancedImageBuilderApi: handle empty error data (HMS-5049)

### DIFF
--- a/src/store/enhancedImageBuilderApi.ts
+++ b/src/store/enhancedImageBuilderApi.ts
@@ -5,7 +5,7 @@ import { imageBuilderApi } from './imageBuilderApi';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const errorMessage = (err: any) => {
   let msg = err.error.statusText;
-  if (err.error.data?.errors[0]?.detail) {
+  if (err.error.data?.errors.length > 0 && err.error.data?.errors[0]?.detail) {
     msg = err.error.data?.errors[0]?.detail;
   }
   return msg;


### PR DESCRIPTION
There's a case where the IB api returns an error without more data in it, though it might be coming from a component which treats the request before the image builder api.