### PR TITLE
ImagesTable: Fix compose filtering by selected blueprint

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -64,6 +64,7 @@ import {
   BlueprintItem,
   ComposesResponseItem,
   ComposeStatus,
+  GetBlueprintComposesApiArg,
   useGetBlueprintComposesQuery,
   useGetComposesQuery,
   useGetComposeStatusQuery,
@@ -82,6 +83,9 @@ const ImagesTable = () => {
   const blueprintSearchInput =
     useAppSelector(selectBlueprintSearchInput) || SEARCH_INPUT;
   const blueprintVersionFilter = useAppSelector(selectBlueprintVersionFilter);
+  const blueprintVersionFilterAPI = useAppSelector(
+    selectBlueprintVersionFilterAPI
+  );
   const blueprintsOffset = useAppSelector(selectOffset) || PAGINATION_OFFSET;
   const blueprintsLimit = useAppSelector(selectLimit) || PAGINATION_LIMIT;
 
@@ -106,20 +110,24 @@ const ImagesTable = () => {
     setPerPage(perPage);
   };
 
+  const searchParams: GetBlueprintComposesApiArg = {
+    id: selectedBlueprintId as string,
+    limit: perPage,
+    offset: perPage * (page - 1),
+  };
+
+  if (blueprintVersionFilterAPI) {
+    searchParams.blueprintVersion = blueprintVersionFilterAPI;
+  }
+
   const {
     data: blueprintsComposes,
     isSuccess: isBlueprintsSuccess,
     isLoading: isLoadingBlueprintsCompose,
     isError: isBlueprintsError,
-  } = useGetBlueprintComposesQuery(
-    {
-      id: selectedBlueprintId as string,
-      limit: perPage,
-      offset: perPage * (page - 1),
-      blueprintVersion: useAppSelector(selectBlueprintVersionFilterAPI) ?? 1,
-    },
-    { skip: !selectedBlueprintId }
-  );
+  } = useGetBlueprintComposesQuery(searchParams, {
+    skip: !selectedBlueprintId,
+  });
 
   const {
     data: composesData,


### PR DESCRIPTION
The filtering was defaulting to version '1', making images of other versions not appear when selecting a blueprint.

How to reproduce:
1. create a blueprint
2. build an image
3. edit the blueprint to get it to version 2
4. build another image

Current behaviour:
- only image with version 1 is visible
![image](https://github.com/user-attachments/assets/b3248e29-2a19-47c1-a972-3e88cc6f974e)


After fix:
- both image for version 1 and image for version 2 of the blueprint should be visible when the blueprint is selected
![image](https://github.com/user-attachments/assets/bdba778b-9b13-4684-9e5d-2bb235e48a8a)
