### PR TITLE
fec: enable useFileHash

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -84,7 +84,7 @@ if (process.env.SENTRY_AUTH_TOKEN) {
 module.exports = {
   sassPrefix: '.imageBuilder',
   debug: true,
-  useFileHash: false,
+  useFileHash: true,
   /*
   mockServiceWorker.js will be served from /beta/apps/image-builder, which
   will become its default scope. Setting the Service-Worker-Allowed header to


### PR DESCRIPTION
this commmit enable useFileHash in fec.config.js - when set it to true Webpack will append a hash (a unique identifier) to the filename based on its content. This helps prevent the browser from using an outdated cached version of a file when its content has changed.