### PR TITLE
packit.yaml: fix upstream tag template

### DIFF
--- a/packit.yaml
+++ b/packit.yaml
@@ -4,6 +4,7 @@ upstream_package_name: cockpit-image-builder
 downstream_package_name: cockpit-image-builder
 # use the nicely formatted release description from our upstream release, instead of git shortlog
 copy_upstream_release_description: true
+upstream_tag_template: v{version}
 
 actions:
   create-archive:


### PR DESCRIPTION
Currently the version in fedora is `v55`, which is wrong, it should just be `55`.