### PR TITLE
Wizard: Reset error text and validate on plus button (HMS-5329)

### DIFF
--- a/src/Components/CreateImageWizard/ChippingInput.tsx
+++ b/src/Components/CreateImageWizard/ChippingInput.tsx
@@ -44,31 +44,39 @@ const ChippingInput = ({
     value: string
   ) => {
     setInputValue(value);
+    setErrorText('');
+  };
+
+  const addItem = (value: string) => {
+    if (validator(value) && !list?.includes(value)) {
+      dispatch(addAction(value));
+      setInputValue('');
+      setErrorText('');
+    }
+
+    if (list?.includes(value)) {
+      setErrorText(`${item} already exists.`);
+    }
+
+    if (!validator(value)) {
+      setErrorText('Invalid format.');
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent, value: string) => {
     if (e.key === ' ' || e.key === 'Enter' || e.key === ',') {
       e.preventDefault();
-
-      if (validator(value) && !list?.includes(value)) {
-        dispatch(addAction(value));
-        setInputValue('');
-        setErrorText('');
-      }
-
-      if (list?.includes(value)) {
-        setErrorText(`${item} already exists.`);
-      }
-
-      if (!validator(value)) {
-        setErrorText('Invalid format.');
-      }
+      addItem(value);
     }
   };
 
   const handleAddItem = (e: React.MouseEvent, value: string) => {
-    dispatch(addAction(value));
+    addItem(value);
+  };
+
+  const handleClear = () => {
     setInputValue('');
+    setErrorText('');
   };
 
   return (
@@ -91,7 +99,7 @@ const ChippingInput = ({
           </Button>
           <Button
             variant="plain"
-            onClick={() => setInputValue('')}
+            onClick={handleClear}
             isDisabled={!inputValue}
             aria-label="Clear input"
           >

--- a/src/test/Components/CreateImageWizard/steps/Timezone/Timezone.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Timezone/Timezone.test.tsx
@@ -58,12 +58,32 @@ const selectTimezone = async () => {
   await waitFor(() => user.click(amsterdamTimezone));
 };
 
-const addNtpServer = async (ntpServer: string) => {
+const addNtpServerViaKeyDown = async (ntpServer: string) => {
   const user = userEvent.setup();
   const ntpServersInput = await screen.findByPlaceholderText(
     /add ntp servers/i
   );
   await waitFor(() => user.type(ntpServersInput, ntpServer.concat(',')));
+};
+
+const addNtpServerViaAddButton = async (ntpServer: string) => {
+  const user = userEvent.setup();
+  const ntpServersInput = await screen.findByPlaceholderText(
+    /add ntp servers/i
+  );
+  const addServerBtn = await screen.findByRole('button', {
+    name: /add ntp server/i,
+  });
+  await waitFor(() => user.type(ntpServersInput, ntpServer));
+  await waitFor(() => user.click(addServerBtn));
+};
+
+const clearInput = async () => {
+  const user = userEvent.setup();
+  const clearInputBtn = await screen.findByRole('button', {
+    name: /clear input/i,
+  });
+  await waitFor(() => user.click(clearInputBtn));
 };
 
 const clickRevisitButton = async () => {
@@ -109,8 +129,14 @@ describe('Step Timezone', () => {
     expect(
       screen.queryByText('NTP server already exists.')
     ).not.toBeInTheDocument();
-    await addNtpServer('0.nl.pool.ntp.org');
-    await addNtpServer('0.nl.pool.ntp.org');
+    await addNtpServerViaKeyDown('0.nl.pool.ntp.org');
+    await addNtpServerViaKeyDown('0.nl.pool.ntp.org');
+    await screen.findByText('NTP server already exists.');
+    await clearInput();
+    expect(
+      screen.queryByText('NTP server already exists.')
+    ).not.toBeInTheDocument();
+    await addNtpServerViaAddButton('0.nl.pool.ntp.org');
     await screen.findByText('NTP server already exists.');
   });
 
@@ -118,7 +144,7 @@ describe('Step Timezone', () => {
     await renderCreateMode();
     await goToTimezoneStep();
     expect(screen.queryByText('Invalid format.')).not.toBeInTheDocument();
-    await addNtpServer('this is not NTP server');
+    await addNtpServerViaKeyDown('this is not NTP server');
     await screen.findByText('Invalid format.');
   });
 
@@ -160,8 +186,8 @@ describe('Timezone request generated correctly', () => {
   test('with NTP servers', async () => {
     await renderCreateMode();
     await goToTimezoneStep();
-    await addNtpServer('0.nl.pool.ntp.org');
-    await addNtpServer('1.nl.pool.ntp.org');
+    await addNtpServerViaKeyDown('0.nl.pool.ntp.org');
+    await addNtpServerViaKeyDown('1.nl.pool.ntp.org');
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
 
@@ -183,8 +209,8 @@ describe('Timezone request generated correctly', () => {
     await renderCreateMode();
     await goToTimezoneStep();
     await selectTimezone();
-    await addNtpServer('0.nl.pool.ntp.org');
-    await addNtpServer('1.nl.pool.ntp.org');
+    await addNtpServerViaKeyDown('0.nl.pool.ntp.org');
+    await addNtpServerViaKeyDown('1.nl.pool.ntp.org');
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
 


### PR DESCRIPTION
This updates `<ChippingInput>` component to resolve two bugs:
- validation wasn't triggered when using the plus button on Timezone and Locale steps
- error text wasn't reset when the value was changed or cleared

JIRA: [HMS-5329](https://issues.redhat.com/browse/HMS-5329)