### PR TITLE
Wizard: Fix "form in form" warning (HMS-5237)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Form, FormGroup } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
@@ -38,7 +38,7 @@ const UserInfo = () => {
   };
 
   return (
-    <Form>
+    <>
       <FormGroup isRequired label="Username">
         <HookValidatedInput
           ariaLabel="blueprint user name"
@@ -59,7 +59,7 @@ const UserInfo = () => {
           fieldName="userPassword"
         />
       </FormGroup>
-    </Form>
+    </>
   );
 };
 


### PR DESCRIPTION
This resolves `Warning: validateDOMNesting(...): <form> cannot appear as a descendant of <form>.` warning in test output. There were two `<Form>` components nested in each other.

JIRA: [HMS-5237](https://issues.redhat.com/browse/HMS-5237)