### PR TITLE
Wizard: Add validation to user's password in User step (HMS-5466)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -492,6 +492,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 key="wizard-users"
                 navItem={customStatusNavItem}
                 isHidden={!isUsersEnabled}
+                status={usersValidation.disabledNext ? 'error' : 'default'}
                 footer={
                   <CustomWizardFooter
                     disableNext={usersValidation.disabledNext}

--- a/src/Components/CreateImageWizard/ValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedInput.tsx
@@ -7,11 +7,7 @@ import {
   TextAreaProps,
   TextInput,
   TextInputProps,
-  Button,
-  InputGroup,
-  InputGroupItem,
 } from '@patternfly/react-core';
-import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 
 import type { StepValidation } from './utilities/useValidation';
 
@@ -59,57 +55,6 @@ type ErrorMessageProps = {
 };
 
 type ValidationResult = 'default' | 'success' | 'error';
-
-export const HookPasswordValidatedInput = ({
-  ariaLabel,
-  placeholder,
-  dataTestId,
-  value,
-  ouiaId,
-  stepValidation,
-  fieldName,
-  onChange,
-  warning = undefined,
-  inputType,
-  isDisabled,
-}: HookValidatedInputPropTypes) => {
-  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
-  const togglePasswordVisibility = () => {
-    setIsPasswordVisible(!isPasswordVisible);
-  };
-
-  return (
-    <>
-      <InputGroup>
-        <InputGroupItem isFill>
-          <HookValidatedInput
-            type={isPasswordVisible ? 'text' : 'password'}
-            ouiaId={ouiaId || ''}
-            data-testid={dataTestId}
-            value={value}
-            onChange={onChange!}
-            stepValidation={stepValidation}
-            ariaLabel={ariaLabel || ''}
-            fieldName={fieldName}
-            placeholder={placeholder || ''}
-            inputType={inputType || 'textInput'}
-            warning={warning || ''}
-            isDisabled={isDisabled || false}
-          />
-        </InputGroupItem>
-        <InputGroupItem>
-          <Button
-            variant="control"
-            onClick={togglePasswordVisibility}
-            aria-label={isPasswordVisible ? 'Show password' : 'Hide password'}
-          >
-            {isPasswordVisible ? <EyeSlashIcon /> : <EyeIcon />}
-          </Button>
-        </InputGroupItem>
-      </InputGroup>
-    </>
-  );
-};
 
 export const ValidatedInputAndTextArea = ({
   value,

--- a/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
@@ -16,11 +16,9 @@ import {
   setUserAdministratorByIndex,
   removeUser,
 } from '../../../../../store/wizardSlice';
+import { PasswordValidatedInput } from '../../../utilities/PasswordValidatedInput';
 import { useUsersValidation } from '../../../utilities/useValidation';
-import {
-  HookPasswordValidatedInput,
-  ValidatedInputAndTextArea,
-} from '../../../ValidatedInput';
+import { ValidatedInputAndTextArea } from '../../../ValidatedInput';
 const UserInfo = () => {
   const dispatch = useAppDispatch();
   const index = 0;
@@ -41,7 +39,7 @@ const UserInfo = () => {
   };
 
   const handlePasswordChange = (
-    _event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
+    _event: React.FormEvent<HTMLInputElement>,
     value: string
   ) => {
     dispatch(setUserPasswordByIndex({ index: index, password: value }));
@@ -81,16 +79,12 @@ const UserInfo = () => {
           fieldName="userName"
         />
       </FormGroup>
-      <FormGroup isRequired label="Password">
-        <HookPasswordValidatedInput
-          ariaLabel="blueprint user password"
-          value={userPassword || ''}
-          onChange={(_e, value) => handlePasswordChange(_e, value)}
-          placeholder="Enter password"
-          stepValidation={stepValidation}
-          fieldName="userPassword"
-        />
-      </FormGroup>
+      <PasswordValidatedInput
+        value={userPassword || ''}
+        ariaLabel="blueprint user password"
+        placeholder="Enter password"
+        onChange={(_e, value) => handlePasswordChange(_e, value)}
+      />
       <FormGroup isRequired label="SSH key">
         <ValidatedInputAndTextArea
           inputType={'textArea'}

--- a/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+
+import {
+  FormGroup,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
+  InputGroup,
+  InputGroupItem,
+  TextInput,
+  Button,
+  TextInputProps,
+} from '@patternfly/react-core';
+import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
+
+import { checkPasswordValidity } from './useValidation';
+
+import { useAppSelector } from '../../../store/hooks';
+import { selectImageTypes } from '../../../store/wizardSlice';
+
+type ValidatedPasswordInput = TextInputProps & {
+  value: string;
+  placeholder: string;
+  ariaLabel: string;
+  onChange: (event: React.FormEvent<HTMLInputElement>, value: string) => void;
+};
+
+export const PasswordValidatedInput = ({
+  value,
+  placeholder,
+  ariaLabel,
+  onChange,
+}: ValidatedPasswordInput) => {
+  const environments = useAppSelector(selectImageTypes);
+  const [isPasswordVisible, setIsPasswordVisible] = useState(false);
+
+  const { validationState, strength } = checkPasswordValidity(
+    value,
+    environments.includes('azure')
+  );
+  const { ruleLength, ruleCharacters } = validationState;
+
+  const togglePasswordVisibility = () => {
+    setIsPasswordVisible(!isPasswordVisible);
+  };
+
+  const passStrLabel = (
+    <HelperText>
+      <HelperTextItem variant={strength.variant} icon={strength.icon}>
+        {strength.text}
+      </HelperTextItem>
+    </HelperText>
+  );
+
+  return (
+    <FormGroup label="Password" isRequired labelInfo={passStrLabel}>
+      <>
+        <InputGroup>
+          <InputGroupItem isFill>
+            <TextInput
+              isRequired
+              type={isPasswordVisible ? 'text' : 'password'}
+              value={value}
+              onChange={onChange}
+              aria-label={ariaLabel}
+              placeholder={placeholder}
+            />
+          </InputGroupItem>
+          <InputGroupItem>
+            <Button
+              variant="control"
+              onClick={togglePasswordVisibility}
+              aria-label={isPasswordVisible ? 'Hide password' : 'Show password'}
+            >
+              {isPasswordVisible ? <EyeSlashIcon /> : <EyeIcon />}
+            </Button>
+          </InputGroupItem>
+        </InputGroup>
+      </>
+      <FormHelperText>
+        <HelperText component="ul">
+          <HelperTextItem variant={ruleLength} component="li" hasIcon>
+            Password must be at least 6 characters long.
+          </HelperTextItem>
+          {environments.includes('azure') && (
+            <HelperTextItem variant={ruleCharacters} component="li" hasIcon>
+              Must include at least 3 of the following: lowercase letters,
+              uppercase letters, numbers, symbols.
+            </HelperTextItem>
+          )}
+        </HelperText>
+      </FormHelperText>
+    </FormGroup>
+  );
+};

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
@@ -19,6 +19,30 @@ const getAzureSourceDropdown = async () => {
   return sourceDropdown;
 };
 
+export const addTargetEnvAzure = async () => {
+  const user = userEvent.setup();
+  expect(
+    await screen.findByRole('radio', {
+      name: /use an account configured from sources\./i,
+    })
+  ).toHaveFocus();
+  const azureSourceDropdown = await getAzureSourceDropdown();
+  await waitFor(() => user.click(azureSourceDropdown));
+  const azureSource = await screen.findByRole('option', {
+    name: /azureSource1/i,
+  });
+  await waitFor(() => user.click(azureSource));
+
+  const resourceGroupDropdown = await screen.findByPlaceholderText(
+    /select resource group/i
+  );
+  await waitFor(() => user.click(resourceGroupDropdown));
+  await waitFor(async () =>
+    user.click(await screen.findByLabelText('Resource group myResourceGroup1'))
+  );
+  await clickNext();
+};
+
 const selectAllEnvironments = async () => {
   const user = userEvent.setup();
 
@@ -119,28 +143,7 @@ describe('Keyboard accessibility', () => {
     await clickNext();
 
     // Target environment azure
-    expect(
-      await screen.findByRole('radio', {
-        name: /use an account configured from sources\./i,
-      })
-    ).toHaveFocus();
-    const azureSourceDropdown = await getAzureSourceDropdown();
-    await waitFor(() => user.click(azureSourceDropdown));
-    const azureSource = await screen.findByRole('option', {
-      name: /azureSource1/i,
-    });
-    await waitFor(() => user.click(azureSource));
-
-    const resourceGroupDropdown = await screen.findByPlaceholderText(
-      /select resource group/i
-    );
-    await waitFor(() => user.click(resourceGroupDropdown));
-    await waitFor(async () =>
-      user.click(
-        await screen.findByLabelText('Resource group myResourceGroup1')
-      )
-    );
-    await clickNext();
+    await addTargetEnvAzure();
 
     // Registration
     await screen.findByText(


### PR DESCRIPTION
This commit adds password validation to the User step:
- Moved password validation logic to a separate `checkPasswordValidity` function, returning detailed results (strength and validation state).
- Simplified validation in `PasswordValidatedInput` by using `checkPasswordValidity` results directly.
- Added dynamic password strength indicator showing success or error based on requirements.
- Integrated environment-specific validation messages (e.g., for Azure).
- Improved code separation between presentation and validation for better maintainability.
- Unit tests: Adds tests for invalid passwords, covering both default and Azure cases.

use this Password strength - https://www.patternfly.org/components/password-strength/ as insperation 


JIRA: [HMS-5466](https://issues.redhat.com/browse/HMS-5466)