### PR TITLE
LandingPage: Hide NewAlert (HMS-5295)

### DIFF
--- a/src/Components/LandingPage/NewAlert.tsx
+++ b/src/Components/LandingPage/NewAlert.tsx
@@ -8,47 +8,52 @@ import {
   FlexItem,
   Text,
 } from '@patternfly/react-core';
-import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
+// Import for optional quickstarts functionality
+// import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
 
 type NewAlertPropTypes = {
   setShowAlert: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 export const NewAlert = ({ setShowAlert }: NewAlertPropTypes) => {
-  const isAlertDismissed = window.localStorage.getItem(
-    'imageBuilder.newFeatureBlueprintsAlertDismissed'
-  );
-  const [displayAlert, setDisplayAlert] = useState(!isAlertDismissed);
+  // Hide the alert until needed again
+  // const isAlertDismissed = window.localStorage.getItem(
+  //   'imageBuilder.newFeatureAlertDismissed'
+  // );
+  const [displayAlert, setDisplayAlert] = useState(false); // when needed switch for !isAlertDismissed);
 
   const dismissAlert = () => {
     setDisplayAlert(false);
     window.localStorage.setItem(
-      'imageBuilder.newFeatureBlueprintsAlertDismissed',
+      'imageBuilder.newFeatureNewStepsAlertDismissed',
       'true'
     );
   };
 
-  const { quickStarts } = useChrome();
-  const activateQuickstart = (qs: string) => () =>
-    quickStarts.activateQuickstart(qs);
+  // Optional quickstarts functionality
+  // const { quickStarts } = useChrome();
+  // const activateQuickstart = (qs: string) => () =>
+  //   quickStarts.activateQuickstart(qs);
 
   if (displayAlert) {
     return (
       <Alert
         style={{ margin: '0 0 16px 0' }}
-        title="New in Images: Blueprints!"
+        title="New in Images: TITLE PLACEHOLDER"
         actionClose={<AlertActionCloseButton onClose={dismissAlert} />}
         actionLinks={
           <>
             <Flex>
               <FlexItem>
-                <AlertActionLink
-                  onClick={activateQuickstart(
-                    'insights-creating-blueprint-images'
-                  )}
-                >
-                  Get started with blueprints
-                </AlertActionLink>
+                {/* Optional quickstarts link
+                  <AlertActionLink
+                    onClick={activateQuickstart(
+                      'insights-creating-blueprint-images'
+                    )}
+                  >
+                    Get started with blueprints
+                  </AlertActionLink>
+                */}
               </FlexItem>
               <FlexItem>
                 <AlertActionLink onClick={() => setShowAlert(false)}>
@@ -65,12 +70,7 @@ export const NewAlert = ({ setShowAlert }: NewAlertPropTypes) => {
           </>
         }
       >
-        <Text>
-          Blueprints make it easier for you to manage your images. Images expire
-          after two weeks, but blueprints last forever. Create a blueprint for
-          your “golden image”, modify it over time as your needs change, and use
-          it to build and deploy images on demand.
-        </Text>
+        <Text>Placeholder</Text>
       </Alert>
     );
   } else {


### PR DESCRIPTION
We'll be switching NewAlert with blueprints for information about newly available customizations. The component itself is a nice scaffolding for the upcoming announcement, would prefer to keep it for now.

Fixes #2550.

JIRA: [HMS-5295](https://issues.redhat.com/browse/HMS-5295)