### PR TITLE
on-prem add blueprint pagination and fix filtering (HMS-5306)

### DIFF
--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -47,8 +47,10 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
         GetBlueprintsApiResponse,
         GetBlueprintsApiArg
       >({
-        queryFn: async () => {
+        queryFn: async (queryArgs) => {
           try {
+            const { name, search } = queryArgs;
+
             const blueprintsDir = await getBlueprintsPath();
 
             // we probably don't need any more information other
@@ -58,7 +60,7 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
             });
 
             const entries = Object.entries(info?.entries || {});
-            const blueprints: BlueprintItem[] = await Promise.all(
+            let blueprints: BlueprintItem[] = await Promise.all(
               entries.map(async ([filename]) => {
                 const file = cockpit.file(path.join(blueprintsDir, filename));
 
@@ -76,6 +78,19 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
                 };
               })
             );
+
+            blueprints = blueprints.filter((blueprint) => {
+              if (name) {
+                return blueprint.name === name;
+              }
+
+              if (search) {
+                // TODO: maybe add other params to the search filter
+                return blueprint.name.includes(search);
+              }
+
+              return true;
+            });
 
             return {
               data: {

--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -49,7 +49,7 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
       >({
         queryFn: async (queryArgs) => {
           try {
-            const { name, search } = queryArgs;
+            const { name, search, offset, limit } = queryArgs;
 
             const blueprintsDir = await getBlueprintsPath();
 
@@ -92,6 +92,11 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
               return true;
             });
 
+            let paginatedBlueprints = blueprints;
+            if (offset !== undefined && limit !== undefined) {
+              paginatedBlueprints = blueprints.slice(offset, offset + limit);
+            }
+
             let first = '';
             let last = '';
 
@@ -109,7 +114,7 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
                   first: first,
                   last: last,
                 },
-                data: blueprints,
+                data: paginatedBlueprints,
               },
             };
           } catch (error) {

--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -92,13 +92,22 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
               return true;
             });
 
+            let first = '';
+            let last = '';
+
+            if (blueprints.length > 0) {
+              first = blueprints[0].id;
+              last = blueprints[blueprints.length - 1].id;
+            }
+
             return {
               data: {
                 meta: { count: blueprints.length },
                 links: {
-                  // TODO: figure out the pagination
-                  first: '',
-                  last: '',
+                  // These are kind of meaningless for the on-prem
+                  // version
+                  first: first,
+                  last: last,
                 },
                 data: blueprints,
               },

--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -73,7 +73,7 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
                 return {
                   ...blueprint,
                   id: filename as string,
-                  version: Math.floor(version),
+                  version: version,
                   last_modified_at: Date.now().toString(),
                 };
               })


### PR DESCRIPTION
This PR adds pagination support for on-prem blueprints and fixes the filtering of blueprints
when trying to search for blueprints.


/jira-epic COMPOSER-2411

JIRA: [HMS-5306](https://issues.redhat.com/browse/HMS-5306)