### PR TITLE
store/enhancedImageBuilderApi: handle empty error data

### DIFF
--- a/src/store/enhancedImageBuilderApi.ts
+++ b/src/store/enhancedImageBuilderApi.ts
@@ -5,7 +5,11 @@ import { imageBuilderApi } from './imageBuilderApi';
 /* eslint-disable @typescript-eslint/no-explicit-any */
 const errorMessage = (err: any) => {
   let msg = err.error.statusText;
-  if (err.error.data?.errors.length > 0 && err.error.data?.errors[0]?.detail) {
+  if (
+    err.error.data?.errors &&
+    err.error.data?.errors.length > 0 &&
+    err.error.data?.errors[0]?.detail
+  ) {
     msg = err.error.data?.errors[0]?.detail;
   }
   return msg;


### PR DESCRIPTION
Turns out it can also return `{error: data: {}}`, so without `errors` inside the data object.