### PR TITLE
fec: enable useFileHash

### DIFF
--- a/cockpit/cockpit-image-builder.spec
+++ b/cockpit/cockpit-image-builder.spec
@@ -1,5 +1,5 @@
 Name:           cockpit-image-builder
-Version:        56
+Version:        57
 Release:        1%{?dist}
 Summary:        Image builder plugin for Cockpit
 

--- a/fec.config.js
+++ b/fec.config.js
@@ -1,8 +1,8 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const path = require('path');
 
-const CopyPlugin = require('copy-webpack-plugin');
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 const webpack = require('webpack');
 
 const plugins = [];
@@ -84,7 +84,7 @@ if (process.env.SENTRY_AUTH_TOKEN) {
 module.exports = {
   sassPrefix: '.imageBuilder',
   debug: true,
-  useFileHash: false,
+  useFileHash: true,
   /*
   mockServiceWorker.js will be served from /beta/apps/image-builder, which
   will become its default scope. Setting the Service-Worker-Allowed header to


### PR DESCRIPTION
fec: enable useFileHash

this commmit enable useFileHash in fec.config.js -
when set it to true Webpack will append a hash (a unique identifier) to the filename based on its content.
This helps prevent the browser from using an outdated cached version of a file when its content has changed.
