### PR TITLE
Wizard: hide compliance radio on stable

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -39,14 +39,15 @@ import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
 
 const OscapStep = () => {
   const dispatch = useAppDispatch();
-  const complianceEnabled = useFlag('image-builder.compliance.enabled');
+  const { isBeta, isProd } = useGetEnvironment();
+  const complianceEnabled =
+    useFlag('image-builder.compliance.enabled') && isBeta();
   const complianceType = useAppSelector(selectComplianceType);
   const profileID = useAppSelector(selectComplianceProfileID);
   const prefetchOscapProfile = imageBuilderApi.usePrefetch(
     'getOscapProfiles',
     {}
   );
-  const { isProd } = useGetEnvironment();
   const release = removeBetaFromRelease(useAppSelector(selectDistribution));
   const { data: currentProfileData } = useGetOscapCustomizationsQuery(
     {


### PR DESCRIPTION
Currently only the title is correctly changed between preview and stable. On stable, the radio should obviously be hidden as well.

---
stable
![afbeelding](https://github.com/user-attachments/assets/4b76be4c-2021-4560-9f01-fff948da7974)


preview
![afbeelding](https://github.com/user-attachments/assets/fdffaadd-a500-4391-b170-af4f6938c84c)
