### PR TITLE
Wizard: Do not show warning icon if warning === '' (HMS-5327)

### DIFF
--- a/src/Components/CreateImageWizard/ValidatedTextInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedTextInput.tsx
@@ -79,7 +79,7 @@ export const HookValidatedInput = ({
           </HelperTextItem>
         </HelperText>
       )}
-      {warning !== undefined && (
+      {warning !== undefined && warning !== '' && (
         <HelperText>
           <HelperTextItem variant="warning" hasIcon>
             {warning}


### PR DESCRIPTION
Fixes #2743

This hides the warning under FSC min size if the body of warning is empty.

Before:
![image](https://github.com/user-attachments/assets/2ed0807a-c2ea-45b8-bd8e-818b7286539e)

After:
![image](https://github.com/user-attachments/assets/b1cc2bc1-a949-4f1c-b28c-2dc48e79f564)


JIRA: [HMS-5327](https://issues.redhat.com/browse/HMS-5327)