### PR TITLE
wizard: create new component with eyeIcon button inside textInput (HMS-5289)

### DIFF
--- a/src/Components/CreateImageWizard/ValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedInput.tsx
@@ -7,7 +7,11 @@ import {
   TextAreaProps,
   TextInput,
   TextInputProps,
+  Button,
+  InputGroup,
+  InputGroupItem,
 } from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 
 import type { StepValidation } from './utilities/useValidation';
 
@@ -33,6 +37,57 @@ type HookValidatedInputPropTypes = TextInputProps &
     warning?: string;
     inputType?: 'textInput' | 'textArea';
   };
+
+export const HookPasswordValidatedInput = ({
+  ariaLabel,
+  placeholder,
+  dataTestId,
+  value,
+  ouiaId,
+  stepValidation,
+  fieldName,
+  onChange,
+  warning = undefined,
+  inputType,
+  isDisabled,
+}: HookValidatedInputPropTypes) => {
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+  const togglePasswordVisibility = () => {
+    setIsPasswordVisible(!isPasswordVisible);
+  };
+
+  return (
+    <>
+      <InputGroup>
+        <InputGroupItem isFill>
+          <HookValidatedInput
+            type={isPasswordVisible ? 'text' : 'password'}
+            ouiaId={ouiaId || ''}
+            data-testid={dataTestId}
+            value={value}
+            onChange={onChange!}
+            stepValidation={stepValidation}
+            ariaLabel={ariaLabel || ''}
+            fieldName={fieldName}
+            placeholder={placeholder || ''}
+            inputType={inputType || 'textInput'}
+            warning={warning || ''}
+            isDisabled={isDisabled || false}
+          />
+        </InputGroupItem>
+        <InputGroupItem>
+          <Button
+            variant="control"
+            onClick={togglePasswordVisibility}
+            aria-label={isPasswordVisible ? 'Show password' : 'Hide password'}
+          >
+            {isPasswordVisible ? <EyeSlashIcon /> : <EyeIcon />}
+          </Button>
+        </InputGroupItem>
+      </InputGroup>
+    </>
+  );
+};
 
 export const HookValidatedInput = ({
   dataTestId,

--- a/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
@@ -16,7 +16,10 @@ import {
   setUserAdministratorByIndex,
 } from '../../../../../store/wizardSlice';
 import { useUsersValidation } from '../../../utilities/useValidation';
-import { HookValidatedInput } from '../../../ValidatedInput';
+import {
+  HookPasswordValidatedInput,
+  HookValidatedInput,
+} from '../../../ValidatedInput';
 const UserInfo = () => {
   const dispatch = useAppDispatch();
   const index = 0;
@@ -74,7 +77,7 @@ const UserInfo = () => {
         />
       </FormGroup>
       <FormGroup isRequired label="Password">
-        <HookValidatedInput
+        <HookPasswordValidatedInput
           ariaLabel="blueprint user password"
           value={userPassword || ''}
           onChange={(_e, value) => handlePasswordChange(_e, value)}


### PR DESCRIPTION
this commit create new component with eyeIcon button inside textInput,
for password field
<img width="832" alt="Screenshot 2025-01-09 at 13 21 59" src="https://github.com/user-attachments/assets/11b42827-bc75-4db9-815f-34bb6e4ddcb9" />



JIRA: [HMS-5289](https://issues.redhat.com/browse/HMS-5289)