### PR TITLE
deps: Bump @redhat-cloud-services/frontend-components from 4.2.22 to 5.2.6 (HMS-5495)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@patternfly/react-code-editor": "5.4.1",
         "@patternfly/react-core": "5.4.12",
         "@patternfly/react-table": "5.4.14",
-        "@redhat-cloud-services/frontend-components": "4.2.22",
+        "@redhat-cloud-services/frontend-components": "5.2.6",
         "@redhat-cloud-services/frontend-components-notifications": "4.1.20",
         "@redhat-cloud-services/frontend-components-utilities": "5.0.11",
         "@reduxjs/toolkit": "2.5.1",
@@ -3867,29 +3867,29 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "4.2.22",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-4.2.22.tgz",
-      "integrity": "sha512-FEDxxNHF0Jg6thM1IIFxHZSVbsS5Eq4QxOuPvbhlXA7ijvxzkgh5hDwBZyRSYhL2za+sZPqZzYTgwwu1Mb3MNw==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-5.2.6.tgz",
+      "integrity": "sha512-YhA6tQ5KlkVoRfkIzRXQa/cvhQ6sbe6jsYt3QrX8SwJ1ojq0ekqHZDbcaPxS3U34MXnsW6877bjyAya5se+2ug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@patternfly/react-component-groups": "^5.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^4.0.0",
-        "@redhat-cloud-services/types": "^1.0.9",
+        "@patternfly/react-component-groups": "^5.5.5",
+        "@redhat-cloud-services/frontend-components-utilities": "^5.0.4",
+        "@redhat-cloud-services/types": "^1.0.19",
         "@scalprum/core": "^0.8.1",
         "@scalprum/react-core": "^0.9.1",
         "classnames": "^2.2.5",
         "sanitize-html": "^2.13.1"
       },
       "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-icons": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
+        "@patternfly/react-core": "^5.4.11",
+        "@patternfly/react-icons": "^5.4.2",
+        "@patternfly/react-table": "^5.4.12",
         "lodash": "^4.17.15",
         "prop-types": "^15.6.2",
         "react": "^18.2.0",
         "react-content-loader": "^6.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": ">=7.0.0",
+        "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
         "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
@@ -4075,33 +4075,6 @@
         "redux": ">=4.2.0"
       }
     },
-    "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/@redhat-cloud-services/frontend-components": {
-      "version": "5.2.5",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components/-/frontend-components-5.2.5.tgz",
-      "integrity": "sha512-t3gbqKE1FQkQB+aXskOs5CmyklTKRQKi1X0lDRigtufVFX04WT3ID3cKVACCgGpzDEKhIc2gJjE2+bxtBFWPBQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@patternfly/react-component-groups": "^5.5.5",
-        "@redhat-cloud-services/frontend-components-utilities": "^5.0.4",
-        "@redhat-cloud-services/types": "^1.0.19",
-        "@scalprum/core": "^0.8.1",
-        "@scalprum/react-core": "^0.9.1",
-        "classnames": "^2.2.5",
-        "sanitize-html": "^2.13.1"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": "^5.4.11",
-        "@patternfly/react-icons": "^5.4.2",
-        "@patternfly/react-table": "^5.4.12",
-        "lodash": "^4.17.15",
-        "prop-types": "^15.6.2",
-        "react": "^18.2.0",
-        "react-content-loader": "^6.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": "^7.0.0 || ^8.0.0 || ^9.0.0",
-        "react-router-dom": "^5.0.0 || ^6.0.0"
-      }
-    },
     "node_modules/@redhat-cloud-services/frontend-components-notifications/node_modules/redux-promise-middleware": {
       "version": "6.1.3",
       "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.3.tgz",
@@ -4146,31 +4119,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@redhat-cloud-services/frontend-components/node_modules/@redhat-cloud-services/frontend-components-utilities": {
-      "version": "4.0.19",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-utilities/-/frontend-components-utilities-4.0.19.tgz",
-      "integrity": "sha512-CD3tp/fHWK/qiHfxsbiKW+odlUrQM8hQ+XxhkMzLcIJFBGbH3CTSpP9ALXdO+3UsaE5h3Hk3LRoFCYWp0Aajxg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@redhat-cloud-services/rbac-client": "^1.0.111 || 2.x",
-        "@redhat-cloud-services/types": "^1.0.9",
-        "@sentry/browser": "^7.119.1",
-        "awesome-debounce-promise": "^2.1.0",
-        "axios": "^0.28.1 || ^1.7.0",
-        "commander": "^2.20.3",
-        "mkdirp": "^1.0.4",
-        "p-all": "^5.0.0",
-        "react-content-loader": "^6.2.0"
-      },
-      "peerDependencies": {
-        "@patternfly/react-core": "^5.0.0",
-        "@patternfly/react-table": "^5.0.0",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": ">=7.0.0",
-        "react-router-dom": "^5.0.0 || ^6.0.0"
       }
     },
     "node_modules/@redhat-cloud-services/javascript-clients-shared": {
@@ -15372,33 +15320,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/p-all": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-all/-/p-all-5.0.0.tgz",
-      "integrity": "sha512-pofqu/1FhCVa+78xNAptCGc9V45exFz2pvBRyIvgXkNM0Rh18Py7j8pQuSjA+zpabI46v9hRjNWmL9EAFcEbpw==",
-      "license": "MIT",
-      "dependencies": {
-        "p-map": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/p-all/node_modules/p-map": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-6.0.0.tgz",
-      "integrity": "sha512-T8BatKGY+k5rU+Q/GTYgrEf2r4xRMevAN5mtXc2aPc4rS1j3s+vWTaO2Wag94neXuCAUAs8cxBL9EeB5EA6diw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@patternfly/react-code-editor": "5.4.1",
     "@patternfly/react-core": "5.4.12",
     "@patternfly/react-table": "5.4.14",
-    "@redhat-cloud-services/frontend-components": "4.2.22",
+    "@redhat-cloud-services/frontend-components": "5.2.6",
     "@redhat-cloud-services/frontend-components-notifications": "4.1.20",
     "@redhat-cloud-services/frontend-components-utilities": "5.0.11",
     "@reduxjs/toolkit": "2.5.1",

--- a/src/Components/edge/ImageDetails.tsx
+++ b/src/Components/edge/ImageDetails.tsx
@@ -27,7 +27,7 @@ const ImageDetail = () => {
   if (edgeParityFlag) {
     return (
       <AsyncComponent
-        appName="edge"
+        scope="edge"
         module="./ImagesDetail"
         ErrorComponent={<ErrorState />}
         navigateProp={useNavigate}

--- a/src/Components/edge/ImagesTable.tsx
+++ b/src/Components/edge/ImagesTable.tsx
@@ -28,7 +28,7 @@ const ImagesTable = () => {
   if (edgeParityFlag) {
     return (
       <AsyncComponent
-        appName="edge"
+        scope="edge"
         module="./Images"
         ErrorComponent={<ErrorState />}
         navigateProp={useNavigate}


### PR DESCRIPTION
This bumps @redhat-cloud-services/frontend-components from 4.2.22 to 5.2.6 and updated `<AsyncComponent>` props. `appName` is no longer supported.

JIRA: [HMS-5495](https://issues.redhat.com/browse/HMS-5495)