### PR TITLE
Wizard: remove extendable users from Review step when there is no user or kernel name (HMS-5474)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -56,6 +56,8 @@ import {
   selectNtpServers,
   selectFirewall,
   selectServices,
+  selectUsers,
+  selectKernel,
 } from '../../../../store/wizardSlice';
 import { useFlag } from '../../../../Utilities/useGetEnvironment';
 
@@ -77,6 +79,8 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
   const ntpServers = useAppSelector(selectNtpServers);
   const firewall = useAppSelector(selectFirewall);
   const services = useAppSelector(selectServices);
+  const users = useAppSelector(selectUsers);
+  const kernel = useAppSelector(selectKernel);
 
   const [isExpandedImageOutput, setIsExpandedImageOutput] = useState(true);
   const [isExpandedTargetEnvs, setIsExpandedTargetEnvs] = useState(true);
@@ -348,7 +352,7 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
         {/* Intentional prop drilling for simplicity - To be removed */}
         <ContentList snapshottingEnabled={snapshottingEnabled} />
       </ExpandableSection>
-      {isUsersEnabled && (
+      {isUsersEnabled && users.length > 0 && (
         <ExpandableSection
           toggleContent={composeExpandable(
             'Users',
@@ -417,7 +421,7 @@ const Review = ({ snapshottingEnabled }: { snapshottingEnabled: boolean }) => {
           <HostnameList />
         </ExpandableSection>
       )}
-      {isKernelEnabled && (
+      {isKernelEnabled && (kernel.name || kernel.append.length > 0) && (
         <ExpandableSection
           toggleContent={composeExpandable(
             'Kernel',


### PR DESCRIPTION
this removes extendable users from Review step when there is no user or kernel name

FIX ISSUE: (https://github.com/osbuild/image-builder-frontend/issues/2718)

JIRA: [HMS-5474](https://issues.redhat.com/browse/HMS-5474)