### PR TITLE
Wizard: Remove `CodeBlocks` for "None" as a value (HMS-5454)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -916,11 +916,13 @@ export const KernelList = () => {
           Append
         </TextListItem>
         <TextListItem component={TextListItemVariants.dd}>
-          <CodeBlock>
-            <CodeBlockCode>
-              {kernel.append.length > 0 ? kernel.append.join(' ') : 'None'}
-            </CodeBlockCode>
-          </CodeBlock>
+          {kernel.append.length > 0 ? (
+            <CodeBlock>
+              <CodeBlockCode>{kernel.append.join(' ')}</CodeBlockCode>
+            </CodeBlock>
+          ) : (
+            'None'
+          )}
         </TextListItem>
       </TextList>
     </TextContent>
@@ -940,11 +942,13 @@ export const FirewallList = () => {
           Ports
         </TextListItem>
         <TextListItem component={TextListItemVariants.dd}>
-          <CodeBlock>
-            <CodeBlockCode>
-              {firewall.ports.length > 0 ? firewall.ports.join(' ') : 'None'}
-            </CodeBlockCode>
-          </CodeBlock>
+          {firewall.ports.length > 0 ? (
+            <CodeBlock>
+              <CodeBlockCode>{firewall.ports.join(' ')}</CodeBlockCode>
+            </CodeBlock>
+          ) : (
+            'None'
+          )}
         </TextListItem>
         <TextListItem
           component={TextListItemVariants.dt}
@@ -953,13 +957,15 @@ export const FirewallList = () => {
           Disabled services
         </TextListItem>
         <TextListItem component={TextListItemVariants.dd}>
-          <CodeBlock>
-            <CodeBlockCode>
-              {firewall.services.disabled.length > 0
-                ? firewall.services.disabled.join(' ')
-                : 'None'}
-            </CodeBlockCode>
-          </CodeBlock>
+          {firewall.services.disabled.length > 0 ? (
+            <CodeBlock>
+              <CodeBlockCode>
+                {firewall.services.disabled.join(' ')}
+              </CodeBlockCode>
+            </CodeBlock>
+          ) : (
+            'None'
+          )}
         </TextListItem>
         <TextListItem
           component={TextListItemVariants.dt}
@@ -968,13 +974,15 @@ export const FirewallList = () => {
           Enabled services
         </TextListItem>
         <TextListItem component={TextListItemVariants.dd}>
-          <CodeBlock>
-            <CodeBlockCode>
-              {firewall.services.enabled.length > 0
-                ? firewall.services.enabled.join(' ')
-                : 'None'}
-            </CodeBlockCode>
-          </CodeBlock>
+          {firewall.services.enabled.length > 0 ? (
+            <CodeBlock>
+              <CodeBlockCode>
+                {firewall.services.enabled.join(' ')}
+              </CodeBlockCode>
+            </CodeBlock>
+          ) : (
+            'None'
+          )}
         </TextListItem>
       </TextList>
     </TextContent>


### PR DESCRIPTION
Fixes #2834

Render "None" just as a plain text when there are no values to be shown in the review expandable.

JIRA: [HMS-5454](https://issues.redhat.com/browse/HMS-5454)