### PR TITLE
Wizard: remove confirmPassword from Mapper

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -232,7 +232,6 @@ function commonRequestToState(
         name: user.name,
         password: '', // The image-builder API does not return the password.
         ssh_key: user.ssh_key || '',
-        confirmPassword: '',
         groups: user.groups || [],
         isAdministrator: user.groups?.includes('wheel') || false,
       })) || [],

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -906,7 +906,6 @@ export const wizardSlice = createSlice({
       const newUser = {
         name: '',
         password: '',
-        confirmPassword: '',
         ssh_key: '',
         groups: [],
         isAdministrator: false,


### PR DESCRIPTION
this commit remove confirmPassword from Mapper because we decide that this field is not relevant anymore to Users step, and it should remove from the mapper as well