### PR TITLE
Wizard: Switch view to "Available" when searching for package

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -784,6 +784,7 @@ const Packages = () => {
   ) => {
     setSearchTerm(selection);
     setToggleSourceRepos(RepoToggle.INCLUDED);
+    setToggleSelected('toggle-available');
   };
 
   const handleClear = async () => {

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -322,14 +322,14 @@ describe('Step Packages', () => {
 
     user.click(checkboxes[0]);
     user.click(checkboxes[1]);
-
     await toggleSelected();
     await clearSearchInput();
     await typeIntoSearchBox('test');
+    await toggleSelected();
 
-    const availablePackages = await getRows();
-    expect(availablePackages[0]).toHaveTextContent('test');
-    expect(availablePackages[1]).toHaveTextContent('test-sources');
+    const selectedPackages = await getRows();
+    expect(selectedPackages[0]).toHaveTextContent('test');
+    expect(selectedPackages[1]).toHaveTextContent('test-sources');
   });
 
   test('should display recommendations', async () => {


### PR DESCRIPTION
this fix an issue when user search for a package, the viewv stay "Selected" instead of switching to "Available

FIX ISSUE: (https://github.com/osbuild/image-builder-frontend/issues/2864)

JIRA: [HMS-5480](https://issues.redhat.com/browse/HMS-5480)