### PR TITLE
Wizard: Fix nav status icon (HMS-5489)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -282,16 +282,14 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
     );
 
     // Only this code is different from the original
-    const status =
-      (step.isVisited && step.id !== activeStep?.id && step.status) ||
-      'default';
+    const status = (step.id !== activeStep.id && step.status) || 'default';
 
     return (
       <WizardNavItem
         key={step.id}
         id={step.id}
         content={step.name}
-        isCurrent={activeStep?.id === step.id}
+        isCurrent={activeStep.id === step.id}
         isDisabled={
           step.isDisabled ||
           (isVisitRequired && !step.isVisited && !hasVisitedNextStep)


### PR DESCRIPTION
Fixes #2700

Status icon rendered only when the step was previously visited, this caused problems with imported blueprints.

How to reproduce a bug:
1. import a blueprint with invalid hostname
2. skip to Review

Current behaviour:
- the Create blueprint button is disabled, but there is no indication of error next to the Hostname step in navigation

After fix:
- the error status should be rendered next to the Hostname nav item

JIRA: [HMS-5489](https://issues.redhat.com/browse/HMS-5489)