### PR TITLE
Wizard: Remove first boot script from services when no script (HMS-5481)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -566,6 +566,13 @@ const getServices = (state: RootState): Services | undefined => {
     enabledSvcs = [...enabledSvcs, FIRST_BOOT_SERVICE];
   }
   if (
+    (!selectFirstBootScript(state) ||
+      selectFirstBootScript(state).length === 0) &&
+    enabledSvcs.includes(FIRST_BOOT_SERVICE)
+  ) {
+    enabledSvcs = enabledSvcs.filter((s) => s !== FIRST_BOOT_SERVICE);
+  }
+  if (
     enabledSvcs.length === 0 &&
     services.masked.length === 0 &&
     services.disabled.length === 0

--- a/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
@@ -11,6 +11,7 @@ import {
   SCRIPT,
   SCRIPT_DOS,
   SCRIPT_WITHOUT_SHEBANG,
+  baseCreateBlueprintRequest,
   firstBootCreateBlueprintRequest,
   firstBootData,
 } from '../../../../fixtures/editMode';
@@ -259,6 +260,30 @@ describe('First Boot edit mode', () => {
       `${EDIT_BLUEPRINT}/${id}`
     );
     const expectedRequest = firstBootCreateBlueprintRequest;
+    expect(receivedRequest).toEqual(expectedRequest);
+  });
+
+  test('enabled service gets removed when first boot script is removed', async () => {
+    const user = userEvent.setup();
+    const id = mockBlueprintIds['firstBoot'];
+    await renderEditMode(id);
+
+    // navigate to the First Boot step
+    const firstBootNavItem = await screen.findAllByRole('button', {
+      name: /first boot/i,
+    });
+    await waitFor(() => user.click(firstBootNavItem[0]));
+
+    // upload empty script file and go to Review
+    await uploadFile(``);
+    await goToReviewStep();
+
+    const receivedRequest = await interceptEditBlueprintRequest(
+      `${EDIT_BLUEPRINT}/${id}`
+    );
+    // both the enabled service and files should be removed
+    // leaving the base blueprint request
+    const expectedRequest = baseCreateBlueprintRequest;
     expect(receivedRequest).toEqual(expectedRequest);
   });
 });


### PR DESCRIPTION
There is a bug that makes `custom-first-boot` service stay in services when the first boot script is removed.

How to reproduce:
1. create a blueprint with a first boot script
2. download the blueprint and confirm `custom-first-boot` was added to enabled services
3. click on "Edit blueprint"
4. go to First boot step and remove the script
5. save edited blueprint

Current behaviour:
- `custom-first-boot` service should be still enabled even with the removed first boot script

Updated behaviour:
- `custom-first-boot` is no longer in the blueprint after first boot script got removed

JIRA: [HMS-5481](https://issues.redhat.com/browse/HMS-5481)