### PR TITLE
Revert "wizard: add confirm password to users step (HMS-4903)"

### DIFF
--- a/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
@@ -6,11 +6,9 @@ import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { GENERATING_SSH_KEY_PAIRS_URL } from '../../../../../constants';
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
-  selectUserConfirmPassword,
   selectUserNameByIndex,
   selectUserPasswordByIndex,
   selectUserSshKeyByIndex,
-  setUserConfirmPasswordByIndex,
   setUserNameByIndex,
   setUserPasswordByIndex,
   setUserSshKeyByIndex,
@@ -23,8 +21,6 @@ const UserInfo = () => {
   const userName = useAppSelector(userNameSelector);
   const userPasswordSelector = selectUserPasswordByIndex(index);
   const userPassword = useAppSelector(userPasswordSelector);
-  const userConfirmPasswordSelector = selectUserConfirmPassword(index);
-  const userConfirmPassword = useAppSelector(userConfirmPasswordSelector);
   const userSshKeySelector = selectUserSshKeyByIndex(index);
   const userSshKey = useAppSelector(userSshKeySelector);
 
@@ -40,15 +36,6 @@ const UserInfo = () => {
     value: string
   ) => {
     dispatch(setUserPasswordByIndex({ index: index, password: value }));
-  };
-
-  const handleConfirmPasswordChange = (
-    _event: React.FormEvent<HTMLInputElement>,
-    value: string
-  ) => {
-    dispatch(
-      setUserConfirmPasswordByIndex({ index: index, confirmPassword: value })
-    );
   };
 
   const handleSshKeyChange = (
@@ -83,16 +70,6 @@ const UserInfo = () => {
           placeholder="Enter password"
           stepValidation={stepValidation}
           fieldName="userPassword"
-        />
-      </FormGroup>
-      <FormGroup isRequired label="Confirm Password">
-        <HookValidatedInput
-          ariaLabel="blueprint user confirm password"
-          value={userConfirmPassword || ''}
-          onChange={(_e, value) => handleConfirmPasswordChange(_e, value)}
-          placeholder="Confirm Password"
-          stepValidation={stepValidation}
-          fieldName="userConfirmPassword"
         />
       </FormGroup>
       <FormGroup isRequired label="SSH key">

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -46,8 +46,6 @@ export type ComplianceType = 'openscap' | 'compliance';
 
 export type UserWithAdditionalInfo = {
   [K in keyof User]-?: NonNullable<User[K]>;
-} & {
-  confirmPassword: string;
 };
 
 type UserPayload = {
@@ -63,11 +61,6 @@ type UserPasswordPayload = {
 type UserSshKeyPayload = {
   index: number;
   sshKey: string;
-};
-
-type UserConfirmPasswordPayload = {
-  index: number;
-  confirmPassword: string;
 };
 
 export type wizardState = {
@@ -378,11 +371,6 @@ export const selectUserNameByIndex =
 export const selectUserPasswordByIndex =
   (userIndex: number) => (state: RootState) => {
     return state.wizard.users[userIndex]?.password;
-  };
-
-export const selectUserConfirmPassword =
-  (userIndex: number) => (state: RootState) => {
-    return state.wizard.users[userIndex]?.confirmPassword;
   };
 
 export const selectUserSshKeyByIndex =
@@ -847,13 +835,6 @@ export const wizardSlice = createSlice({
     ) => {
       state.users[action.payload.index].password = action.payload.password;
     },
-    setUserConfirmPasswordByIndex: (
-      state,
-      action: PayloadAction<UserConfirmPasswordPayload>
-    ) => {
-      state.users[action.payload.index].confirmPassword =
-        action.payload.confirmPassword;
-    },
     setUserSshKeyByIndex: (state, action: PayloadAction<UserSshKeyPayload>) => {
       state.users[action.payload.index].ssh_key = action.payload.sshKey;
     },
@@ -929,6 +910,5 @@ export const {
   setUserNameByIndex,
   setUserPasswordByIndex,
   setUserSshKeyByIndex,
-  setUserConfirmPasswordByIndex,
 } = wizardSlice.actions;
 export default wizardSlice.reducer;


### PR DESCRIPTION
Reverts osbuild/image-builder-frontend#2709

Reverting because for now we think the UX of the confirm password field is bad. It makes the user do more work for questionable gains - there is already a 'show password' button, so it feels duplicitous. 