### PR TITLE
cockpit: make `CreateImageWizard` functional (HMS-5408)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -45,12 +45,14 @@ export const CreateSaveAndBuildBtn = ({
     const requestBody = await getBlueprintPayload();
     setIsOpen(false);
 
-    analytics.track(`${AMPLITUDE_MODULE_NAME}-blueprintCreated`, {
-      module: AMPLITUDE_MODULE_NAME,
-      isPreview: isBeta(),
-      type: 'createBlueprintAndBuildImages',
-      packages: packages.map((pkg) => pkg.name),
-    });
+    if (!process.env.IS_ON_PREMISE) {
+      analytics.track(`${AMPLITUDE_MODULE_NAME}-blueprintCreated`, {
+        module: AMPLITUDE_MODULE_NAME,
+        isPreview: isBeta(),
+        type: 'createBlueprintAndBuildImages',
+        packages: packages.map((pkg) => pkg.name),
+      });
+    }
 
     const blueprint =
       requestBody &&
@@ -136,12 +138,14 @@ export const CreateSaveButton = ({
     const requestBody = await getBlueprintPayload();
     setIsOpen(false);
 
-    analytics.track(`${AMPLITUDE_MODULE_NAME}-blueprintCreated`, {
-      module: AMPLITUDE_MODULE_NAME,
-      isPreview: isBeta(),
-      type: 'createBlueprint',
-      packages: packages.map((pkg) => pkg.name),
-    });
+    if (!process.env.IS_ON_PREMISE) {
+      analytics.track(`${AMPLITUDE_MODULE_NAME}-blueprintCreated`, {
+        module: AMPLITUDE_MODULE_NAME,
+        isPreview: isBeta(),
+        type: 'createBlueprint',
+        packages: packages.map((pkg) => pkg.name),
+      });
+    }
 
     const blueprint =
       requestBody &&

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -13,12 +13,12 @@ import {
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 import { AMPLITUDE_MODULE_NAME } from '../../../../../constants';
+import { useCreateBlueprintMutation } from '../../../../../store/backendApi';
 import { setBlueprintId } from '../../../../../store/BlueprintSlice';
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
   CreateBlueprintRequest,
   useComposeBlueprintMutation,
-  useCreateBlueprintMutation,
 } from '../../../../../store/imageBuilderApi';
 import { selectPackages } from '../../../../../store/wizardSlice';
 

--- a/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
@@ -50,10 +50,16 @@ const ReviewWizardFooter = () => {
   }, [isUpdateSuccess, isCreateSuccess, resetCreate, resetUpdate, navigate]);
 
   const getBlueprintPayload = async () => {
-    const userData = await auth?.getUser();
-    const orgId = userData?.identity?.internal?.org_id;
-    const requestBody = orgId && mapRequestFromState(store, orgId);
-    return requestBody;
+    if (!process.env.IS_ON_PREMISE) {
+      const userData = await auth?.getUser();
+      const orgId = userData?.identity?.internal?.org_id;
+      const requestBody = orgId && mapRequestFromState(store, orgId);
+      return requestBody;
+    }
+
+    // NOTE: This should be fine on-prem, we should
+    // be able to ignore the `org-id`
+    return mapRequestFromState(store, '');
   };
 
   return (

--- a/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
@@ -15,10 +15,8 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { CreateSaveAndBuildBtn, CreateSaveButton } from './CreateDropdown';
 import { EditSaveAndBuildBtn, EditSaveButton } from './EditDropdown';
 
-import {
-  useCreateBlueprintMutation,
-  useUpdateBlueprintMutation,
-} from '../../../../../store/imageBuilderApi';
+import { useCreateBlueprintMutation } from '../../../../../store/backendApi';
+import { useUpdateBlueprintMutation } from '../../../../../store/imageBuilderApi';
 import { resolveRelPath } from '../../../../../Utilities/path';
 import { mapRequestFromState } from '../../../utilities/requestMapper';
 import { useIsBlueprintValid } from '../../../utilities/useValidation';

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -35,7 +35,7 @@ import {
   targetOptions,
   UNIT_GIB,
 } from '../../../../constants';
-import { useListSnapshotsByDateMutation } from '../../../../store/contentSourcesApi';
+import { useListSnapshotsByDateMutation } from '../../../../store/backendApi';
 import { useAppSelector } from '../../../../store/hooks';
 import { useGetSourceListQuery } from '../../../../store/provisioningApi';
 import { useShowActivationKeyQuery } from '../../../../store/rhsmApi';

--- a/src/store/backendApi.ts
+++ b/src/store/backendApi.ts
@@ -20,6 +20,10 @@ export const useLazyGetBlueprintsQuery = process.env.IS_ON_PREMISE
   ? cockpitQueries.useLazyGetBlueprintsQuery
   : imageBuilderQueries.useLazyGetBlueprintsQuery;
 
+export const useCreateBlueprintMutation = process.env.IS_ON_PREMISE
+  ? cockpitQueries.useCreateBlueprintMutation
+  : imageBuilderQueries.useCreateBlueprintMutation;
+
 export const useDeleteBlueprintMutation = process.env.IS_ON_PREMISE
   ? cockpitQueries.useDeleteBlueprintMutation
   : imageBuilderQueries.useDeleteBlueprintMutation;

--- a/src/store/backendApi.ts
+++ b/src/store/backendApi.ts
@@ -1,4 +1,5 @@
 import * as cockpitQueries from './cockpitApi';
+import { useListSnapshotsByDateMutation as useContentSourcesListSnapshotsByDateMutation } from './contentSourcesApi';
 import { cockpitApi } from './enhancedCockpitApi';
 import { imageBuilderApi } from './enhancedImageBuilderApi';
 import * as imageBuilderQueries from './imageBuilderApi';
@@ -26,6 +27,10 @@ export const useDeleteBlueprintMutation = process.env.IS_ON_PREMISE
 export const useGetOscapProfilesQuery = process.env.IS_ON_PREMISE
   ? cockpitQueries.useGetOscapProfilesQuery
   : imageBuilderQueries.useGetOscapProfilesQuery;
+
+export const useListSnapshotsByDateMutation = process.env.IS_ON_PREMISE
+  ? cockpitQueries.useListSnapshotsByDateMutation
+  : useContentSourcesListSnapshotsByDateMutation;
 
 export const useBackendPrefetch = process.env.IS_ON_PREMISE
   ? cockpitApi.usePrefetch

--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -27,6 +27,8 @@ import {
   GetOscapProfilesApiResponse,
   GetBlueprintApiResponse,
   GetBlueprintApiArg,
+  CreateBlueprintApiResponse,
+  CreateBlueprintApiArg,
 } from './imageBuilderApi';
 
 import { mapOnPremToHosted } from '../Components/Blueprints/helpers/onPremToHostedBlueprintMapper';
@@ -183,6 +185,23 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
           }
         },
       }),
+      createBlueprint: builder.mutation<
+        CreateBlueprintApiResponse,
+        CreateBlueprintApiArg
+      >({
+        queryFn: async () => {
+          // TODO: actually save the result to file
+          try {
+            return {
+              data: {
+                id: '',
+              },
+            };
+          } catch (error) {
+            return { error };
+          }
+        },
+      }),
       deleteBlueprint: builder.mutation<
         DeleteBlueprintApiResponse,
         DeleteBlueprintApiArg
@@ -239,6 +258,7 @@ export const {
   useGetBlueprintQuery,
   useGetBlueprintsQuery,
   useLazyGetBlueprintsQuery,
+  useCreateBlueprintMutation,
   useDeleteBlueprintMutation,
   useGetOscapProfilesQuery,
   useListSnapshotsByDateMutation,

--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -10,6 +10,10 @@ import cockpit from 'cockpit';
 import { fsinfo } from 'cockpit/fsinfo';
 import toml from 'toml';
 
+import {
+  ListSnapshotsByDateApiArg,
+  ListSnapshotsByDateApiResponse,
+} from './contentSourcesApi';
 import { emptyCockpitApi } from './emptyCockpitApi';
 import {
   GetArchitecturesApiResponse,
@@ -213,6 +217,19 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
           };
         },
       }),
+      // add an empty response for now
+      // just so we can step through the create
+      // image wizard for on prem
+      listSnapshotsByDate: builder.mutation<
+        ListSnapshotsByDateApiResponse,
+        ListSnapshotsByDateApiArg
+      >({
+        queryFn: () => ({
+          data: {
+            data: [],
+          },
+        }),
+      }),
     };
   },
 });
@@ -224,4 +241,5 @@ export const {
   useLazyGetBlueprintsQuery,
   useDeleteBlueprintMutation,
   useGetOscapProfilesQuery,
+  useListSnapshotsByDateMutation,
 } = cockpitApi;


### PR DESCRIPTION
This PR makes it possible to step through each step of the `CreateImageWizard` and make the wizard functional.
It is a follow up to #2735. The actual blueprint creation will be done in a follow up PR.

/jira-epic COMPOSER-2411

JIRA: [HMS-5408](https://issues.redhat.com/browse/HMS-5408)