### PR TITLE
Wizard: TIMEZONE 2a - Add Timezone to on-prem mapper (HMS-5102)

### DIFF
--- a/src/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -172,6 +172,10 @@ minsize = 2147483648
 [customizations.installer]
 unattended = true
 sudo-nopasswd = ["user", "%wheel"]
+
+[customizations.timezone]
+timezone = "US/Eastern"
+ntpservers = ["0.north-america.pool.ntp.org", "1.north-america.pool.ntp.org"]
 `;
 
 const uploadFile = async (filename: string, content: string): Promise<void> => {
@@ -339,6 +343,19 @@ describe('Import modal', () => {
       async () =>
         await user.click(await screen.findByTestId('packages-selected-toggle'))
     );
+
+    // Users
+    await clickNext();
+
+    // Timezone
+    await clickNext();
+    await screen.findByRole('heading', { name: /Timezone/ });
+    const timezoneDropDown = await screen.findByPlaceholderText(
+      /Select a timezone/i
+    );
+    expect(timezoneDropDown).toHaveValue('US/Eastern');
+    await screen.findByText(/0\.north-america\.pool\.ntp\.org/i);
+    await screen.findByText(/1\.north-america\.pool\.ntp\.org/i);
 
     await clickNext();
   }, 20000);

--- a/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
+++ b/src/Components/Blueprints/helpers/onPremToHostedBlueprintMapper.tsx
@@ -146,6 +146,13 @@ export const mapOnPremToHosted = (
               enabled: blueprint.customizations?.fips,
             }
           : undefined,
+      timezone:
+        blueprint.customizations?.timezone !== undefined
+          ? {
+              timezone: blueprint.customizations.timezone.timezone,
+              ntpservers: blueprint.customizations.timezone.ntpservers,
+            }
+          : undefined,
     },
     metadata: {
       parent_id: null,


### PR DESCRIPTION
This adds Timezone values to the on-prem mapper and updates the import test to check for expected values.

Based on and blocked by https://github.com/osbuild/image-builder-frontend/pull/2613