### PR TITLE
.github/workflows/release: fix release workflow 2     

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       # so the v needs to be in the tarball when we upload it as a release artefact.
       - name: Upload release artefact
         run: |
-          RELEASE_NO=$(echo ${{github.event.release.tag_name}} | tr -d 'v')
-          mv "cockpit-image-builder-$RELEASE_NO.tar.gz" cockpit-image-builder-${{github.event.release.tag_name}}.tar.gz
-          gh release upload ${{github.event.release.tag_name}} \
-            cockpit-image-builder-${{github.event.release.tag_name}}.tar.gz
+          RELEASE_NO=$(echo ${{github.ref_name}} | tr -d 'v')
+          mv "cockpit-image-builder-$RELEASE_NO.tar.gz" cockpit-image-builder-${{github.ref_name}}.tar.gz
+          gh release upload ${{github.ref_name}} \
+            cockpit-image-builder-${{github.ref_name}}.tar.gz

--- a/cockpit/cockpit-image-builder.spec
+++ b/cockpit/cockpit-image-builder.spec
@@ -1,5 +1,5 @@
 Name:           cockpit-image-builder
-Version:        56
+Version:        55
 Release:        1%{?dist}
 Summary:        Image builder plugin for Cockpit
 


### PR DESCRIPTION

    The release event isn't present when a tag is pushed, so use ref_name to
    get the tag name.
