### PR TITLE
store/cockpit: don't use top-level constants that use cockpit

### DIFF
--- a/src/store/cockpit/baseQuery.ts
+++ b/src/store/cockpit/baseQuery.ts
@@ -3,10 +3,6 @@ import cockpit from 'cockpit';
 
 import type { Method, Params, Headers } from './types.js';
 
-const cockpitApi = cockpit.http('/run/cloudapi/api.socket', {
-  superuser: 'try',
-});
-
 export const baseQuery =
   (
     { baseUrl }: { baseUrl: string } = { baseUrl: '' }
@@ -32,7 +28,10 @@ export const baseQuery =
     // async/await because cockpit rejects the http request
     // with two arguments (error & data/body)
     return new Promise((resolve, reject) => {
-      return cockpitApi
+      const cloudApi = cockpit.http('/run/cloudapi/api.socket', {
+        superuser: 'try',
+      });
+      return cloudApi
         .request({
           path: baseUrl + options.url,
           body: options.body ?? '',


### PR DESCRIPTION
Only invoke the cockpit library when actually contacting the cloudapi.

The cockpit library isn't defined in the service, so any invocation of the cockpit library when the application loads will make the frontend crash.