### PR TITLE
Wizard: Fix "and build images" buttons (HMS-5366)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -25,7 +25,7 @@ import { selectPackages } from '../../../../../store/wizardSlice';
 type CreateDropdownProps = {
   getBlueprintPayload: () => Promise<'' | CreateBlueprintRequest | undefined>;
   setIsOpen: (isOpen: boolean) => void;
-  isDisabled?: boolean;
+  isDisabled: boolean;
 };
 
 export const CreateSaveAndBuildBtn = ({
@@ -69,7 +69,7 @@ export const CreateSaveAndBuildBtn = ({
       <DropdownItem
         onClick={onSaveAndBuild}
         ouiaId="wizard-create-build-btn"
-        isDisabled={isDisabled || true}
+        isDisabled={isDisabled}
       >
         Create blueprint and build image(s)
       </DropdownItem>

--- a/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
@@ -19,7 +19,7 @@ type EditDropdownProps = {
   getBlueprintPayload: () => Promise<'' | CreateBlueprintRequest | undefined>;
   setIsOpen: (isOpen: boolean) => void;
   blueprintId: string;
-  isDisabled?: boolean;
+  isDisabled: boolean;
 };
 
 export const EditSaveAndBuildBtn = ({
@@ -50,7 +50,7 @@ export const EditSaveAndBuildBtn = ({
       <DropdownItem
         onClick={onSaveAndBuild}
         ouiaId="wizard-edit-build-btn"
-        isDisabled={isDisabled || true}
+        isDisabled={isDisabled}
       >
         Save changes and build image(s)
       </DropdownItem>


### PR DESCRIPTION
Fixes #2778

The "Create / Save changes to a blueprint and build images" buttons were disabled by default.

![image](https://github.com/user-attachments/assets/6c76d6d8-bcaa-40e8-850d-aeb01c455699)

The button should be enabled any time the main button is enabled.

JIRA: [HMS-5366](https://issues.redhat.com/browse/HMS-5366)