### PR TITLE
cockpit/spec: add obsoletes & fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Make dist
         run: |
           make dist
+          RELEASE_NO=$(echo ${{github.ref_name}} | tr -d 'v')
+          mv "cockpit-image-builder-$RELEASE_NO.tar.gz" ../cockpit-image-builder-$RELEASE_NO.tar.gz
 
       # create release, which will bump the version
       - name: Upstream release

--- a/cockpit/cockpit-image-builder.spec
+++ b/cockpit/cockpit-image-builder.spec
@@ -18,7 +18,7 @@ BuildRequires:  nodejs
 
 Requires:       cockpit
 Requires:       cockpit-files
-Requires:       osbuild-composer >= 103
+Requires:       osbuild-composer >= 131
 
 %description
 The image-builder-frontend generates custom images suitable for

--- a/cockpit/cockpit-image-builder.spec
+++ b/cockpit/cockpit-image-builder.spec
@@ -7,9 +7,8 @@ License:        Apache-2.0
 URL:            http://osbuild.org/
 Source0:        https://github.com/osbuild/image-builder-frontend/releases/download/v%{version}/%{name}-%{version}.tar.gz
 
-# Drop obsoletes until functional enough compared to cockpit-composer
-# Obsoletes:      cockpit-composer < 54
-# Provides:       cockpit-composer = %{version}-%{release}
+Obsoletes:      cockpit-composer < 54
+Provides:       cockpit-composer = %{version}-%{release}
 
 BuildArch:      noarch
 BuildRequires:  gettext


### PR DESCRIPTION
With #2862  moving the artefact out of the checkout dir got reverted.


Adds an obsoletes for cockpit-composer.