### PR TITLE
requestMapper: Fix snapshot date parsing (HMS-5463)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -183,14 +183,10 @@ function commonRequestToState(
   // Currently used format is RFC3339 (YYYY-MM-DDTHH:MM:SSZ), this condition
   // checks which format is getting parsed and converts DateOnly to RFC3339
   // when necessary.
-  if (
-    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\+\d{2}:\d{2}$/.test(
-      snapshotDateFromRequest
-    )
-  ) {
+  if (/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/.test(snapshotDateFromRequest)) {
     snapshot_date = snapshotDateFromRequest;
   } else if (/^\d{4}-\d{2}-\d{2}$/.test(snapshotDateFromRequest)) {
-    snapshot_date = snapshotDateFromRequest + 'T00:00:00+00:00';
+    snapshot_date = snapshotDateFromRequest + 'T00:00:00Z';
   } else {
     snapshot_date = '';
   }


### PR DESCRIPTION
Regex was wrong, would take "2025-01-01T00:00:00.000Z" even though it's a valid RFC 3339 date.

JIRA: [HMS-5463](https://issues.redhat.com/browse/HMS-5463)