### PR TITLE
Wizard: Sticky footer returns (HMS-5506)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -86,16 +86,5 @@ div.pf-v5-c-alert.pf-m-inline.pf-m-plain.pf-m-warning {
 }
 
 .pf-v5-c-wizard__main {
-    /* TO DO: This part of the code is responsible for the Wizard footer being fixed
-    at the bottom of the page. Unfortunately there's a new bug that's at least
-    partially caused by this styling: when zooming in or out while in Wizard,
-    the Wizard shrunks it's height to an unusable value.
-
-    Temporarily commenting out this code, until we figure out how the handle
-    this bug.
-    */
-    // flex: 1 1 0
-    
-    // TO DO: Remove after the fix
-    min-height: 800px;
+    flex: 1 1 0
 }


### PR DESCRIPTION
The original solution that broke some time ago works again. Removing the comments and temporary workaround.

![sticky-footer](https://github.com/user-attachments/assets/ea492d85-3efc-49cb-89ef-9970b96a2b6e)


JIRA: [HMS-5506](https://issues.redhat.com/browse/HMS-5506)