### PR TITLE
scripts: add start:federated script

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "start:stage": "fec dev --clouddotEnv=stage",
     "start:prod": "fec dev --clouddotEnv=prod",
     "start:msw:stage": "NODE_ENV=development MSW=TRUE fec dev --clouddotEnv=stage",
+    "start:federated": "fec static",
     "test": "TZ=UTC vitest run",
     "test:watch": "TZ=UTC vitest",
     "test:coverage": "TZ=UTC vitest run --coverage",


### PR DESCRIPTION
This PR adds `start:federated` script for running image-builder-frontend as a static federated module.