### PR TITLE
store:/cockpitApi: add cockpitBaseQuery (HMS-5361)

### DIFF
--- a/src/store/cockpit/baseQuery.ts
+++ b/src/store/cockpit/baseQuery.ts
@@ -1,0 +1,67 @@
+import { BaseQueryFn } from '@reduxjs/toolkit/query';
+import cockpit from 'cockpit';
+
+import type { Method, Params, Headers } from './types.js';
+
+const cockpitApi = cockpit.http('/run/cloudapi/api.socket', {
+  superuser: 'try',
+});
+
+export const baseQuery =
+  (
+    { baseUrl }: { baseUrl: string } = { baseUrl: '' }
+  ): BaseQueryFn<
+    {
+      url: string;
+      method?: Method;
+      body?: unknown;
+      params?: Params;
+      headers?: Headers;
+    },
+    // we have to explicitly set the result type as `any`,
+    // since each of the endpoints might have a slightly
+    // different output. Unfortunately, typescript still
+    // complains if we try set the result type as `unknown`
+    // see the above comment
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    any,
+    unknown
+  > =>
+  async (options) => {
+    // we need to wrap this call in a Promise rather than
+    // async/await because cockpit rejects the http request
+    // with two arguments (error & data/body)
+    return new Promise((resolve, reject) => {
+      return cockpitApi
+        .request({
+          path: baseUrl + options.url,
+          body: options.body ?? '',
+          method: options.method ?? 'GET',
+          params: options.params,
+          headers: options.headers,
+        })
+        .then((result) => {
+          resolve({ data: JSON.parse(result) });
+        })
+        .catch(
+          // cockpit rejects the promise with two arguments.
+          // The first argument is the error, the second is the
+          // data object from the `osbuild-composer` error.
+          // This makes typescript unhappy.
+          // @ts-expect-error see above comment
+          (error: { message: string; problem: string }, data: string) => {
+            let body = data;
+            try {
+              body = JSON.parse(body);
+            } finally {
+              reject({
+                problem: error.problem,
+                message: error.message,
+                options,
+                body,
+              });
+            }
+          }
+        );
+    });
+  };

--- a/src/store/cockpit/types.ts
+++ b/src/store/cockpit/types.ts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Params = Record<string, any>;
+export type Method = 'GET' | 'DELETE' | 'POST' | 'PUT' | 'PATCH'; // We can add more if we need
+export type Headers = { [name: string]: string };

--- a/src/store/emptyCockpitApi.ts
+++ b/src/store/emptyCockpitApi.ts
@@ -1,8 +1,11 @@
-import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
+import { createApi } from '@reduxjs/toolkit/query/react';
+
+import { baseQuery } from './cockpit/baseQuery';
 
 export const emptyCockpitApi = createApi({
   reducerPath: 'cockpitApi',
-  baseQuery: fetchBaseQuery({ baseUrl: '/api' }),
-  tagTypes: ['Composes'],
+  baseQuery: baseQuery({
+    baseUrl: '/api/image-builder-composer/v2',
+  }),
   endpoints: () => ({}),
 });

--- a/src/test/mocks/cockpit/index.ts
+++ b/src/test/mocks/cockpit/index.ts
@@ -33,7 +33,11 @@ export default {
         });
       },
       close: () => {},
-      replace: (contents: string) => {},
+      replace: (contents: string): Promise<void> => {
+        return new Promise((resolve) => {
+          resolve();
+        });
+      },
     };
   },
   spawn: (args: string[], attributes: object): Promise<string | Uint8Array> => {

--- a/src/test/mocks/cockpit/index.ts
+++ b/src/test/mocks/cockpit/index.ts
@@ -1,7 +1,16 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import type { Method, Headers, Params } from '../../../store/cockpit/types';
 
 type userinfo = {
   home: string;
+};
+
+type requestOptions = {
+  path: string;
+  method: Method;
+  body: unknown;
+  headers: Headers | undefined;
+  params: Params | undefined;
 };
 
 export default {
@@ -39,6 +48,11 @@ export default {
       },
       post: (path: string, data: object, headers?: object): string => {
         return '';
+      },
+      request: (request: requestOptions): Promise<string> => {
+        return new Promise((resolve) => {
+          resolve('');
+        });
       },
     };
   },


### PR DESCRIPTION
Add a `cockpitBaseQuery` for api calls that need to be made against the `cloudapi` on the osbuild-composer unix-socket. This function adds an extra step of parsing the result and transforming it into JSON.

There are currently no calls being made to the socket just yet, but we will need this going forward.

/jira-epic COMPOSER-2411

JIRA: [HMS-5361](https://issues.redhat.com/browse/HMS-5361)