### PR TITLE
sentry: use webpack plugin for injecting (HMS-5179)

### DIFF
--- a/ci.sh
+++ b/ci.sh
@@ -13,7 +13,6 @@ if [ "$IS_PR" == true ]; then
 else
     export BETA=false
     build
-    npm run sentry:inject
     source build_app_info.sh
     mv ${DIST_FOLDER} stable
     export BETA=true
@@ -22,9 +21,8 @@ else
     # both inject debug ids and upload the sourcemaps, in konflux only
     # the debug ids are injected.  As the debug ids are consistend
     # across builds, this works.
-    export SENTRY_AUTH_TOKEN SENTRY_DSN SENTRY_ORG SENTRY_PROJECT
+    export SENTRY_AUTH_TOKEN
     build
-    npm run sentry:inject
     source build_app_info.sh
     mv ${DIST_FOLDER} preview
     mkdir -p ${DIST_FOLDER}

--- a/fec.config.js
+++ b/fec.config.js
@@ -59,10 +59,22 @@ if (process.env.SENTRY_AUTH_TOKEN) {
   plugins.push(
     sentryWebpackPlugin({
       authToken: process.env.SENTRY_AUTH_TOKEN,
-      org: process.env.SENTRY_ORG,
-      project: process.env.SENTRY_PROJECT,
+      org: 'red-hat-it',
+      project: 'image-builder-rhel',
       moduleMetadata: ({ release }) => ({
-        dsn: process.env.SENTRY_DSN,
+        dsn: 'https://f4b4288bbb7cf6c0b2ac1a2b90a076bf@o490301.ingest.us.sentry.io/4508297557901312',
+        release,
+      }),
+    })
+  );
+} else {
+  // justs injects the debug ids
+  plugins.push(
+    sentryWebpackPlugin({
+      org: 'red-hat-it',
+      project: 'image-builder-rhel',
+      moduleMetadata: ({ release }) => ({
+        dsn: 'https://f4b4288bbb7cf6c0b2ac1a2b90a076bf@o490301.ingest.us.sentry.io/4508297557901312',
         release,
       }),
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "@redhat-cloud-services/frontend-components-utilities": "4.0.19",
         "@reduxjs/toolkit": "2.3.0",
         "@scalprum/react-core": "0.9.3",
-        "@sentry/cli": "2.39.1",
         "@sentry/webpack-plugin": "2.22.6",
         "@unleash/proxy-client-react": "4.3.1",
         "classnames": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "@redhat-cloud-services/frontend-components-utilities": "4.0.19",
     "@reduxjs/toolkit": "2.3.0",
     "@scalprum/react-core": "0.9.3",
-    "@sentry/cli": "2.39.1",
     "@sentry/webpack-plugin": "2.22.6",
     "@unleash/proxy-client-react": "4.3.1",
     "classnames": "2.5.1",
@@ -109,8 +108,7 @@
     "verify": "npm-run-all build lint test",
     "postinstall": "ts-patch install",
     "circular": "madge --circular ./src --extensions js,ts,tsx",
-    "circular:graph": "madge --circular ./src --extensions js,ts,tsx -i deps.png",
-    "sentry:inject": "sentry-cli sourcemaps inject --org red-hat-it --project image-builder-rhel ./dist"
+    "circular:graph": "madge --circular ./src --extensions js,ts,tsx -i deps.png"
   },
   "insights": {
     "appname": "image-builder"


### PR DESCRIPTION
Rationale is the same as in  #2662, but we need the module metadata for correct routing. None of these values are actually secret, only the auth token is. And turns out that the webpack plugin justs injects and doesn't upload in case we don't specify the auth token, so that's nice.<br/><br/>JIRA: [HMS-5179](https://issues.redhat.com/browse/HMS-5179)