### PR TITLE
.github/workflows/release: make sure GH_TOKEN is set for upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,8 @@ jobs:
       # Source0 expands to `https://github.com/osbuild/image-builder-frontend/releases/download/v$VERSION/cockpit-image-builder-v$VERSION.tar.gz`,
       # so the v needs to be in the tarball when we upload it as a release artefact.
       - name: Upload release artefact
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{github.ref_name}} \
             ../cockpit-image-builder-${{github.ref_name}}.tar.gz

--- a/cockpit/cockpit-image-builder.spec
+++ b/cockpit/cockpit-image-builder.spec
@@ -1,5 +1,5 @@
 Name:           cockpit-image-builder
-Version:        56
+Version:        55
 Release:        1%{?dist}
 Summary:        Image builder plugin for Cockpit
 


### PR DESCRIPTION
I thought the GH_TOKEN was set automatically :roll_eyes: 