### PR TITLE
dependabot: Increase limit of opened pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,5 +5,5 @@ updates:
     schedule:
       interval: "daily"
       time: "04:00"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 5
     rebase-strategy: "auto"


### PR DESCRIPTION
This will temporarily increase limit of opened pull requests, until the frontend-components bumps get resolved.