### PR TITLE
Wizard: LOCALE 2- Add locale structure to store and mapper (HMS-5097)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -76,6 +76,8 @@ import {
   selectFirstBootScript,
   selectMetadata,
   initialState,
+  selectLanguages,
+  selectKeyboard,
 } from '../../../store/wizardSlice';
 import { FileSystemConfigurationType } from '../steps/FileSystem';
 import {
@@ -290,6 +292,10 @@ function commonRequestToState(
           repository: '' as PackageRepository,
           package_list: [],
         })) || [],
+    locale: {
+      languages: request.customizations.locale?.languages || [],
+      keyboard: request.customizations.locale?.keyboard || '',
+    },
     services: {
       enabled: request.customizations?.services?.enabled || [],
       masked: request.customizations?.services?.masked || [],
@@ -496,7 +502,7 @@ const getCustomizations = (state: RootState, orgID: string): Customizations => {
       : undefined,
     groups: undefined,
     timezone: undefined,
-    locale: undefined,
+    locale: getLocale(state),
     firewall: undefined,
     installation_device: undefined,
     fdo: undefined,
@@ -611,6 +617,20 @@ const getSubscription = (
       return { ...initialSubscription, insights: true, rhc: false };
     case 'register-now':
       return { ...initialSubscription, insights: false, rhc: false };
+  }
+};
+
+const getLocale = (state: RootState) => {
+  const languages = selectLanguages(state);
+  const keyboard = selectKeyboard(state);
+
+  if (languages?.length === 0 && !keyboard) {
+    return undefined;
+  } else {
+    return {
+      languages: languages && languages.length > 0 ? languages : undefined,
+      keyboard: keyboard ? keyboard : undefined,
+    };
   }
 };
 

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -7,6 +7,7 @@ import type {
   Distributions,
   ImageRequest,
   ImageTypes,
+  Locale,
   Repository,
 } from './imageBuilderApi';
 import type { ActivationKeys } from './rhsmApi';
@@ -106,6 +107,7 @@ export type wizardState = {
   kernel: {
     append: string;
   };
+  locale: Locale;
   details: {
     blueprintName: string;
     blueprintDescription: string;
@@ -176,6 +178,10 @@ export const initialState: wizardState = {
   },
   kernel: {
     append: '',
+  },
+  locale: {
+    languages: [],
+    keyboard: '',
   },
   details: {
     blueprintName: '',
@@ -325,6 +331,14 @@ export const selectServices = (state: RootState) => {
 
 export const selectKernel = (state: RootState) => {
   return state.wizard.kernel;
+};
+
+export const selectLanguages = (state: RootState) => {
+  return state.wizard.locale.languages;
+};
+
+export const selectKeyboard = (state: RootState) => {
+  return state.wizard.locale.keyboard;
 };
 
 export const selectBlueprintName = (state: RootState) => {
@@ -660,6 +674,28 @@ export const wizardSlice = createSlice({
         1
       );
     },
+    addLanguage: (state, action: PayloadAction<string>) => {
+      if (
+        state.locale.languages &&
+        !state.locale.languages.some((lang) => lang === action.payload)
+      ) {
+        state.locale.languages.push(action.payload);
+      }
+    },
+    removeLanguage: (state, action: PayloadAction<string>) => {
+      if (state.locale.languages) {
+        state.locale.languages.splice(
+          state.locale.languages.findIndex((lang) => lang === action.payload),
+          1
+        );
+      }
+    },
+    clearLanguages: (state) => {
+      state.locale.languages = [];
+    },
+    changeKeyboard: (state, action: PayloadAction<string>) => {
+      state.locale.keyboard = action.payload;
+    },
     changeBlueprintName: (state, action: PayloadAction<string>) => {
       state.details.blueprintName = action.payload;
     },
@@ -732,6 +768,10 @@ export const {
   removePackage,
   addGroup,
   removeGroup,
+  addLanguage,
+  removeLanguage,
+  clearLanguages,
+  changeKeyboard,
   changeBlueprintName,
   changeBlueprintDescription,
   loadWizardState,


### PR DESCRIPTION
This creates structure and actions for the locale customization in the wizardSlice and requestMapper.

Based on and blocked by https://github.com/osbuild/image-builder-frontend/pull/2625