### PR TITLE
test: Clean up comments left over after rebasing

### DIFF
--- a/src/test/Components/CreateImageWizard/steps/Locale/Locale.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Locale/Locale.test.tsx
@@ -248,6 +248,3 @@ describe('Locale edit mode', () => {
     expect(receivedRequest).toEqual(expectedRequest);
   });
 });
-
-// TO DO 'with languages selected'
-// TO DO 'with languages and keyboard selected'


### PR DESCRIPTION
This removes two comments left over after rebasing, both tests are already implemented a bit higher in the file.