### PR TITLE
src: Align to center (HMS-5452)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -307,7 +307,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   return (
     <>
       <ImageBuilderHeader inWizard />
-      <PageSection isWidthLimited>
+      <PageSection isWidthLimited isCenterAligned>
         <Wizard
           startIndex={startIndex}
           onClose={() => navigate(resolveRelPath(''))}

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -59,7 +59,7 @@ export const LandingPage = () => {
 
   const imageList = (
     <>
-      <PageSection isWidthLimited>
+      <PageSection isWidthLimited isCenterAligned>
         {showAlert && <NewAlert setShowAlert={setShowAlert} />}
         <Sidebar hasBorder className="pf-v5-u-background-color-100">
           <SidebarPanel


### PR DESCRIPTION
Fixes #2372

This ensures that both Landing page and Wizard are aligned to center within wide windows.

Before:
![image](https://github.com/user-attachments/assets/371bdd80-1e5f-47ad-9f2b-cb80f133e198)

After:
![image](https://github.com/user-attachments/assets/dfad35a5-2119-4981-8573-ca61f91128cc)


JIRA: [HMS-5452](https://issues.redhat.com/browse/HMS-5452)