### PR TITLE
CreateImageWizard: Add RHEL10beta search parameter

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -167,6 +167,9 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
     if (searchParams.get('release') === 'rhel8') {
       dispatch(changeDistribution(RHEL_8));
     }
+    if (searchParams.get('release') === 'rhel10beta') {
+      dispatch(changeDistribution(RHEL_10_BETA));
+    }
     if (searchParams.get('arch') === AARCH64) {
       dispatch(changeArchitecture(AARCH64));
     }

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -512,6 +512,11 @@ describe('Set release using query parameter', () => {
     await renderCreateMode({ release: 'rhel8' });
     await screen.findByText('Red Hat Enterprise Linux (RHEL) 8');
   });
+
+  test('rhel 10 beta (query parameter provided)', async () => {
+    await renderCreateMode({ release: 'rhel10beta' });
+    await screen.findByText('Red Hat Enterprise Linux (RHEL) 10 Beta');
+  });
 });
 
 describe('Set architecture using query parameter', () => {


### PR DESCRIPTION
This means we can easily link to the wizard and pre-select RHEL 10 Beta which will be nice for the release announcement blog post.