### PR TITLE
on-prem: add ability to delete blueprints (HMS-5224)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,6 @@ cockpit/devel-uninstall:
 cockpit/devel-install: PREFIX=~/.local
 cockpit/devel-install:
 	PREFIX="~/.local"
-	mkdir -p $(PREFIX)$(INSTALL_DIR)
 	ln -s $(shell pwd)/cockpit/public $(PREFIX)$(INSTALL_DIR)
 
 .PHONY: cockpit/download

--- a/cockpit/webpack.config.ts
+++ b/cockpit/webpack.config.ts
@@ -28,6 +28,9 @@ module.exports = {
   devtool,
   plugins,
   resolve: {
+    fallback: {
+      path: require.resolve('path-browserify'),
+    },
     modules: [
       'node_modules',
       // this tells webpack to check `node_modules`

--- a/package-lock.json
+++ b/package-lock.json
@@ -75,6 +75,7 @@
         "moment": "2.30.1",
         "msw": "2.7.0",
         "npm-run-all": "4.1.5",
+        "path-browserify": "1.0.1",
         "postcss-scss": "4.0.9",
         "react-chartjs-2": "5.3.0",
         "redux-mock-store": "1.5.5",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "moment": "2.30.1",
     "msw": "2.7.0",
     "npm-run-all": "4.1.5",
+    "path-browserify": "1.0.1",
     "postcss-scss": "4.0.9",
     "react-chartjs-2": "5.3.0",
     "redux-mock-store": "1.5.5",

--- a/src/Components/Blueprints/BlueprintsPagination.tsx
+++ b/src/Components/Blueprints/BlueprintsPagination.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
 import { OnSetPage } from '@patternfly/react-core/dist/esm/components/Pagination/Pagination';
 
+import { useGetBlueprintsQuery } from '../../store/backendApi';
 import {
   selectBlueprintSearchInput,
   selectLimit,
@@ -11,10 +12,7 @@ import {
   setBlueprintsOffset,
 } from '../../store/BlueprintSlice';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import {
-  useGetBlueprintsQuery,
-  GetBlueprintsApiArg,
-} from '../../store/imageBuilderApi';
+import { GetBlueprintsApiArg } from '../../store/imageBuilderApi';
 
 const BlueprintsPagination = () => {
   const blueprintSearchInput = useAppSelector(selectBlueprintSearchInput);

--- a/src/Components/Blueprints/DeleteBlueprintModal.tsx
+++ b/src/Components/Blueprints/DeleteBlueprintModal.tsx
@@ -9,19 +9,19 @@ import {
 
 import { PAGINATION_LIMIT, PAGINATION_OFFSET } from '../../constants';
 import {
+  backendApi,
+  useDeleteBlueprintMutation,
+  useGetBlueprintsQuery,
+} from '../../store/backendApi';
+import {
   selectBlueprintSearchInput,
   selectLimit,
   selectOffset,
   selectSelectedBlueprintId,
   setBlueprintId,
 } from '../../store/BlueprintSlice';
-import { imageBuilderApi } from '../../store/enhancedImageBuilderApi';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
-import {
-  GetBlueprintsApiArg,
-  useDeleteBlueprintMutation,
-  useGetBlueprintsQuery,
-} from '../../store/imageBuilderApi';
+import { GetBlueprintsApiArg } from '../../store/imageBuilderApi';
 
 interface DeleteBlueprintModalProps {
   setShowDeleteModal: React.Dispatch<React.SetStateAction<boolean>>;
@@ -62,7 +62,7 @@ export const DeleteBlueprintModal: React.FunctionComponent<
       setShowDeleteModal(false);
       await deleteBlueprint({ id: selectedBlueprintId });
       dispatch(setBlueprintId(undefined));
-      dispatch(imageBuilderApi.util.invalidateTags([{ type: 'Blueprints' }]));
+      dispatch(backendApi.util.invalidateTags([{ type: 'Blueprints' }]));
     }
   };
   const onDeleteClose = () => {

--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -10,6 +10,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 
+import { useGetBlueprintsQuery } from '../../store/backendApi';
 import {
   selectSelectedBlueprintId,
   selectBlueprintSearchInput,
@@ -18,7 +19,6 @@ import {
 import { useAppSelector } from '../../store/hooks';
 import {
   BlueprintItem,
-  useGetBlueprintsQuery,
   useGetBlueprintComposesQuery,
   Distributions,
   GetBlueprintComposesApiArg,

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -26,6 +26,7 @@ import {
   MODAL_ANCHOR,
   SEARCH_INPUT,
 } from '../../constants';
+import { useGetBlueprintsQuery } from '../../store/backendApi';
 import {
   selectSelectedBlueprintId,
   selectBlueprintSearchInput,
@@ -33,7 +34,6 @@ import {
 import { useAppSelector } from '../../store/hooks';
 import {
   BlueprintItem,
-  useGetBlueprintsQuery,
   ComposesResponseItem,
   ComposeStatus,
   ImageTypes,

--- a/src/store/backendApi.ts
+++ b/src/store/backendApi.ts
@@ -1,6 +1,22 @@
-import { useGetBlueprintsQuery as useCockpitGetBlueprintsQuery } from './cockpitApi';
-import { useGetBlueprintsQuery as useImageBuilderGetBlueprintsQuery } from './imageBuilderApi';
+import {
+  useGetBlueprintsQuery as useCockpitGetBlueprintsQuery,
+  useDeleteBlueprintMutation as useCockpitDeleteMutation,
+} from './cockpitApi';
+import { cockpitApi } from './enhancedCockpitApi';
+import { imageBuilderApi } from './enhancedImageBuilderApi';
+import {
+  useGetBlueprintsQuery as useImageBuilderGetBlueprintsQuery,
+  useDeleteBlueprintMutation as useImageBuilderDeleteMutation,
+} from './imageBuilderApi';
 
 export const useGetBlueprintsQuery = process.env.IS_ON_PREMISE
   ? useCockpitGetBlueprintsQuery
   : useImageBuilderGetBlueprintsQuery;
+
+export const useDeleteBlueprintMutation = process.env.IS_ON_PREMISE
+  ? useCockpitDeleteMutation
+  : useImageBuilderDeleteMutation;
+
+export const backendApi = process.env.IS_ON_PREMISE
+  ? cockpitApi
+  : imageBuilderApi;

--- a/src/store/enhancedCockpitApi.ts
+++ b/src/store/enhancedCockpitApi.ts
@@ -1,0 +1,42 @@
+import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
+
+import { cockpitApi } from './cockpitApi';
+import { errorMessage } from './enhancedImageBuilderApi';
+
+const enhancedApi = cockpitApi.enhanceEndpoints({
+  addTagTypes: ['Blueprints'],
+  endpoints: {
+    getBlueprints: {
+      providesTags: () => {
+        return [{ type: 'Blueprints' }];
+      },
+    },
+    deleteBlueprint: {
+      invalidatesTags: [{ type: 'Blueprints' }],
+      onQueryStarted: async (_, { dispatch, queryFulfilled }) => {
+        queryFulfilled
+          .then(() => {
+            dispatch(
+              addNotification({
+                variant: 'success',
+                title: 'Blueprint was deleted',
+              })
+            );
+          })
+          .catch((err) => {
+            dispatch(
+              addNotification({
+                variant: 'danger',
+                title: 'Blueprint could not be deleted',
+                description: `Status code ${err.error.status}: ${errorMessage(
+                  err
+                )}`,
+              })
+            );
+          });
+      },
+    },
+  },
+});
+
+export { enhancedApi as cockpitApi };

--- a/src/store/enhancedImageBuilderApi.ts
+++ b/src/store/enhancedImageBuilderApi.ts
@@ -3,7 +3,7 @@ import { addNotification } from '@redhat-cloud-services/frontend-components-noti
 import { imageBuilderApi } from './imageBuilderApi';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
-const errorMessage = (err: any) => {
+export const errorMessage = (err: any) => {
   let msg = err.error.statusText;
   if (
     err.error.data?.errors &&

--- a/src/test/mocks/cockpit/index.ts
+++ b/src/test/mocks/cockpit/index.ts
@@ -22,4 +22,9 @@ export default {
       close: () => {},
     };
   },
+  spawn: (args: string[], attributes: object): Promise<string | Uint8Array> => {
+    return new Promise((resolve) => {
+      resolve('');
+    });
+  },
 };


### PR DESCRIPTION
Subject says it all, this PR adds the ability to delete blueprints using the on-prem version of the frontend.

/jira-epic COMPOSER-2411

JIRA: [HMS-5224](https://issues.redhat.com/browse/HMS-5224)