### PR TITLE
.github/workflows/release: fix artefact name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
       - name: Make dist
         run: |
           make dist
-          RELEASE_NO=$(echo ${{github.ref_name}} | tr -d 'v')
-          mv "cockpit-image-builder-$RELEASE_NO.tar.gz" ../cockpit-image-builder-${{github.ref_name}}.tar.gz
 
       # create release, which will bump the version
       - name: Upstream release
@@ -42,5 +40,6 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          RELEASE_NO=$(echo ${{github.ref_name}} | tr -d 'v')
           gh release upload ${{github.ref_name}} \
-            ../cockpit-image-builder-${{github.ref_name}}.tar.gz
+            ../cockpit-image-builder-$RELEASE_NO.tar.gz


### PR DESCRIPTION
After the upstream tag template changed, packit is now looking for the artefact matching the template, so without the "v".