### PR TITLE
store/cockpitApi: make cache dir in case it doesn't exist (HMS-5419)

### DIFF
--- a/src/store/cockpitApi.ts
+++ b/src/store/cockpitApi.ts
@@ -227,9 +227,10 @@ export const cockpitApi = emptyCockpitApi.injectEndpoints({
           try {
             const id = uuidv4();
             const blueprintsDir = await getBlueprintsPath();
-            await cockpit.spawn(['mkdir', id], {
-              directory: blueprintsDir,
-            });
+            await cockpit.spawn(
+              ['mkdir', '-p', path.join(blueprintsDir, id)],
+              {}
+            );
             await cockpit
               .file(path.join(blueprintsDir, id, `${id}.json`))
               .replace(JSON.stringify(blueprintReq));


### PR DESCRIPTION
Pass `-p` when creating blueprint directories in case `~/.cache/cockpit-image-builder` doesn't exist yet.

JIRA: [HMS-5419](https://issues.redhat.com/browse/HMS-5419)