### PR TITLE
vitests: Set global retry (HMS-5458)

### DIFF
--- a/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
@@ -246,7 +246,7 @@ describe('OpenSCAP request generated correctly', () => {
     });
   });
 
-  test('remove a profile', { retry: 3, timeout: 20000 }, async () => {
+  test('remove a profile', { timeout: 20000 }, async () => {
     await renderCreateMode();
     await selectGuestImageTarget();
     await goToOscapStep();
@@ -265,7 +265,7 @@ describe('OpenSCAP request generated correctly', () => {
     });
   });
 
-  test('change profile', { retry: 3, timeout: 20000 }, async () => {
+  test('change profile', { timeout: 20000 }, async () => {
     await renderCreateMode();
     await selectGuestImageTarget();
     await goToOscapStep();

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
@@ -220,7 +220,7 @@ describe('Step Upload to Azure', () => {
     await verifyCancelButton(router);
   });
 
-  test('basics work', { retry: 3 }, async () => {
+  test('basics work', async () => {
     await renderCreateMode();
     await selectAzureTarget();
     await goToAzureStep();

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -118,7 +118,7 @@ describe('Images Table', () => {
     expect(await screen.findByText(/ami-0e778053cd490ad21/i)).not.toBeVisible();
   });
 
-  test('check error details', { retry: 3 }, async () => {
+  test('check error details', async () => {
     await renderCustomRoutesWithReduxRouter();
 
     let table = await screen.findByTestId('images-table');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
-import react from '@vitejs/plugin-react';
 import path from 'path';
+
+import react from '@vitejs/plugin-react';
 
 const config = {
   plugins: [react()],
@@ -18,6 +19,7 @@ const config = {
     testTimeout: 10000,
     fileParallelism: false,
     exclude: ['./pkg/lib/**', '**/node_modules/**', '**/dist/**'],
+    retry: 3,
   },
   reporters: ['default', 'junit'],
   outputFile: {


### PR DESCRIPTION
This sets retry globally to `3`, so we don't have to add it to the tests individually.

For the tests that are reliable this shouldn't have any effect, but it will trigger on tests that proved to be a bit flakey (like revisit tests).

JIRA: [HMS-5458](https://issues.redhat.com/browse/HMS-5458)