### PR TITLE
tsconfig: exactOptionalPropertyTypes (COMPOSER-2412)

### DIFF
--- a/api/config/compliance.ts
+++ b/api/config/compliance.ts
@@ -7,6 +7,7 @@ const config: ConfigFile = {
   outputFile: '../../src/store/complianceApi.ts',
   exportName: 'complianceApi',
   hooks: true,
+  unionUndefined: true,
   filterEndpoints: ['policies', 'policy'],
 };
 

--- a/api/config/contentSources.ts
+++ b/api/config/contentSources.ts
@@ -7,6 +7,7 @@ const config: ConfigFile = {
   outputFile: '../../src/store/contentSourcesApi.ts',
   exportName: 'contentSourcesApi',
   hooks: true,
+  unionUndefined: true,
   filterEndpoints: [
     'createRepository',
     'listRepositories',

--- a/api/config/edge.ts
+++ b/api/config/edge.ts
@@ -7,6 +7,7 @@ const config: ConfigFile = {
   outputFile: '../../src/store/edgeApi.ts',
   exportName: 'edgeApi',
   hooks: true,
+  unionUndefined: true,
   filterEndpoints: [
     'createImage',
     'createImageUpdate',

--- a/api/config/imageBuilder.ts
+++ b/api/config/imageBuilder.ts
@@ -7,6 +7,7 @@ const config: ConfigFile = {
   outputFile: '../../src/store/imageBuilderApi.ts',
   exportName: 'imageBuilderApi',
   hooks: { queries: true, lazyQueries: true, mutations: true },
+  unionUndefined: true,
   filterEndpoints: [
     'cloneCompose',
     'composeImage',

--- a/api/config/provisioning.ts
+++ b/api/config/provisioning.ts
@@ -7,6 +7,7 @@ const config: ConfigFile = {
   outputFile: '../../src/store/provisioningApi.ts',
   exportName: 'provisioningApi',
   hooks: true,
+  unionUndefined: true,
   filterEndpoints: ['getSourceList', 'getSourceUploadInfo'],
 };
 

--- a/api/config/rhsm.ts
+++ b/api/config/rhsm.ts
@@ -7,7 +7,12 @@ const config: ConfigFile = {
   outputFile: '../../src/store/rhsmApi.ts',
   exportName: 'rhsmApi',
   hooks: true,
-  filterEndpoints: ['listActivationKeys', 'showActivationKey', 'createActivationKeys'],
+  unionUndefined: true,
+  filterEndpoints: [
+    'listActivationKeys',
+    'showActivationKey',
+    'createActivationKeys',
+  ],
 };
 
 export default config;

--- a/src/Components/Blueprints/BlueprintsPagination.tsx
+++ b/src/Components/Blueprints/BlueprintsPagination.tsx
@@ -11,18 +11,27 @@ import {
   setBlueprintsOffset,
 } from '../../store/BlueprintSlice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import { useGetBlueprintsQuery } from '../../store/imageBuilderApi';
+import {
+  useGetBlueprintsQuery,
+  GetBlueprintsApiArg,
+} from '../../store/imageBuilderApi';
 
 const BlueprintsPagination = () => {
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
   const blueprintsOffset = useAppSelector(selectOffset) || 0;
   const blueprintsLimit = useAppSelector(selectLimit) || 10;
   const currPage = Math.floor(blueprintsOffset / blueprintsLimit) + 1;
-  const { data: blueprintsData } = useGetBlueprintsQuery({
-    search: blueprintSearchInput,
+
+  const searchParams: GetBlueprintsApiArg = {
     limit: blueprintsLimit,
     offset: blueprintsOffset,
-  });
+  };
+
+  if (blueprintSearchInput) {
+    searchParams.search = blueprintSearchInput;
+  }
+
+  const { data: blueprintsData } = useGetBlueprintsQuery(searchParams);
   const dispatch = useAppDispatch();
 
   const blueprintsTotal = blueprintsData?.meta?.count || 0;

--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -24,7 +24,11 @@ import { Link } from 'react-router-dom';
 import BlueprintCard from './BlueprintCard';
 import BlueprintsPagination from './BlueprintsPagination';
 
-import { DEBOUNCED_SEARCH_WAIT_TIME } from '../../constants';
+import {
+  DEBOUNCED_SEARCH_WAIT_TIME,
+  PAGINATION_OFFSET,
+  PAGINATION_LIMIT,
+} from '../../constants';
 import { useGetBlueprintsQuery } from '../../store/backendApi';
 import {
   selectBlueprintSearchInput,
@@ -55,8 +59,8 @@ type emptyBlueprintStateProps = {
 const BlueprintsSidebar = () => {
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
-  const blueprintsOffset = useAppSelector(selectOffset);
-  const blueprintsLimit = useAppSelector(selectLimit);
+  const blueprintsOffset = useAppSelector(selectOffset) || PAGINATION_OFFSET;
+  const blueprintsLimit = useAppSelector(selectLimit) || PAGINATION_LIMIT;
   const {
     data: blueprintsData,
     isLoading,

--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -41,7 +41,10 @@ import {
 } from '../../store/BlueprintSlice';
 import { imageBuilderApi } from '../../store/enhancedImageBuilderApi';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import { BlueprintItem } from '../../store/imageBuilderApi';
+import {
+  BlueprintItem,
+  GetBlueprintsApiArg,
+} from '../../store/imageBuilderApi';
 import { resolveRelPath } from '../../Utilities/path';
 
 type blueprintSearchProps = {
@@ -61,15 +64,21 @@ const BlueprintsSidebar = () => {
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
   const blueprintsOffset = useAppSelector(selectOffset) || PAGINATION_OFFSET;
   const blueprintsLimit = useAppSelector(selectLimit) || PAGINATION_LIMIT;
+
+  const searchParams: GetBlueprintsApiArg = {
+    limit: blueprintsLimit,
+    offset: blueprintsOffset,
+  };
+
+  if (blueprintSearchInput) {
+    searchParams.search = blueprintSearchInput;
+  }
+
   const {
     data: blueprintsData,
     isLoading,
     isFetching,
-  } = useGetBlueprintsQuery({
-    search: blueprintSearchInput,
-    limit: blueprintsLimit,
-    offset: blueprintsOffset,
-  });
+  } = useGetBlueprintsQuery(searchParams);
   const dispatch = useAppDispatch();
   const blueprints = blueprintsData?.data;
 
@@ -189,7 +198,7 @@ const BlueprintSearch = ({ blueprintsTotal }: blueprintSearchProps) => {
 
   return (
     <SearchInput
-      value={blueprintSearchInput}
+      value={blueprintSearchInput || ''}
       placeholder="Search by name or description"
       onChange={(_event, value) => onChange(value)}
       onClear={() => onChange('')}

--- a/src/Components/Blueprints/BuildImagesButton.tsx
+++ b/src/Components/Blueprints/BuildImagesButton.tsx
@@ -179,7 +179,7 @@ export const BuildImagesButtonEmptyState = ({
       onClick={onBuildHandler}
       isDisabled={!selectedBlueprintId}
       isLoading={imageBuildLoading}
-      variant={variant}
+      variant={variant || 'primary'}
     >
       {children ? children : 'Build images'}
     </Button>

--- a/src/Components/Blueprints/DeleteBlueprintModal.tsx
+++ b/src/Components/Blueprints/DeleteBlueprintModal.tsx
@@ -7,6 +7,7 @@ import {
   ModalVariant,
 } from '@patternfly/react-core';
 
+import { PAGINATION_LIMIT, PAGINATION_OFFSET } from '../../constants';
 import {
   selectBlueprintSearchInput,
   selectLimit,
@@ -20,7 +21,6 @@ import {
   useDeleteBlueprintMutation,
   useGetBlueprintsQuery,
 } from '../../store/imageBuilderApi';
-import { PAGINATION_LIMIT, PAGINATION_OFFSET } from '../../constants';
 
 interface DeleteBlueprintModalProps {
   setShowDeleteModal: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/Components/Blueprints/DeleteBlueprintModal.tsx
+++ b/src/Components/Blueprints/DeleteBlueprintModal.tsx
@@ -18,6 +18,7 @@ import {
 import { imageBuilderApi } from '../../store/enhancedImageBuilderApi';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import {
+  GetBlueprintsApiArg,
   useDeleteBlueprintMutation,
   useGetBlueprintsQuery,
 } from '../../store/imageBuilderApi';
@@ -35,21 +36,24 @@ export const DeleteBlueprintModal: React.FunctionComponent<
   const blueprintsOffset = useAppSelector(selectOffset) || PAGINATION_OFFSET;
   const blueprintsLimit = useAppSelector(selectLimit) || PAGINATION_LIMIT;
   const dispatch = useAppDispatch();
-  const { blueprintName } = useGetBlueprintsQuery(
-    {
-      search: blueprintSearchInput,
-      limit: blueprintsLimit,
-      offset: blueprintsOffset,
-    },
-    {
-      selectFromResult: ({ data }) => ({
-        blueprintName: data?.data?.find(
-          (blueprint: { id: string | undefined }) =>
-            blueprint.id === selectedBlueprintId
-        )?.name,
-      }),
-    }
-  );
+
+  const searchParams: GetBlueprintsApiArg = {
+    limit: blueprintsLimit,
+    offset: blueprintsOffset,
+  };
+
+  if (blueprintSearchInput) {
+    searchParams.search = blueprintSearchInput;
+  }
+
+  const { blueprintName } = useGetBlueprintsQuery(searchParams, {
+    selectFromResult: ({ data }) => ({
+      blueprintName: data?.data?.find(
+        (blueprint: { id: string | undefined }) =>
+          blueprint.id === selectedBlueprintId
+      )?.name,
+    }),
+  });
   const [deleteBlueprint] = useDeleteBlueprintMutation({
     fixedCacheKey: 'delete-blueprint',
   });

--- a/src/Components/Blueprints/DeleteBlueprintModal.tsx
+++ b/src/Components/Blueprints/DeleteBlueprintModal.tsx
@@ -20,6 +20,7 @@ import {
   useDeleteBlueprintMutation,
   useGetBlueprintsQuery,
 } from '../../store/imageBuilderApi';
+import { PAGINATION_LIMIT, PAGINATION_OFFSET } from '../../constants';
 
 interface DeleteBlueprintModalProps {
   setShowDeleteModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -31,8 +32,8 @@ export const DeleteBlueprintModal: React.FunctionComponent<
 > = ({ setShowDeleteModal, isOpen }: DeleteBlueprintModalProps) => {
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
-  const blueprintsOffset = useAppSelector(selectOffset);
-  const blueprintsLimit = useAppSelector(selectLimit);
+  const blueprintsOffset = useAppSelector(selectOffset) || PAGINATION_OFFSET;
+  const blueprintsLimit = useAppSelector(selectLimit) || PAGINATION_LIMIT;
   const dispatch = useAppDispatch();
   const { blueprintName } = useGetBlueprintsQuery(
     {

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -102,7 +102,7 @@ export const CustomWizardFooter = ({
         ouiaId="wizard-back-btn"
         variant="secondary"
         onClick={goToPrevStep}
-        isDisabled={disableBack}
+        isDisabled={disableBack || false}
       >
         Back
       </Button>
@@ -252,7 +252,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
           step.isDisabled ||
           (isVisitRequired && !step.isVisited && !hasVisitedNextStep)
         }
-        isVisited={step.isVisited}
+        isVisited={step.isVisited || false}
         stepIndex={step.index}
         onClick={() => goToStepByIndex(step.index)}
         status={status}

--- a/src/Components/CreateImageWizard/ValidatedTextInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedTextInput.tsx
@@ -63,14 +63,14 @@ export const HookValidatedInput = ({
       <TextInput
         value={value}
         data-testid={dataTestId}
-        ouiaId={ouiaId}
+        ouiaId={ouiaId || ''}
         type={type}
-        onChange={onChange}
+        onChange={onChange!}
         validated={validated}
-        aria-label={ariaLabel}
+        aria-label={ariaLabel || ''}
         onBlur={handleBlur}
-        placeholder={placeholder}
-        isDisabled={isDisabled}
+        placeholder={placeholder || ''}
+        isDisabled={isDisabled || false}
       />
       {validated === 'error' && (
         <HelperText>
@@ -119,13 +119,13 @@ export const ValidatedTextInput = ({
       <TextInput
         value={value}
         data-testid={dataTestId}
-        ouiaId={ouiaId}
+        ouiaId={ouiaId || ''}
         type="text"
-        onChange={onChange}
+        onChange={onChange!}
         validated={handleValidation()}
-        aria-label={ariaLabel}
+        aria-label={ariaLabel || ''}
         onBlur={handleBlur}
-        placeholder={placeholder}
+        placeholder={placeholder || ''}
       />
       {!isPristine && !validator(value) && (
         <HelperText>

--- a/src/Components/CreateImageWizard/steps/FileSystem/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/FileSystemTable.tsx
@@ -260,7 +260,7 @@ const MinimumSize = ({ partition }: MinimumSizePropTypes) => {
       warning={
         partition.unit === 'B'
           ? 'The Wizard only supports KiB, MiB, or GiB. Adjust or keep the current value.'
-          : undefined
+          : ''
       }
       type="text"
       ouiaId="size"

--- a/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
@@ -62,7 +62,7 @@ const PackageRecommendations = () => {
       offset: 0,
     });
 
-  if (isSuccessDistroRepositories && distroRepositories.data) {
+  if (isSuccessDistroRepositories && distroRepositories?.data) {
     distroRepoUrls = distroRepositories.data.map((repo) => repo.url || '');
   }
 

--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -267,7 +267,7 @@ const Packages = () => {
         apiContentUnitSearchRequest: {
           search: debouncedSearchTerm,
           urls: distroRepositories
-            .filter((archItem) => {
+            ?.filter((archItem) => {
               return archItem.arch === arch;
             })[0]
             .repositories.flatMap((repo) => {
@@ -329,7 +329,7 @@ const Packages = () => {
         apiContentUnitSearchRequest: {
           search: debouncedSearchTerm.substr(1),
           urls: distroRepositories
-            .filter((archItem) => {
+            ?.filter((archItem) => {
               return archItem.arch === arch;
             })[0]
             .repositories.flatMap((repo) => {
@@ -348,7 +348,7 @@ const Packages = () => {
       searchCustomGroups({
         apiContentUnitSearchRequest: {
           search: debouncedSearchTerm.substr(1),
-          urls: customRepositories.flatMap((repo) => {
+          urls: customRepositories?.flatMap((repo) => {
             if (!repo.baseurl) {
               throw new Error(
                 `Repository (id: ${repo.id}, name: ${repo?.name}) is missing baseurl`
@@ -824,7 +824,7 @@ const Packages = () => {
     if (isSelecting) {
       if (
         isSuccessEpelRepo &&
-        epelRepo.data &&
+        epelRepo?.data &&
         pkg.repository === 'recommended' &&
         !recommendedRepositories.some((repo) => repo.name?.startsWith('EPEL'))
       ) {
@@ -837,7 +837,7 @@ const Packages = () => {
       dispatch(removePackage(pkg.name));
       if (
         isSuccessEpelRepo &&
-        epelRepo.data &&
+        epelRepo?.data &&
         packages.filter((pkg) => pkg.repository === 'recommended').length ===
           1 &&
         groups.filter((grp) => grp.repository === 'recommended').length === 0
@@ -855,7 +855,7 @@ const Packages = () => {
     if (isSelecting) {
       if (
         isSuccessEpelRepo &&
-        epelRepo.data &&
+        epelRepo?.data &&
         grp.repository === 'recommended' &&
         !recommendedRepositories.some((repo) => repo.name?.startsWith('EPEL'))
       ) {
@@ -868,7 +868,7 @@ const Packages = () => {
       dispatch(removeGroup(grp.name));
       if (
         isSuccessEpelRepo &&
-        epelRepo.data &&
+        epelRepo?.data &&
         groups.filter((grp) => grp.repository === 'recommended').length === 1 &&
         packages.filter((pkg) => pkg.repository === 'recommended').length === 0
       ) {

--- a/src/Components/CreateImageWizard/steps/Registration/ActivationKeyInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/ActivationKeyInformation.tsx
@@ -50,19 +50,19 @@ const ActivationKeyInformation = (): JSX.Element => {
               Role:
             </TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
-              {activationKeyInfo.body?.role || 'Not defined'}
+              {activationKeyInfo?.body?.role || 'Not defined'}
             </TextListItem>
             <TextListItem component={TextListItemVariants.dt}>
               SLA:
             </TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
-              {activationKeyInfo.body?.serviceLevel || 'Not defined'}
+              {activationKeyInfo?.body?.serviceLevel || 'Not defined'}
             </TextListItem>
             <TextListItem component={TextListItemVariants.dt}>
               Usage:
             </TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
-              {activationKeyInfo.body?.usage || 'Not defined'}
+              {activationKeyInfo?.body?.usage || 'Not defined'}
             </TextListItem>
             <TextListItem component={TextListItemVariants.dt}>
               Additional repositories:
@@ -90,8 +90,8 @@ const ActivationKeyInformation = (): JSX.Element => {
               component={TextListItemVariants.dd}
               className="pf-v5-u-display-flex pf-v5-u-align-items-flex-end"
             >
-              {activationKeyInfo.body?.additionalRepositories &&
-              activationKeyInfo.body?.additionalRepositories?.length > 0 ? (
+              {activationKeyInfo?.body?.additionalRepositories &&
+              activationKeyInfo?.body?.additionalRepositories?.length > 0 ? (
                 <Popover
                   position="right"
                   minWidth="30rem"

--- a/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
@@ -157,7 +157,7 @@ const ActivationKeysList = () => {
     const isActivationKeysEmpty =
       isSuccessActivationKeys &&
       !isLoadingActivationKey &&
-      activationKeys.body?.length === 0;
+      activationKeys?.body?.length === 0;
 
     const handleCreateActivationKey = async () => {
       try {
@@ -207,7 +207,7 @@ const ActivationKeysList = () => {
   const setSelectOptions = () => {
     const selectOptions = [];
     if (isSuccessActivationKeys) {
-      activationKeys.body?.map((key, index) =>
+      activationKeys?.body?.map((key, index) =>
         selectOptions.push(<SelectOption key={index} value={key.name} />)
       );
     }

--- a/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
@@ -133,7 +133,7 @@ const Repositories = () => {
       url:
         toggleSelected === 'toggle-group-selected'
           ? [...selected].join(',')
-          : undefined,
+          : '',
     },
     { refetchOnMountOrArgChange: 60 }
   );

--- a/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
@@ -30,7 +30,7 @@ import {
 import RepositoriesStatus from './RepositoriesStatus';
 import RepositoryUnavailable from './RepositoryUnavailable';
 
-import { ContentOrigin } from '../../../../constants';
+import { ContentOrigin, PAGINATION_COUNT } from '../../../../constants';
 import {
   ApiRepositoryResponseRead,
   useListRepositoriesQuery,
@@ -580,7 +580,7 @@ const Repositories = () => {
         </PanelMain>
       </Panel>
       <Pagination
-        itemCount={count}
+        itemCount={count ?? PAGINATION_COUNT}
         perPage={perPage}
         page={page}
         onSetPage={(_, newPage) => setPage(newPage)}

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -69,7 +69,7 @@ export const CreateSaveAndBuildBtn = ({
       <DropdownItem
         onClick={onSaveAndBuild}
         ouiaId="wizard-create-build-btn"
-        isDisabled={isDisabled}
+        isDisabled={isDisabled || true}
       >
         Create blueprint and build image(s)
       </DropdownItem>

--- a/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
@@ -50,7 +50,7 @@ export const EditSaveAndBuildBtn = ({
       <DropdownItem
         onClick={onSaveAndBuild}
         ouiaId="wizard-edit-build-btn"
-        isDisabled={isDisabled}
+        isDisabled={isDisabled || true}
       >
         Save changes and build image(s)
       </DropdownItem>

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
@@ -64,8 +64,8 @@ const RepoName = ({ repoUrl }: repoPropType) => {
         - query finished and the repo was found -> render the name of the repo
         - query finished, but the repo was not found -> render an error
       */}
-      {isSuccess && data.data?.[0]?.name && <p>{data.data?.[0].name}</p>}
-      {isSuccess && !data.data?.[0]?.name && errorLoading()}
+      {isSuccess && data?.data?.[0]?.name && <p>{data.data?.[0].name}</p>}
+      {isSuccess && !data?.data?.[0]?.name && errorLoading()}
       {isFetching && <Spinner size="md" />}
       {isError && errorLoading()}
     </>

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -346,7 +346,7 @@ export const TargetEnvAzureList = () => {
             </TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
               {
-                rawAzureSources.data?.find(
+                rawAzureSources?.data?.find(
                   (source) => source.id === azureSource
                 )?.name
               }

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Aws/AwsAccountId.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Aws/AwsAccountId.tsx
@@ -37,7 +37,7 @@ export const AwsAccountId = () => {
           readOnlyVariant="default"
           isRequired
           id="aws-account-id"
-          value={sourceId && data ? data.aws?.account_id : ''}
+          value={sourceId && data ? data.aws?.account_id ?? '' : ''}
           aria-label="aws account id"
         />
       </FormGroup>

--- a/src/Components/CreateImageWizard/types.ts
+++ b/src/Components/CreateImageWizard/types.ts
@@ -1,6 +1,6 @@
 // The Sources API only defines a V1ListSourceResponseItem[] type
 export type V1ListSourceResponseItem = {
-  id?: string;
+  id?: string | undefined;
   name?: string;
   source_type_id?: string;
   uid?: string;

--- a/src/Components/CreateImageWizard/utilities/checkRepositoriesAvailability.ts
+++ b/src/Components/CreateImageWizard/utilities/checkRepositoriesAvailability.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { ContentOrigin } from '../../../constants';
+import { ContentOrigin, PAGINATION_LIMIT } from '../../../constants';
 import { useListRepositoriesQuery } from '../../../store/contentSourcesApi';
 import { useAppSelector } from '../../../store/hooks';
 import {
@@ -41,7 +41,7 @@ export const useCheckRepositoriesAvailability = () => {
       availableForVersion: version,
       contentType: 'rpm',
       origin: ContentOrigin.EXTERNAL,
-      limit: firstRequest?.data?.meta?.count,
+      limit: firstRequest?.data?.meta?.count || PAGINATION_LIMIT,
       offset: 0,
     },
     {

--- a/src/Components/CreateImageWizard/utilities/checkRepositoriesAvailability.ts
+++ b/src/Components/CreateImageWizard/utilities/checkRepositoriesAvailability.ts
@@ -64,7 +64,7 @@ export const useCheckRepositoriesAvailability = () => {
     // Transform the fresh repos array into a Set to access its elements in O(1)
     // complexity later in the for loop.
     const freshReposUrls = new Set(
-      freshRepos.data?.map((freshRepo) => freshRepo.url)
+      freshRepos?.data?.map((freshRepo) => freshRepo.url)
     );
     for (const customRepo of customRepositories) {
       if (customRepo.baseurl && !freshReposUrls.has(customRepo.baseurl[0])) {

--- a/src/Components/ImagesTable/ClonesTable.tsx
+++ b/src/Components/ImagesTable/ClonesTable.tsx
@@ -107,7 +107,7 @@ const ComposeRow = ({ compose }: ComposeRowPropTypes) => {
   });
   return isSuccess ? (
     <Row
-      ami={<Ami status={data.image_status.upload_status} />}
+      ami={<Ami status={data?.image_status.upload_status} />}
       region={<ComposeRegion />}
       status={<AwsDetailsStatus compose={compose} />}
     />

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -116,7 +116,7 @@ const ImagesTable = () => {
       id: selectedBlueprintId as string,
       limit: perPage,
       offset: perPage * (page - 1),
-      blueprintVersion: useAppSelector(selectBlueprintVersionFilterAPI),
+      blueprintVersion: useAppSelector(selectBlueprintVersionFilterAPI) ?? 1,
     },
     { skip: !selectedBlueprintId }
   );
@@ -217,7 +217,9 @@ const ImagesTable = () => {
           <Tbody>
             <Tr>
               <Td colSpan={12}>
-                <ImagesEmptyState selectedBlueprint={selectedBlueprintId} />
+                <ImagesEmptyState
+                  selectedBlueprint={selectedBlueprintId || ''}
+                />
               </Td>
             </Tr>
           </Tbody>

--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -44,6 +44,9 @@ import { AwsTarget, Target } from './Target';
 import {
   AWS_S3_EXPIRATION_TIME_IN_HOURS,
   OCI_STORAGE_EXPIRATION_TIME_IN_DAYS,
+  PAGINATION_LIMIT,
+  PAGINATION_OFFSET,
+  SEARCH_INPUT,
   STATUS_POLLING_INTERVAL,
 } from '../../constants';
 import { useGetBlueprintsQuery } from '../../store/backendApi';
@@ -76,10 +79,11 @@ const ImagesTable = () => {
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(10);
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
-  const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
+  const blueprintSearchInput =
+    useAppSelector(selectBlueprintSearchInput) || SEARCH_INPUT;
   const blueprintVersionFilter = useAppSelector(selectBlueprintVersionFilter);
-  const blueprintsOffset = useAppSelector(selectOffset);
-  const blueprintsLimit = useAppSelector(selectLimit);
+  const blueprintsOffset = useAppSelector(selectOffset) || PAGINATION_OFFSET;
+  const blueprintsLimit = useAppSelector(selectLimit) || PAGINATION_LIMIT;
 
   const { selectedBlueprintVersion } = useGetBlueprintsQuery(
     {

--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -10,6 +10,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 
+import { SEARCH_INPUT } from '../../constants';
 import {
   selectSelectedBlueprintId,
   selectBlueprintSearchInput,
@@ -28,7 +29,6 @@ import BlueprintVersionFilter from '../Blueprints/BlueprintVersionFilter';
 import { BuildImagesButton } from '../Blueprints/BuildImagesButton';
 import { DeleteBlueprintModal } from '../Blueprints/DeleteBlueprintModal';
 import { EditBlueprintButton } from '../Blueprints/EditBlueprintButton';
-import { SEARCH_INPUT } from '../../constants';
 
 interface imagesTableToolbarProps {
   itemCount: number;

--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -28,6 +28,7 @@ import BlueprintVersionFilter from '../Blueprints/BlueprintVersionFilter';
 import { BuildImagesButton } from '../Blueprints/BuildImagesButton';
 import { DeleteBlueprintModal } from '../Blueprints/DeleteBlueprintModal';
 import { EditBlueprintButton } from '../Blueprints/EditBlueprintButton';
+import { SEARCH_INPUT } from '../../constants';
 
 interface imagesTableToolbarProps {
   itemCount: number;
@@ -47,7 +48,8 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDiffModal, setShowDiffModal] = useState(false);
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
-  const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
+  const blueprintSearchInput =
+    useAppSelector(selectBlueprintSearchInput) || SEARCH_INPUT;
 
   const {
     data: blueprintsComposes,

--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -60,7 +60,7 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
       id: selectedBlueprintId as string,
       limit: perPage,
       offset: perPage * (page - 1),
-      blueprintVersion: useAppSelector(selectBlueprintVersionFilterAPI),
+      blueprintVersion: useAppSelector(selectBlueprintVersionFilterAPI) ?? 1,
     },
     { skip: !selectedBlueprintId }
   );

--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -103,7 +103,7 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
   const isBlueprintDistroCentos8 = () => {
     if (isSuccessBlueprintsCompose) {
       return (
-        blueprintsComposes.data[0].request.distribution ===
+        blueprintsComposes?.data[0].request.distribution ===
         ('centos-8' as Distributions)
       );
     }

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -78,7 +78,7 @@ const DisabledProvisioningLink = () => {
 
 type ProvisioningLinkPropTypes = {
   compose: ComposesResponseItem;
-  composeStatus: ComposeStatus;
+  composeStatus: ComposeStatus | undefined;
 };
 
 const ProvisioningLink = ({

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -124,7 +124,7 @@ const ProvisioningLink = ({
   if (
     error ||
     !exposedScalprumModule ||
-    composeStatus.image_status.status !== 'success'
+    composeStatus?.image_status.status !== 'success'
   ) {
     return <DisabledProvisioningLink />;
   } else {
@@ -243,7 +243,7 @@ export const OciInstance = ({ compose, isExpired }: OciInstancePropTypes) => {
     return <Skeleton />;
   }
 
-  const options = data.image_status.upload_status?.options;
+  const options = data?.image_status.upload_status?.options;
 
   if (options && !isOciUploadStatus(options)) {
     throw TypeError(
@@ -375,8 +375,8 @@ export const AwsS3Instance = ({
     oci: '',
   };
 
-  const status = composeStatus.image_status.status;
-  const options = composeStatus.image_status.upload_status?.options;
+  const status = composeStatus?.image_status.status;
+  const options = composeStatus?.image_status.upload_status?.options;
 
   if (options && !isAwss3UploadStatus(options)) {
     throw TypeError(

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -21,7 +21,11 @@ import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome'
 import { useLoadModule, useScalprum } from '@scalprum/react-core';
 import { useNavigate } from 'react-router-dom';
 
-import { FILE_SYSTEM_CUSTOMIZATION_URL, MODAL_ANCHOR } from '../../constants';
+import {
+  FILE_SYSTEM_CUSTOMIZATION_URL,
+  MODAL_ANCHOR,
+  SEARCH_INPUT,
+} from '../../constants';
 import {
   selectSelectedBlueprintId,
   selectBlueprintSearchInput,
@@ -104,7 +108,8 @@ const ProvisioningLink = ({
   );
 
   const selectedBlueprintId = useAppSelector(selectSelectedBlueprintId);
-  const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);
+  const blueprintSearchInput =
+    useAppSelector(selectBlueprintSearchInput) || SEARCH_INPUT;
   const { selectedBlueprintVersion } = useGetBlueprintsQuery(
     { search: blueprintSearchInput },
     {

--- a/src/Components/ImagesTable/Status.tsx
+++ b/src/Components/ImagesTable/Status.tsx
@@ -78,7 +78,7 @@ export const AwsDetailsStatus = ({ compose }: ComposeStatusPropTypes) => {
     return <></>;
   }
 
-  switch (data.image_status.status) {
+  switch (data?.image_status.status) {
     case 'failure':
       return (
         <ErrorStatus
@@ -90,8 +90,8 @@ export const AwsDetailsStatus = ({ compose }: ComposeStatusPropTypes) => {
     default:
       return (
         <Status
-          icon={statuses[data.image_status.status].icon}
-          text={statuses[data.image_status.status].text}
+          icon={statuses[data!.image_status.status].icon}
+          text={statuses[data!.image_status.status].text}
         />
       );
   }
@@ -110,7 +110,7 @@ export const CloudStatus = ({ compose }: CloudStatusPropTypes) => {
     return <Skeleton />;
   }
 
-  switch (data.image_status.status) {
+  switch (data?.image_status.status) {
     case 'failure':
       return (
         <ErrorStatus
@@ -122,8 +122,8 @@ export const CloudStatus = ({ compose }: CloudStatusPropTypes) => {
     default:
       return (
         <Status
-          icon={statuses[data.image_status.status].icon}
-          text={statuses[data.image_status.status].text}
+          icon={statuses[data!.image_status.status].icon}
+          text={statuses[data!.image_status.status].text}
         />
       );
   }
@@ -172,7 +172,7 @@ export const ExpiringStatus = ({
     return <Skeleton />;
   }
 
-  const status = composeStatus.image_status.status;
+  const status = composeStatus!.image_status.status;
   const remainingHours = AWS_S3_EXPIRATION_TIME_IN_HOURS - timeToExpiration;
   const remainingDays = OCI_STORAGE_EXPIRATION_TIME_IN_DAYS - timeToExpiration;
 
@@ -205,7 +205,7 @@ export const ExpiringStatus = ({
       <ErrorStatus
         icon={statuses[status].icon}
         text={statuses[status].text}
-        error={composeStatus.image_status.error || ''}
+        error={composeStatus?.image_status.error || ''}
       />
     );
   } else {

--- a/src/Components/ImagesTable/Target.tsx
+++ b/src/Components/ImagesTable/Target.tsx
@@ -27,6 +27,6 @@ export const AwsTarget = ({ compose }: AwsTargetPropTypes) => {
     return <Skeleton />;
   }
 
-  const text = `${targetOptions.aws} (${data.data.length + 1})`;
+  const text = `${targetOptions.aws} (${data?.data?.length ?? 0 + 1})`;
   return <>{text}</>;
 };

--- a/src/Components/ShareImageModal/RegionsSelect.tsx
+++ b/src/Components/ShareImageModal/RegionsSelect.tsx
@@ -142,7 +142,7 @@ const RegionsSelect = ({ composeId, handleClose }: RegionsSelectPropTypes) => {
 
   const handleSubmit = async () => {
     setIsSaving(true);
-    const requests = generateRequests(composeId, composeStatus, selected);
+    const requests = generateRequests(composeId, composeStatus!, selected);
     await Promise.allSettled(requests.map((request) => cloneCompose(request)));
     navigate(resolveRelPath(''));
   };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -258,3 +258,8 @@ export enum ContentOrigin {
 }
 
 export const AMPLITUDE_MODULE_NAME = 'imageBuilder';
+
+export const PAGINATION_OFFSET = 0;
+export const PAGINATION_LIMIT = 10;
+export const PAGINATION_COUNT = 0;
+export const SEARCH_INPUT = '';

--- a/src/store/BlueprintSlice.ts
+++ b/src/store/BlueprintSlice.ts
@@ -6,7 +6,7 @@ export type versionFilterType = 'latest' | 'all';
 
 type blueprintsState = {
   selectedBlueprintId: string | undefined;
-  searchInput?: string;
+  searchInput?: string | undefined;
   offset?: number;
   limit?: number;
   versionFilter?: versionFilterType;

--- a/src/store/complianceApi.ts
+++ b/src/store/complianceApi.ts
@@ -29,11 +29,13 @@ const injectedRtkApi = api.injectEndpoints({
 });
 export { injectedRtkApi as complianceApi };
 export type PoliciesApiResponse = /** status 200 Lists Policies */ {
-  meta?: MetadataRead;
-  links?: LinksRead;
-  data?: {
-    schema?: PolicyRead;
-  }[];
+  meta?: MetadataRead | undefined;
+  links?: LinksRead | undefined;
+  data?:
+    | {
+        schema?: PolicyRead | undefined;
+      }[]
+    | undefined;
 };
 export type PoliciesApiArg = {
   /** For internal use only */
@@ -66,9 +68,11 @@ export type PoliciesApiArg = {
   filter?: string;
 };
 export type PolicyApiResponse = /** status 200 Returns a Policy */ {
-  data?: {
-    schema?: PolicyRead;
-  };
+  data?:
+    | {
+        schema?: PolicyRead | undefined;
+      }
+    | undefined;
 };
 export type PolicyApiArg = {
   /** For internal use only */
@@ -77,74 +81,74 @@ export type PolicyApiArg = {
 };
 export type Metadata = {
   /** Attribute and direction the items are sorted by */
-  sort_by?: string;
+  sort_by?: string | undefined;
   /** Query string used to filter items by their attributes */
-  filter?: string;
+  filter?: string | undefined;
 };
 export type MetadataRead = {
   /** Total number of items */
-  total?: number;
+  total?: number | undefined;
   /** Number of items returned per page */
-  limit?: number;
+  limit?: number | undefined;
   /** Offset of the first item of paginated response */
-  offset?: number;
+  offset?: number | undefined;
   /** Attribute and direction the items are sorted by */
-  sort_by?: string;
+  sort_by?: string | undefined;
   /** Query string used to filter items by their attributes */
-  filter?: string;
+  filter?: string | undefined;
 };
 export type Links = {};
 export type LinksRead = {
   /** Link to first page */
-  first?: string;
+  first?: string | undefined;
   /** Link to last page */
-  last?: string;
+  last?: string | undefined;
   /** Link to previous page */
-  previous?: string;
+  previous?: string | undefined;
   /** Link to next page */
-  next?: string;
+  next?: string | undefined;
 };
 export type Id = string;
 export type IdRead = string;
 export type Policy = {
-  id?: Id;
+  id?: Id | undefined;
   /** Short title of the Policy */
-  title?: string;
+  title?: string | undefined;
   /** Longer description of the Policy */
-  description?: string;
+  description?: string | undefined;
   /** The Business Objective associated to the Policy */
-  business_objective?: string;
+  business_objective?: string | undefined;
   /** The percentage above which the Policy meets compliance requirements */
   compliance_threshold: number;
 };
 export type PolicyRead = {
-  id?: IdRead;
-  type?: "policy";
+  id?: IdRead | undefined;
+  type?: "policy" | undefined;
   /** Short title of the Policy */
-  title?: string;
+  title?: string | undefined;
   /** Longer description of the Policy */
-  description?: string;
+  description?: string | undefined;
   /** The Business Objective associated to the Policy */
-  business_objective?: string;
+  business_objective?: string | undefined;
   /** The percentage above which the Policy meets compliance requirements */
   compliance_threshold: number;
   /** Major version of the Operating System that the Policy covers */
-  os_major_version?: number;
+  os_major_version?: number | undefined;
   /** Identificator of the Profile */
-  ref_id?: string;
+  ref_id?: string | undefined;
   /** Title of the associated Policy */
-  profile_title?: string;
+  profile_title?: string | undefined;
   /** The number of Systems assigned to this Policy */
-  total_system_count?: number;
+  total_system_count?: number | undefined;
 };
 export type PolicyWrite = {
-  id?: Id;
+  id?: Id | undefined;
   /** Short title of the Policy */
-  title?: string;
+  title?: string | undefined;
   /** Longer description of the Policy */
-  description?: string;
+  description?: string | undefined;
   /** The Business Objective associated to the Policy */
-  business_objective?: string;
+  business_objective?: string | undefined;
   /** The percentage above which the Policy meets compliance requirements */
   compliance_threshold: number;
   /** Identifier of the underlying Profile */

--- a/src/store/contentSourcesApi.ts
+++ b/src/store/contentSourcesApi.ts
@@ -156,307 +156,313 @@ export type ListSnapshotsByDateApiArg = {
 };
 export type ApiFeature = {
   /** Whether the current user can access the feature */
-  accessible?: boolean;
+  accessible?: boolean | undefined;
   /** Whether the feature is enabled on the running server */
-  enabled?: boolean;
+  enabled?: boolean | undefined;
 };
 export type ApiFeatureSet = {
   [key: string]: ApiFeature;
 };
 export type ApiSearchPackageGroupResponse = {
   /** Description of the package group found */
-  description?: string;
+  description?: string | undefined;
   /** Package group ID */
-  id?: string;
+  id?: string | undefined;
   /** Name of package group found */
-  package_group_name?: string;
+  package_group_name?: string | undefined;
   /** Package list of the package group found */
-  package_list?: string[];
+  package_list?: string[] | undefined;
 };
 export type ErrorsHandlerError = {
   /** An explanation specific to the problem */
-  detail?: string;
+  detail?: string | undefined;
   /** HTTP status code applicable to the error */
-  status?: number;
+  status?: number | undefined;
   /** A summary of the problem */
-  title?: string;
+  title?: string | undefined;
 };
 export type ErrorsErrorResponse = {
-  errors?: ErrorsHandlerError[];
+  errors?: ErrorsHandlerError[] | undefined;
 };
 export type ApiContentUnitSearchRequest = {
   /** List of names to search using an exact match */
-  exact_names?: string[];
+  exact_names?: string[] | undefined;
   /** Maximum number of records to return for the search */
-  limit?: number;
+  limit?: number | undefined;
   /** Search string to search content unit names */
-  search?: string;
+  search?: string | undefined;
   /** URLs of repositories to search */
-  urls?: string[];
+  urls?: string[] | undefined;
   /** List of repository UUIDs to search */
-  uuids?: string[];
+  uuids?: string[] | undefined;
 };
 export type ApiSnapshotResponse = {
   /** Count of each content type */
-  added_counts?: {
-    [key: string]: number;
-  };
+  added_counts?:
+    | {
+        [key: string]: number;
+      }
+    | undefined;
   /** Count of each content type */
-  content_counts?: {
-    [key: string]: number;
-  };
+  content_counts?:
+    | {
+        [key: string]: number;
+      }
+    | undefined;
   /** Datetime the snapshot was created */
-  created_at?: string;
+  created_at?: string | undefined;
   /** Count of each content type */
-  removed_counts?: {
-    [key: string]: number;
-  };
+  removed_counts?:
+    | {
+        [key: string]: number;
+      }
+    | undefined;
   /** Name of repository the snapshot belongs to */
-  repository_name?: string;
+  repository_name?: string | undefined;
   /** Path to repository snapshot contents */
-  repository_path?: string;
+  repository_path?: string | undefined;
   /** UUID of the repository the snapshot belongs to */
-  repository_uuid?: string;
+  repository_uuid?: string | undefined;
   /** URL to the snapshot's content */
-  url?: string;
-  uuid?: string;
+  url?: string | undefined;
+  uuid?: string | undefined;
 };
 export type ApiTaskInfoResponse = {
   /** Timestamp of task creation */
-  created_at?: string;
+  created_at?: string | undefined;
   /** UUIDs of parent tasks */
-  dependencies?: string[];
+  dependencies?: string[] | undefined;
   /** UUIDs of child tasks */
-  dependents?: string[];
+  dependents?: string[] | undefined;
   /** Timestamp task ended running at */
-  ended_at?: string;
+  ended_at?: string | undefined;
   /** Error thrown while running task */
-  error?: string;
+  error?: string | undefined;
   /** Name of the associated repository or template */
-  object_name?: string;
+  object_name?: string | undefined;
   /** Type of the associated object, either repository or template */
-  object_type?: string;
+  object_type?: string | undefined;
   /** UUID of the associated repository or template */
-  object_uuid?: string;
+  object_uuid?: string | undefined;
   /** Organization ID of the owner */
-  org_id?: string;
+  org_id?: string | undefined;
   /** Status of task (running, failed, completed, canceled, pending) */
-  status?: string;
+  status?: string | undefined;
   /** Type of task */
-  type?: string;
+  type?: string | undefined;
   /** UUID of the object */
-  uuid?: string;
+  uuid?: string | undefined;
 };
 export type ApiRepositoryResponse = {
   /** Content Type (rpm) of the repository */
-  content_type?: string;
+  content_type?: string | undefined;
   /** Architecture to restrict client usage to */
-  distribution_arch?: string;
+  distribution_arch?: string | undefined;
   /** Versions to restrict client usage to */
-  distribution_versions?: string[];
+  distribution_versions?: string[] | undefined;
   /** Number of consecutive failed introspections */
-  failed_introspections_count?: number;
+  failed_introspections_count?: number | undefined;
   /** GPG key for repository */
-  gpg_key?: string;
+  gpg_key?: string | undefined;
   /** Label used to configure the yum repository on clients */
-  label?: string;
+  label?: string | undefined;
   /** Error of last attempted introspection */
-  last_introspection_error?: string;
+  last_introspection_error?: string | undefined;
   /** Status of last introspection */
-  last_introspection_status?: string;
+  last_introspection_status?: string | undefined;
   /** Timestamp of last attempted introspection */
-  last_introspection_time?: string;
-  last_snapshot?: ApiSnapshotResponse;
-  last_snapshot_task?: ApiTaskInfoResponse;
+  last_introspection_time?: string | undefined;
+  last_snapshot?: ApiSnapshotResponse | undefined;
+  last_snapshot_task?: ApiTaskInfoResponse | undefined;
   /** UUID of the last snapshot task */
-  last_snapshot_task_uuid?: string;
+  last_snapshot_task_uuid?: string | undefined;
   /** UUID of the last dao.Snapshot */
-  last_snapshot_uuid?: string;
+  last_snapshot_uuid?: string | undefined;
   /** Timestamp of last successful introspection */
-  last_success_introspection_time?: string;
+  last_success_introspection_time?: string | undefined;
   /** Timestamp of last introspection that had updates */
-  last_update_introspection_time?: string;
+  last_update_introspection_time?: string | undefined;
   /** Latest URL for the snapshot distribution */
-  latest_snapshot_url?: string;
+  latest_snapshot_url?: string | undefined;
   /** Verify packages */
-  metadata_verification?: boolean;
+  metadata_verification?: boolean | undefined;
   /** Disable modularity filtering on this repository */
-  module_hotfixes?: boolean;
+  module_hotfixes?: boolean | undefined;
   /** Name of the remote yum repository */
-  name?: string;
+  name?: string | undefined;
   /** Origin of the repository */
-  origin?: string;
+  origin?: string | undefined;
   /** Number of packages last read in the repository */
-  package_count?: number;
+  package_count?: number | undefined;
   /** Enable snapshotting and hosting of this repository */
-  snapshot?: boolean;
+  snapshot?: boolean | undefined;
   /** Combined status of last introspection and snapshot of repository (Valid, Invalid, Unavailable, Pending) */
-  status?: string;
+  status?: string | undefined;
   /** URL of the remote yum repository */
-  url?: string;
+  url?: string | undefined;
 };
 export type ApiRepositoryResponseRead = {
   /** Account ID of the owner */
-  account_id?: string;
+  account_id?: string | undefined;
   /** Content Type (rpm) of the repository */
-  content_type?: string;
+  content_type?: string | undefined;
   /** Architecture to restrict client usage to */
-  distribution_arch?: string;
+  distribution_arch?: string | undefined;
   /** Versions to restrict client usage to */
-  distribution_versions?: string[];
+  distribution_versions?: string[] | undefined;
   /** Number of consecutive failed introspections */
-  failed_introspections_count?: number;
+  failed_introspections_count?: number | undefined;
   /** GPG key for repository */
-  gpg_key?: string;
+  gpg_key?: string | undefined;
   /** Label used to configure the yum repository on clients */
-  label?: string;
+  label?: string | undefined;
   /** Error of last attempted introspection */
-  last_introspection_error?: string;
+  last_introspection_error?: string | undefined;
   /** Status of last introspection */
-  last_introspection_status?: string;
+  last_introspection_status?: string | undefined;
   /** Timestamp of last attempted introspection */
-  last_introspection_time?: string;
-  last_snapshot?: ApiSnapshotResponse;
-  last_snapshot_task?: ApiTaskInfoResponse;
+  last_introspection_time?: string | undefined;
+  last_snapshot?: ApiSnapshotResponse | undefined;
+  last_snapshot_task?: ApiTaskInfoResponse | undefined;
   /** UUID of the last snapshot task */
-  last_snapshot_task_uuid?: string;
+  last_snapshot_task_uuid?: string | undefined;
   /** UUID of the last dao.Snapshot */
-  last_snapshot_uuid?: string;
+  last_snapshot_uuid?: string | undefined;
   /** Timestamp of last successful introspection */
-  last_success_introspection_time?: string;
+  last_success_introspection_time?: string | undefined;
   /** Timestamp of last introspection that had updates */
-  last_update_introspection_time?: string;
+  last_update_introspection_time?: string | undefined;
   /** Latest URL for the snapshot distribution */
-  latest_snapshot_url?: string;
+  latest_snapshot_url?: string | undefined;
   /** Verify packages */
-  metadata_verification?: boolean;
+  metadata_verification?: boolean | undefined;
   /** Disable modularity filtering on this repository */
-  module_hotfixes?: boolean;
+  module_hotfixes?: boolean | undefined;
   /** Name of the remote yum repository */
-  name?: string;
+  name?: string | undefined;
   /** Organization ID of the owner */
-  org_id?: string;
+  org_id?: string | undefined;
   /** Origin of the repository */
-  origin?: string;
+  origin?: string | undefined;
   /** Number of packages last read in the repository */
-  package_count?: number;
+  package_count?: number | undefined;
   /** Enable snapshotting and hosting of this repository */
-  snapshot?: boolean;
+  snapshot?: boolean | undefined;
   /** Combined status of last introspection and snapshot of repository (Valid, Invalid, Unavailable, Pending) */
-  status?: string;
+  status?: string | undefined;
   /** URL of the remote yum repository */
-  url?: string;
+  url?: string | undefined;
   /** UUID of the object */
-  uuid?: string;
+  uuid?: string | undefined;
 };
 export type ApiLinks = {
   /** Path to first page of results */
-  first?: string;
+  first?: string | undefined;
   /** Path to last page of results */
-  last?: string;
+  last?: string | undefined;
   /** Path to next page of results */
-  next?: string;
+  next?: string | undefined;
   /** Path to previous page of results */
-  prev?: string;
+  prev?: string | undefined;
 };
 export type ApiResponseMetadata = {
   /** Total count of results */
-  count?: number;
+  count?: number | undefined;
   /** Limit of results used for the request */
-  limit?: number;
+  limit?: number | undefined;
   /** Offset into results used for the request */
-  offset?: number;
+  offset?: number | undefined;
 };
 export type ApiRepositoryCollectionResponse = {
   /** Requested Data */
-  data?: ApiRepositoryResponse[];
-  links?: ApiLinks;
-  meta?: ApiResponseMetadata;
+  data?: ApiRepositoryResponse[] | undefined;
+  links?: ApiLinks | undefined;
+  meta?: ApiResponseMetadata | undefined;
 };
 export type ApiRepositoryCollectionResponseRead = {
   /** Requested Data */
-  data?: ApiRepositoryResponseRead[];
-  links?: ApiLinks;
-  meta?: ApiResponseMetadata;
+  data?: ApiRepositoryResponseRead[] | undefined;
+  links?: ApiLinks | undefined;
+  meta?: ApiResponseMetadata | undefined;
 };
 export type ApiRepositoryRequest = {
   /** Architecture to restrict client usage to */
-  distribution_arch?: string;
+  distribution_arch?: string | undefined;
   /** Versions to restrict client usage to */
-  distribution_versions?: string[];
+  distribution_versions?: string[] | undefined;
   /** GPG key for repository */
-  gpg_key?: string;
+  gpg_key?: string | undefined;
   /** Verify packages */
-  metadata_verification?: boolean;
+  metadata_verification?: boolean | undefined;
   /** Disable modularity filtering on this repository */
-  module_hotfixes?: boolean;
+  module_hotfixes?: boolean | undefined;
   /** Name of the remote yum repository */
   name: string;
   /** Enable snapshotting and hosting of this repository */
-  snapshot?: boolean;
+  snapshot?: boolean | undefined;
   /** URL of the remote yum repository */
-  url?: string;
+  url?: string | undefined;
 };
 export type ApiRepositoryRequestRead = {
   /** Architecture to restrict client usage to */
-  distribution_arch?: string;
+  distribution_arch?: string | undefined;
   /** Versions to restrict client usage to */
-  distribution_versions?: string[];
+  distribution_versions?: string[] | undefined;
   /** GPG key for repository */
-  gpg_key?: string;
+  gpg_key?: string | undefined;
   /** Verify packages */
-  metadata_verification?: boolean;
+  metadata_verification?: boolean | undefined;
   /** Disable modularity filtering on this repository */
-  module_hotfixes?: boolean;
+  module_hotfixes?: boolean | undefined;
   /** Name of the remote yum repository */
   name: string;
   /** Origin of the repository */
-  origin?: string;
+  origin?: string | undefined;
   /** Enable snapshotting and hosting of this repository */
-  snapshot?: boolean;
+  snapshot?: boolean | undefined;
   /** URL of the remote yum repository */
-  url?: string;
+  url?: string | undefined;
 };
 export type ApiRepositoryRpm = {
   /** The architecture of the rpm */
-  arch?: string;
+  arch?: string | undefined;
   /** The checksum of the rpm */
-  checksum?: string;
+  checksum?: string | undefined;
   /** The epoch of the rpm */
-  epoch?: number;
+  epoch?: number | undefined;
   /** The rpm package name */
-  name?: string;
+  name?: string | undefined;
   /** The release of the rpm */
-  release?: string;
+  release?: string | undefined;
   /** The summary of the rpm */
-  summary?: string;
+  summary?: string | undefined;
   /** Identifier of the rpm */
-  uuid?: string;
+  uuid?: string | undefined;
   /** The version of the  rpm */
-  version?: string;
+  version?: string | undefined;
 };
 export type ApiRepositoryRpmCollectionResponse = {
   /** List of rpms */
-  data?: ApiRepositoryRpm[];
-  links?: ApiLinks;
-  meta?: ApiResponseMetadata;
+  data?: ApiRepositoryRpm[] | undefined;
+  links?: ApiLinks | undefined;
+  meta?: ApiResponseMetadata | undefined;
 };
 export type ApiSearchRpmResponse = {
   /** Package name found */
-  package_name?: string;
+  package_name?: string | undefined;
   /** Summary of the package found */
-  summary?: string;
+  summary?: string | undefined;
 };
 export type ApiSnapshotForDate = {
   /** Is the snapshot after the specified date */
-  is_after?: boolean;
-  match?: ApiSnapshotResponse;
+  is_after?: boolean | undefined;
+  match?: ApiSnapshotResponse | undefined;
   /** Repository uuid for associated snapshot */
-  repository_uuid?: string;
+  repository_uuid?: string | undefined;
 };
 export type ApiListSnapshotByDateResponse = {
   /** Requested Data */
-  data?: ApiSnapshotForDate[];
+  data?: ApiSnapshotForDate[] | undefined;
 };
 export type ApiListSnapshotByDateRequest = {
   /** Exact date to search by. */

--- a/src/store/edgeApi.ts
+++ b/src/store/edgeApi.ts
@@ -298,258 +298,258 @@ export type GetImageByOstreeApiArg = {
   ostreeCommitHash: string;
 };
 export type ModelsEdgeApiTime = {
-  time?: string;
+  time?: string | undefined;
   /** Valid is true if Time is not NULL */
-  valid?: boolean;
+  valid?: boolean | undefined;
 };
 export type GormDeletedAt = {
-  time?: string;
+  time?: string | undefined;
   /** Valid is true if Time is not NULL */
-  valid?: boolean;
+  valid?: boolean | undefined;
 };
 export type ModelsInstalledPackage = {
-  CreatedAt?: ModelsEdgeApiTime;
-  DeletedAt?: GormDeletedAt;
-  ID?: number;
-  UpdatedAt?: ModelsEdgeApiTime;
-  arch?: string;
-  commits?: ModelsCommit[];
-  epoch?: string;
-  name?: string;
-  release?: string;
-  sigmd5?: string;
-  signature?: string;
-  type?: string;
-  version?: string;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  DeletedAt?: GormDeletedAt | undefined;
+  ID?: number | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
+  arch?: string | undefined;
+  commits?: ModelsCommit[] | undefined;
+  epoch?: string | undefined;
+  name?: string | undefined;
+  release?: string | undefined;
+  sigmd5?: string | undefined;
+  signature?: string | undefined;
+  type?: string | undefined;
+  version?: string | undefined;
 };
 export type ModelsRepo = {
-  CreatedAt?: ModelsEdgeApiTime;
-  DeletedAt?: GormDeletedAt;
-  ID?: number;
-  RepoStatus?: string;
-  RepoURL?: string;
-  UpdatedAt?: ModelsEdgeApiTime;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  DeletedAt?: GormDeletedAt | undefined;
+  ID?: number | undefined;
+  RepoStatus?: string | undefined;
+  RepoURL?: string | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
 };
 export type ModelsCommit = {
-  Account?: string;
-  Arch?: string;
-  BlueprintToml?: string;
-  BuildDate?: string;
-  BuildNumber?: number;
-  ChangesRefs?: boolean;
-  ComposeJobID?: string;
-  CreatedAt?: ModelsEdgeApiTime;
-  DeletedAt?: GormDeletedAt;
-  ID?: number;
-  ImageBuildHash?: string;
-  ImageBuildParentHash?: string;
-  ImageBuildTarURL?: string;
-  InstalledPackages?: ModelsInstalledPackage[];
-  OSTreeCommit?: string;
-  OSTreeParentCommit?: string;
-  OSTreeParentRef?: string;
-  OSTreeRef?: string;
-  Repo?: ModelsRepo;
-  RepoID?: number;
-  Status?: string;
-  UpdatedAt?: ModelsEdgeApiTime;
-  external?: boolean;
-  name?: string;
-  org_id?: string;
+  Account?: string | undefined;
+  Arch?: string | undefined;
+  BlueprintToml?: string | undefined;
+  BuildDate?: string | undefined;
+  BuildNumber?: number | undefined;
+  ChangesRefs?: boolean | undefined;
+  ComposeJobID?: string | undefined;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  DeletedAt?: GormDeletedAt | undefined;
+  ID?: number | undefined;
+  ImageBuildHash?: string | undefined;
+  ImageBuildParentHash?: string | undefined;
+  ImageBuildTarURL?: string | undefined;
+  InstalledPackages?: ModelsInstalledPackage[] | undefined;
+  OSTreeCommit?: string | undefined;
+  OSTreeParentCommit?: string | undefined;
+  OSTreeParentRef?: string | undefined;
+  OSTreeRef?: string | undefined;
+  Repo?: ModelsRepo | undefined;
+  RepoID?: number | undefined;
+  Status?: string | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
+  external?: boolean | undefined;
+  name?: string | undefined;
+  org_id?: string | undefined;
 };
 export type ModelsPackage = {
-  CreatedAt?: ModelsEdgeApiTime;
-  DeletedAt?: GormDeletedAt;
-  ID?: number;
-  Name?: string;
-  UpdatedAt?: ModelsEdgeApiTime;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  DeletedAt?: GormDeletedAt | undefined;
+  ID?: number | undefined;
+  Name?: string | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
 };
 export type ModelsInstaller = {
-  Account?: string;
-  Checksum?: string;
-  ComposeJobID?: string;
-  CreatedAt?: ModelsEdgeApiTime;
-  DeletedAt?: GormDeletedAt;
-  ID?: number;
-  ImageBuildISOURL?: string;
-  SshKey?: string;
-  Status?: string;
-  UpdatedAt?: ModelsEdgeApiTime;
-  Username?: string;
-  org_id?: string;
+  Account?: string | undefined;
+  Checksum?: string | undefined;
+  ComposeJobID?: string | undefined;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  DeletedAt?: GormDeletedAt | undefined;
+  ID?: number | undefined;
+  ImageBuildISOURL?: string | undefined;
+  SshKey?: string | undefined;
+  Status?: string | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
+  Username?: string | undefined;
+  org_id?: string | undefined;
 };
 export type ModelsThirdPartyRepo = {
-  CreatedAt?: ModelsEdgeApiTime;
-  DeletedAt?: GormDeletedAt;
-  Description?: string;
-  ID?: number;
-  Images?: ModelsImage[];
-  Name?: string;
-  URL?: string;
-  UpdatedAt?: ModelsEdgeApiTime;
-  account?: string;
-  distribution_arch?: string;
-  distribution_version?: string[];
-  gpg_key?: string;
-  org_id?: string;
-  package_count?: number;
-  uuid?: string;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  DeletedAt?: GormDeletedAt | undefined;
+  Description?: string | undefined;
+  ID?: number | undefined;
+  Images?: ModelsImage[] | undefined;
+  Name?: string | undefined;
+  URL?: string | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
+  account?: string | undefined;
+  distribution_arch?: string | undefined;
+  distribution_version?: string[] | undefined;
+  gpg_key?: string | undefined;
+  org_id?: string | undefined;
+  package_count?: number | undefined;
+  uuid?: string | undefined;
 };
 export type ModelsImage = {
-  Account?: string;
-  Commit?: ModelsCommit;
-  CommitID?: number;
-  CreatedAt?: ModelsEdgeApiTime;
-  CustomPackages?: ModelsPackage[];
-  DeletedAt?: GormDeletedAt;
-  Description?: string;
-  Distribution?: string;
-  ID?: number;
+  Account?: string | undefined;
+  Commit?: ModelsCommit | undefined;
+  CommitID?: number | undefined;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  CustomPackages?: ModelsPackage[] | undefined;
+  DeletedAt?: GormDeletedAt | undefined;
+  Description?: string | undefined;
+  Distribution?: string | undefined;
+  ID?: number | undefined;
   /** TODO: Wipe staging database and set to not nullable */
-  ImageSetID?: number;
+  ImageSetID?: number | undefined;
   /** TODO: Remove as soon as the frontend stops using */
-  ImageType?: string;
-  Installer?: ModelsInstaller;
-  InstallerID?: number;
-  Name?: string;
-  OutputTypes?: string[];
-  Packages?: ModelsPackage[];
-  Status?: string;
+  ImageType?: string | undefined;
+  Installer?: ModelsInstaller | undefined;
+  InstallerID?: number | undefined;
+  Name?: string | undefined;
+  OutputTypes?: string[] | undefined;
+  Packages?: ModelsPackage[] | undefined;
+  Status?: string | undefined;
   /** only for forms */
-  SystemsRunning?: number;
-  ThirdPartyRepositories?: ModelsThirdPartyRepo[];
+  SystemsRunning?: number | undefined;
+  ThirdPartyRepositories?: ModelsThirdPartyRepo[] | undefined;
   /** only for forms */
-  TotalPackages?: number;
-  UpdatedAt?: ModelsEdgeApiTime;
-  Version?: number;
-  org_id?: string;
+  TotalPackages?: number | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
+  Version?: number | undefined;
+  org_id?: string | undefined;
   /** storing for logging reference on resume */
-  request_id?: string;
+  request_id?: string | undefined;
 };
 export type ModelsImageSetApi = {
-  CreatedAt?: ModelsEdgeApiTime;
-  DeletedAt?: GormDeletedAt;
-  ID?: number;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  DeletedAt?: GormDeletedAt | undefined;
+  ID?: number | undefined;
   /** images of image set */
-  Images?: ModelsImage[];
-  UpdatedAt?: ModelsEdgeApiTime;
+  Images?: ModelsImage[] | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
   /** the image set name */
-  name?: string;
+  name?: string | undefined;
   /** the image set version */
-  version?: number;
+  version?: number | undefined;
 };
 export type ModelsImageSetInstallerUrlapi = {
   /** The image-set latest available image ISO */
-  image_build_iso_url?: string;
+  image_build_iso_url?: string | undefined;
   /** image set data */
-  image_set?: ModelsImageSetApi;
+  image_set?: ModelsImageSetApi | undefined;
 };
 export type ModelsImageSetsResponseApi = {
   /** count of image-sets */
-  Count?: number;
+  Count?: number | undefined;
   /** all data of image-sets */
-  Data?: ModelsImageSetInstallerUrlapi[];
+  Data?: ModelsImageSetInstallerUrlapi[] | undefined;
 };
 export type ErrorsBadRequest = {
-  Code?: string;
-  Status?: number;
-  Title?: string;
+  Code?: string | undefined;
+  Status?: number | undefined;
+  Title?: string | undefined;
 };
 export type ErrorsNotFound = {
-  Code?: string;
-  Status?: number;
-  Title?: string;
+  Code?: string | undefined;
+  Status?: number | undefined;
+  Title?: string | undefined;
 };
 export type ErrorsInternalServerError = {
-  Code?: string;
-  Status?: number;
-  Title?: string;
+  Code?: string | undefined;
+  Status?: number | undefined;
+  Title?: string | undefined;
 };
 export type ModelsImageSetView = {
-  Distribution?: string;
-  ID?: number;
-  ImageBuildIsoURL?: string;
-  ImageID?: number;
-  Name?: string;
-  OutputTypes?: string[];
-  Status?: string;
-  UpdatedAt?: ModelsEdgeApiTime;
-  Version?: number;
+  Distribution?: string | undefined;
+  ID?: number | undefined;
+  ImageBuildIsoURL?: string | undefined;
+  ImageID?: number | undefined;
+  Name?: string | undefined;
+  OutputTypes?: string[] | undefined;
+  Status?: string | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
+  Version?: number | undefined;
 };
 export type ModelsImageSetsViewResponseApi = {
   /** count of image-sets */
-  count?: number;
+  count?: number | undefined;
   /** data of image set view */
-  data?: ModelsImageSetView[];
+  data?: ModelsImageSetView[] | undefined;
 };
 export type ModelsImageDetailApi = {
   /** Number of additional packages */
-  additional_packages?: number;
-  image?: ModelsImage;
+  additional_packages?: number | undefined;
+  image?: ModelsImage | undefined;
   /** Number of packages */
-  packages?: number;
+  packages?: number | undefined;
   /** Number of added update */
-  update_added?: number;
+  update_added?: number | undefined;
   /** Number of removed update */
-  update_removed?: number;
+  update_removed?: number | undefined;
   /** Number of updated update */
-  update_updated?: number;
+  update_updated?: number | undefined;
 };
 export type ModelsImageSetImageIdViewApi = {
   /** The image-set latest available image ISO */
-  ImageBuildIsoURL?: string;
+  ImageBuildIsoURL?: string | undefined;
   /** the requested image details */
-  ImageDetails?: ModelsImageDetailApi;
+  ImageDetails?: ModelsImageDetailApi | undefined;
   /** image set data */
-  ImageSet?: ModelsImageSetApi;
+  ImageSet?: ModelsImageSetApi | undefined;
 };
 export type ModelsImageView = {
-  CommitCheckSum?: string;
-  CreatedAt?: ModelsEdgeApiTime;
-  ID?: number;
-  ImageBuildIsoURL?: string;
-  ImageType?: string;
-  Name?: string;
-  OutputTypes?: string[];
-  Status?: string;
-  Version?: number;
+  CommitCheckSum?: string | undefined;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  ID?: number | undefined;
+  ImageBuildIsoURL?: string | undefined;
+  ImageType?: string | undefined;
+  Name?: string | undefined;
+  OutputTypes?: string[] | undefined;
+  Status?: string | undefined;
+  Version?: number | undefined;
 };
 export type ModelsImagesViewDataApi = {
   /** total number of image view data */
-  count?: number;
-  data?: ModelsImageView[];
+  count?: number | undefined;
+  data?: ModelsImageView[] | undefined;
 };
 export type ModelsSuccessPlaceholderResponse = object;
 export type ImageResponse = {
-  Account?: string;
-  Commit?: ModelsCommit;
-  CommitID?: number;
-  CreatedAt?: ModelsEdgeApiTime;
-  CustomPackages?: ModelsPackage[];
-  DeletedAt?: GormDeletedAt;
-  Description?: string;
-  Distribution?: string;
-  ID?: number;
+  Account?: string | undefined;
+  Commit?: ModelsCommit | undefined;
+  CommitID?: number | undefined;
+  CreatedAt?: ModelsEdgeApiTime | undefined;
+  CustomPackages?: ModelsPackage[] | undefined;
+  DeletedAt?: GormDeletedAt | undefined;
+  Description?: string | undefined;
+  Distribution?: string | undefined;
+  ID?: number | undefined;
   /** TODO: Wipe staging database and set to not nullable */
-  ImageSetID?: number;
+  ImageSetID?: number | undefined;
   /** TODO: Remove as soon as the frontend stops using */
-  ImageType?: string;
-  Installer?: ModelsInstaller;
-  InstallerID?: number;
-  Name?: string;
-  OutputTypes?: string[];
-  Packages?: ModelsPackage[];
-  Status?: string;
+  ImageType?: string | undefined;
+  Installer?: ModelsInstaller | undefined;
+  InstallerID?: number | undefined;
+  Name?: string | undefined;
+  OutputTypes?: string[] | undefined;
+  Packages?: ModelsPackage[] | undefined;
+  Status?: string | undefined;
   /** only for forms */
-  SystemsRunning?: number;
-  ThirdPartyRepositories?: ModelsThirdPartyRepo[];
+  SystemsRunning?: number | undefined;
+  ThirdPartyRepositories?: ModelsThirdPartyRepo[] | undefined;
   /** only for forms */
-  TotalPackages?: number;
-  UpdatedAt?: ModelsEdgeApiTime;
-  Version?: number;
-  org_id?: string;
+  TotalPackages?: number | undefined;
+  UpdatedAt?: ModelsEdgeApiTime | undefined;
+  Version?: number | undefined;
+  org_id?: string | undefined;
   /** storing for logging reference on resume */
-  request_id?: string;
+  request_id?: string | undefined;
 };
 export type CreateImage = object;
 export const {

--- a/src/store/imageBuilderApi.ts
+++ b/src/store/imageBuilderApi.ts
@@ -235,7 +235,7 @@ export type ComposeBlueprintApiArg = {
   id: string;
   /** list of target image types that the user wants to build for this compose */
   body: {
-    image_types?: ImageTypes[];
+    image_types?: ImageTypes[] | undefined;
   };
 };
 export type GetBlueprintComposesApiResponse =
@@ -337,16 +337,16 @@ export type RecommendPackageApiArg = {
 };
 export type Repository = {
   rhsm: boolean;
-  baseurl?: string;
-  mirrorlist?: string;
-  metalink?: string;
-  gpgkey?: string;
-  check_gpg?: boolean;
+  baseurl?: string | undefined;
+  mirrorlist?: string | undefined;
+  metalink?: string | undefined;
+  gpgkey?: string | undefined;
+  check_gpg?: boolean | undefined;
   /** Enables gpg verification of the repository metadata
    */
-  check_repo_gpg?: boolean;
-  ignore_ssl?: boolean;
-  module_hotfixes?: boolean;
+  check_repo_gpg?: boolean | undefined;
+  ignore_ssl?: boolean | undefined;
+  module_hotfixes?: boolean | undefined;
 };
 export type ArchitectureItem = {
   arch: string;
@@ -435,8 +435,8 @@ export type UploadTypes =
   | "aws.s3"
   | "oci.objectstorage";
 export type AwsUploadRequestOptions = {
-  share_with_accounts?: string[];
-  share_with_sources?: string[];
+  share_with_accounts?: string[] | undefined;
+  share_with_sources?: string[] | undefined;
 };
 export type Awss3UploadRequestOptions = object;
 export type GcpUploadRequestOptions = {
@@ -453,23 +453,23 @@ export type GcpUploadRequestOptions = {
         If not specified, the imported Compute Node image is not shared with any
         account.
      */
-  share_with_accounts?: string[];
+  share_with_accounts?: string[] | undefined;
 };
 export type AzureUploadRequestOptions = {
   /** ID of the source that will be used to resolve the tenant and subscription IDs.
     Do not provide a tenant_id or subscription_id when providing a source_id.
      */
-  source_id?: string;
+  source_id?: string | undefined;
   /** ID of the tenant where the image should be uploaded. This link explains how
     to find it in the Azure Portal:
     https://docs.microsoft.com/en-us/azure/active-directory/fundamentals/active-directory-how-to-find-tenant
     When providing a tenant_id, also be sure to provide a subscription_id and do not include a source_id.
      */
-  tenant_id?: string;
+  tenant_id?: string | undefined;
   /** ID of subscription where the image should be uploaded.
     When providing a subscription_id, also be sure to provide a tenant_id and do not include a source_id.
      */
-  subscription_id?: string;
+  subscription_id?: string | undefined;
   /** Name of the resource group where the image should be uploaded.
    */
   resource_group: string;
@@ -477,11 +477,11 @@ export type AzureUploadRequestOptions = {
     Must begin with a letter or number, end with a letter, number or underscore, and may contain only letters, numbers, underscores, periods, or hyphens.
     The total length is limited to 60 characters.
      */
-  image_name?: string;
+  image_name?: string | undefined;
   /** Choose the VM Image HyperV generation, different features on Azure are available
     depending on the HyperV generation.
      */
-  hyper_v_generation?: "V1" | "V2";
+  hyper_v_generation?: ("V1" | "V2") | undefined;
 };
 export type OciUploadRequestOptions = object;
 export type UploadRequest = {
@@ -494,20 +494,20 @@ export type UploadRequest = {
     | OciUploadRequestOptions;
 };
 export type OsTree = {
-  url?: string;
+  url?: string | undefined;
   /** A URL which, if set, is used for fetching content. Implies that `url` is set as well,
     which will be used for metadata only.
      */
-  contenturl?: string;
-  ref?: string;
+  contenturl?: string | undefined;
+  ref?: string | undefined;
   /** Can be either a commit (example: 02604b2da6e954bd34b8b82a835e5a77d2b60ffa), or a branch-like reference (example: rhel/8/x86_64/edge)
    */
-  parent?: string;
+  parent?: string | undefined;
   /** Determines whether a valid subscription manager (candlepin) identity is required to
     access this repository. Consumer certificates will be used as client certificates when
     fetching metadata and content.
      */
-  rhsm?: boolean;
+  rhsm?: boolean | undefined;
 };
 export type ImageRequest = {
   /** CPU architecture of the image, x86_64 and aarch64 are currently supported.
@@ -515,54 +515,54 @@ export type ImageRequest = {
   architecture: "x86_64" | "aarch64";
   image_type: ImageTypes;
   upload_request: UploadRequest;
-  ostree?: OsTree;
+  ostree?: OsTree | undefined;
   /** Size of image, in bytes. When set to 0 the image size is a minimum
     defined by the image type.
      */
-  size?: any;
+  size?: any | undefined;
   /** Snapshotted content will be used instead of the official repositories of the
     distribution. The snapshot that was made closest to, but before the specified date will
     be used. If no snapshots made before the specified date can be found, the snapshot
     closest to, but after the specified date will be used. If no snapshots can be found at
     all, the request will fail. The format must be YYYY-MM-DD (ISO 8601 extended).
      */
-  snapshot_date?: string;
+  snapshot_date?: string | undefined;
 };
 export type Container = {
   /** Reference to the container to embed */
   source: string;
   /** Name to use for the container from the image */
-  name?: string;
+  name?: string | undefined;
   /** Control TLS verifification */
-  tls_verify?: boolean;
+  tls_verify?: boolean | undefined;
 };
 export type Directory = {
   /** Path to the directory */
   path: string;
   /** Permissions string for the directory in octal format */
-  mode?: string;
+  mode?: string | undefined;
   /** Owner of the directory as a user name or a uid */
-  user?: string | number;
+  user?: (string | number) | undefined;
   /** Group of the directory as a group name or a gid */
-  group?: string | number;
+  group?: (string | number) | undefined;
   /** Ensure that the parent directories exist */
-  ensure_parents?: boolean;
+  ensure_parents?: boolean | undefined;
 };
 export type File = {
   /** Path to the file */
   path: string;
   /** Permissions string for the file in octal format */
-  mode?: string;
+  mode?: string | undefined;
   /** Owner of the file as a uid or a user name */
-  user?: string | number;
+  user?: (string | number) | undefined;
   /** Group of the file as a gid or a group name */
-  group?: string | number;
+  group?: (string | number) | undefined;
   /** Contents of the file as plain text */
-  data?: string;
+  data?: string | undefined;
   /** When data is base64-encoded to prevent Akamai content filter false positives */
-  data_encoding?: "plain" | "base64";
+  data_encoding?: ("plain" | "base64") | undefined;
   /** Ensure that the parent directories exist */
-  ensure_parents?: boolean;
+  ensure_parents?: boolean | undefined;
 };
 export type Subscription = {
   organization: number;
@@ -572,32 +572,32 @@ export type Subscription = {
   insights: boolean;
   /** Optional flag to use rhc to register the system, which also always enables Insights.
    */
-  rhc?: boolean;
+  rhc?: boolean | undefined;
 };
 export type CustomRepository = {
   id: string;
-  name?: string;
-  filename?: string;
-  baseurl?: string[];
-  mirrorlist?: string;
-  metalink?: string;
+  name?: string | undefined;
+  filename?: string | undefined;
+  baseurl?: string[] | undefined;
+  mirrorlist?: string | undefined;
+  metalink?: string | undefined;
   /** GPG key used to sign packages in this repository. Can be a gpg key or a URL */
-  gpgkey?: string[];
-  check_gpg?: boolean;
-  check_repo_gpg?: boolean;
-  enabled?: boolean;
-  priority?: number;
-  ssl_verify?: boolean;
-  module_hotfixes?: boolean;
+  gpgkey?: string[] | undefined;
+  check_gpg?: boolean | undefined;
+  check_repo_gpg?: boolean | undefined;
+  enabled?: boolean | undefined;
+  priority?: number | undefined;
+  ssl_verify?: boolean | undefined;
+  module_hotfixes?: boolean | undefined;
 };
 export type OpenScapProfile = {
   /** Uses the OpenSCAP tooling directly to apply a pre-defined profile without tailorings.
    */
   profile_id: string;
   /** The profile type */
-  profile_name?: string;
+  profile_name?: string | undefined;
   /** The longform profile description */
-  profile_description?: string;
+  profile_description?: string | undefined;
 };
 export type OpenScapCompliance = {
   /** Apply a compliance policy which is defined in the Red Hat Insights Compliance
@@ -617,63 +617,65 @@ export type User = {
   /** List of groups to add the user to. The 'wheel' group should be added explicitly, as the
     default value is empty.
      */
-  groups?: string[];
-  ssh_key?: string;
+  groups?: string[] | undefined;
+  ssh_key?: string | undefined;
   /** Plaintext passwords are also supported, they will be hashed and stored using the SHA-512 algorithm.
     The password is never returned in the response.
     Empty string can be used to remove the password during update but only with ssh_key set.
      */
-  password?: string;
+  password?: string | undefined;
 };
 export type Services = {
   /** List of services to enable by default */
-  enabled?: string[];
+  enabled?: string[] | undefined;
   /** List of services to disable by default */
-  disabled?: string[];
+  disabled?: string[] | undefined;
   /** List of services to mask by default */
-  masked?: string[];
+  masked?: string[] | undefined;
 };
 export type Kernel = {
   /** Name of the kernel to use */
-  name?: string;
+  name?: string | undefined;
   /** Appends arguments to the bootloader kernel command line */
-  append?: string;
+  append?: string | undefined;
 };
 export type Group = {
   /** Name of the group to create */
   name: string;
   /** Group id of the group to create (optional) */
-  gid?: number;
+  gid?: number | undefined;
 };
 export type Timezone = {
   /** Name of the timezone, defaults to UTC */
-  timezone?: string;
+  timezone?: string | undefined;
   /** List of ntp servers */
-  ntpservers?: string[];
+  ntpservers?: string[] | undefined;
 };
 export type Locale = {
   /** List of locales to be installed, the first one becomes primary, subsequent ones are secondary
    */
-  languages?: string[];
+  languages?: string[] | undefined;
   /** Sets the keyboard layout */
-  keyboard?: string;
+  keyboard?: string | undefined;
 };
 export type FirewallCustomization = {
   /** List of ports (or port ranges) and protocols to open */
-  ports?: string[];
+  ports?: string[] | undefined;
   /** Firewalld services to enable or disable */
-  services?: {
-    /** List of services to enable */
-    enabled?: string[];
-    /** List of services to disable */
-    disabled?: string[];
-  };
+  services?:
+    | {
+        /** List of services to enable */
+        enabled?: string[] | undefined;
+        /** List of services to disable */
+        disabled?: string[] | undefined;
+      }
+    | undefined;
 };
 export type Fdo = {
-  manufacturing_server_url?: string;
-  diun_pub_key_insecure?: string;
-  diun_pub_key_hash?: string;
-  diun_pub_key_root_certs?: string;
+  manufacturing_server_url?: string | undefined;
+  diun_pub_key_insecure?: string | undefined;
+  diun_pub_key_hash?: string | undefined;
+  diun_pub_key_root_certs?: string | undefined;
 };
 export type IgnitionEmbedded = {
   config: string;
@@ -683,56 +685,56 @@ export type IgnitionFirstboot = {
   url: string;
 };
 export type Ignition = {
-  embedded?: IgnitionEmbedded;
-  firstboot?: IgnitionFirstboot;
+  embedded?: IgnitionEmbedded | undefined;
+  firstboot?: IgnitionFirstboot | undefined;
 };
 export type Fips = {
   /** Enables the system FIPS mode */
-  enabled?: boolean;
+  enabled?: boolean | undefined;
 };
 export type Installer = {
   /** Create a kickstart file for a fully automated installation
    */
-  unattended?: boolean;
-  "sudo-nopasswd"?: string[];
+  unattended?: boolean | undefined;
+  "sudo-nopasswd"?: string[] | undefined;
 };
 export type Customizations = {
-  containers?: Container[];
-  directories?: Directory[];
-  files?: File[];
-  subscription?: Subscription;
-  packages?: string[];
-  payload_repositories?: Repository[];
+  containers?: Container[] | undefined;
+  directories?: Directory[] | undefined;
+  files?: File[] | undefined;
+  subscription?: Subscription | undefined;
+  packages?: string[] | undefined;
+  payload_repositories?: Repository[] | undefined;
   /** List of custom repositories. */
-  custom_repositories?: CustomRepository[];
-  openscap?: OpenScap;
-  filesystem?: Filesystem[];
+  custom_repositories?: CustomRepository[] | undefined;
+  openscap?: OpenScap | undefined;
+  filesystem?: Filesystem[] | undefined;
   /** List of users that a customer can add,
     also specifying their respective groups and SSH keys and/or password
      */
-  users?: User[];
-  services?: Services;
+  users?: User[] | undefined;
+  services?: Services | undefined;
   /** Configures the hostname */
-  hostname?: string;
-  kernel?: Kernel;
+  hostname?: string | undefined;
+  kernel?: Kernel | undefined;
   /** List of groups to create */
-  groups?: Group[];
-  timezone?: Timezone;
-  locale?: Locale;
-  firewall?: FirewallCustomization;
+  groups?: Group[] | undefined;
+  timezone?: Timezone | undefined;
+  locale?: Locale | undefined;
+  firewall?: FirewallCustomization | undefined;
   /** Name of the installation device, currently only useful for the edge-simplified-installer type
    */
-  installation_device?: string;
-  fdo?: Fdo;
-  ignition?: Ignition;
+  installation_device?: string | undefined;
+  fdo?: Fdo | undefined;
+  ignition?: Ignition | undefined;
   /** Select how the disk image will be partitioned. 'auto-lvm' will use raw unless
     there are one or more mountpoints in which case it will use LVM. 'lvm' always
     uses LVM, even when there are no extra mountpoints. 'raw' uses raw partitions
     even when there are one or more mountpoints.
      */
-  partitioning_mode?: "raw" | "lvm" | "auto-lvm";
-  fips?: Fips;
-  installer?: Installer;
+  partitioning_mode?: ("raw" | "lvm" | "auto-lvm") | undefined;
+  fips?: Fips | undefined;
+  installer?: Installer | undefined;
 };
 export type BlueprintMetadata = {
   parent_id: string | null;
@@ -741,13 +743,13 @@ export type BlueprintMetadata = {
 };
 export type CreateBlueprintRequest = {
   name: string;
-  description?: string;
+  description?: string | undefined;
   distribution: Distributions;
   /** Array of image requests. Having more image requests in a single blueprint is currently not supported.
    */
   image_requests: ImageRequest[];
   customizations: Customizations;
-  metadata?: BlueprintMetadata;
+  metadata?: BlueprintMetadata | undefined;
 };
 export type BlueprintResponse = {
   id: string;
@@ -768,7 +770,7 @@ export type BlueprintExportResponse = {
   /** List of custom repositories including all the repository details needed in order
     to recreate the repositories.
      */
-  content_sources?: object[];
+  content_sources?: object[] | undefined;
 };
 export type ComposeResponse = {
   id: string;
@@ -776,22 +778,22 @@ export type ComposeResponse = {
 export type ClientId = "api" | "ui";
 export type ComposeRequest = {
   distribution: Distributions;
-  image_name?: string;
-  image_description?: string;
-  client_id?: ClientId;
+  image_name?: string | undefined;
+  image_description?: string | undefined;
+  client_id?: ClientId | undefined;
   /** Array of exactly one image request. Having more image requests in one compose is currently not supported.
    */
   image_requests: ImageRequest[];
-  customizations?: Customizations;
+  customizations?: Customizations | undefined;
 };
 export type ComposesResponseItem = {
   id: string;
   request: ComposeRequest;
   created_at: string;
-  image_name?: string;
-  client_id?: ClientId;
-  blueprint_id?: string | null;
-  blueprint_version?: number | null;
+  image_name?: string | undefined;
+  client_id?: ClientId | undefined;
+  blueprint_id?: (string | null) | undefined;
+  blueprint_version?: (number | null) | undefined;
 };
 export type ComposesResponse = {
   meta: ListResponseMeta;
@@ -828,7 +830,7 @@ export type UploadStatus = {
 export type ComposeStatusError = {
   id: number;
   reason: string;
-  details?: any;
+  details?: any | undefined;
 };
 export type ImageStatus = {
   status:
@@ -838,8 +840,8 @@ export type ImageStatus = {
     | "building"
     | "uploading"
     | "registering";
-  upload_status?: UploadStatus;
-  error?: ComposeStatusError;
+  upload_status?: UploadStatus | undefined;
+  error?: ComposeStatusError | undefined;
 };
 export type ComposeStatus = {
   image_status: ImageStatus;
@@ -856,8 +858,8 @@ export type Awsec2Clone = {
   /** An array of AWS account IDs as described in
     https://docs.aws.amazon.com/IAM/latest/UserGuide/console_account-alias.html
      */
-  share_with_accounts?: string[];
-  share_with_sources?: string[];
+  share_with_accounts?: string[] | undefined;
+  share_with_sources?: string[] | undefined;
 };
 export type CloneRequest = Awsec2Clone;
 export type ClonesResponseItem = {
@@ -873,7 +875,7 @@ export type ClonesResponse = {
   data: ClonesResponseItem[];
 };
 export type CloneStatusResponse = {
-  compose_id?: string;
+  compose_id?: string | undefined;
 } & UploadStatus;
 export type Package = {
   name: string;

--- a/src/store/provisioningApi.ts
+++ b/src/store/provisioningApi.ts
@@ -31,33 +31,39 @@ export type GetSourceUploadInfoApiArg = {
   id: number;
 };
 export type V1ListSourceResponse = {
-  data?: {
-    id?: string;
-    name?: string;
-    source_type_id?: string;
-    uid?: string;
-  }[];
+  data?:
+    | {
+        id?: string | undefined;
+        name?: string | undefined;
+        source_type_id?: string | undefined;
+        uid?: string | undefined;
+      }[]
+    | undefined;
 };
 export type V1ResponseError = {
-  build_time?: string;
-  edge_id?: string;
-  environment?: string;
-  error?: string;
-  msg?: string;
-  trace_id?: string;
-  version?: string;
+  build_time?: string | undefined;
+  edge_id?: string | undefined;
+  environment?: string | undefined;
+  error?: string | undefined;
+  msg?: string | undefined;
+  trace_id?: string | undefined;
+  version?: string | undefined;
 };
 export type V1SourceUploadInfoResponse = {
-  aws?: {
-    account_id?: string;
-  } | null;
-  azure?: {
-    resource_groups?: string[];
-    subscription_id?: string;
-    tenant_id?: string;
-  } | null;
-  gcp?: any | null;
-  provider?: string;
+  aws?:
+    | ({
+        account_id?: string | undefined;
+      } | null)
+    | undefined;
+  azure?:
+    | ({
+        resource_groups?: string[] | undefined;
+        subscription_id?: string | undefined;
+        tenant_id?: string | undefined;
+      } | null)
+    | undefined;
+  gcp?: (any | null) | undefined;
+  provider?: string | undefined;
 };
 export const { useGetSourceListQuery, useGetSourceUploadInfoQuery } =
   injectedRtkApi;

--- a/src/store/rhsmApi.ts
+++ b/src/store/rhsmApi.ts
@@ -29,48 +29,50 @@ const injectedRtkApi = api.injectEndpoints({
 export { injectedRtkApi as rhsmApi };
 export type ListActivationKeysApiResponse =
   /** status 200 Array of activation keys */ {
-    body?: ActivationKeys[];
+    body?: ActivationKeys[] | undefined;
   };
 export type ListActivationKeysApiArg = void;
 export type CreateActivationKeysApiResponse = /** status 200 Activation key */ {
-  body?: ActivationKeys;
+  body?: ActivationKeys | undefined;
 };
 export type CreateActivationKeysApiArg = {
   /** Create an activation key */
   body: {
-    additionalRepositories?: {
-      repositoryLabel?: string;
-    }[];
+    additionalRepositories?:
+      | {
+          repositoryLabel?: string | undefined;
+        }[]
+      | undefined;
     /** Name should be present, unique and can only contain letters, numbers, underscores, or hyphens */
     name: string;
-    releaseVersion?: string;
-    role?: string;
-    serviceLevel?: string;
-    usage?: string;
+    releaseVersion?: string | undefined;
+    role?: string | undefined;
+    serviceLevel?: string | undefined;
+    usage?: string | undefined;
   };
 };
 export type ShowActivationKeyApiResponse = /** status 200 Activation key */ {
-  body?: ActivationKeys;
+  body?: ActivationKeys | undefined;
 };
 export type ShowActivationKeyApiArg = {
   name: string;
 };
 export type AdditionalRepositories = {
-  repositoryLabel?: string;
-  repositoryName?: string;
+  repositoryLabel?: string | undefined;
+  repositoryName?: string | undefined;
 };
 export type ActivationKeys = {
-  additionalRepositories?: AdditionalRepositories[];
-  id?: string;
-  name?: string;
-  releaseVersion?: string;
-  role?: string;
-  serviceLevel?: string;
-  usage?: string;
+  additionalRepositories?: AdditionalRepositories[] | undefined;
+  id?: string | undefined;
+  name?: string | undefined;
+  releaseVersion?: string | undefined;
+  role?: string | undefined;
+  serviceLevel?: string | undefined;
+  usage?: string | undefined;
 };
 export type ErrorDetails = {
-  code?: number;
-  message?: string;
+  code?: number | undefined;
+  message?: string | undefined;
 };
 export const {
   useListActivationKeysQuery,

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -56,7 +56,7 @@ export type wizardState = {
     accountId: string;
     shareMethod: AwsShareMethod;
     source: V1ListSourceResponseItem | undefined;
-    sourceId?: string;
+    sourceId?: string | undefined;
   };
   azure: {
     shareMethod: AzureShareMethod;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "outDir": "./dist/",
     "noImplicitAny": true,
     "module": "esnext",
-    "target": "es5",
+    "target": "es2021",
     "downlevelIteration": true, // Needed to allow iteration over some objects like Map() while target is es5
     "jsx": "react-jsx",
     "sourceMap": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,11 @@
     "sourceMap": true,
     "allowJs": true,
     "moduleResolution": "node",
-    "types": ["vitest/globals", "@testing-library/jest-dom"],
+    "types": [
+      "vitest/globals",
+      "@testing-library/jest-dom"
+    ],
+    "exactOptionalPropertyTypes": true,
     "strictNullChecks": true,
     "allowSyntheticDefaultImports": true
   }


### PR DESCRIPTION
Enable `exactOptionalProperty` types.
This PR updates some of the typescript config to make our types a little bit
stricter.

The PR is broken into several commits before enabling the option in the tsconfig.

This is a recommended setting, see:
https://www.typescriptlang.org/tsconfig/#exactOptionalPropertyTypes