### PR TITLE
Wizard: `register-later` for non-RHEL images (HMS-5515)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -78,6 +78,7 @@ import {
   selectImageTypes,
   addImageType,
 } from '../../store/wizardSlice';
+import isRhel from '../../Utilities/isRhel';
 import { resolveRelPath } from '../../Utilities/path';
 import { useFlag } from '../../Utilities/useGetEnvironment';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
@@ -379,7 +380,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 name="Register"
                 id="step-register"
                 key="step-register"
-                isHidden={!!process.env.IS_ON_PREMISE}
+                isHidden={!!process.env.IS_ON_PREMISE || !isRhel(distribution)}
                 navItem={customStatusNavItem}
                 status={
                   registrationValidation.disabledNext ? 'error' : 'default'

--- a/src/Components/CreateImageWizard/steps/ImageOutput/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/ReleaseSelect.tsx
@@ -23,6 +23,7 @@ import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import { Distributions } from '../../../../store/imageBuilderApi';
 import {
   changeDistribution,
+  changeRegistrationType,
   selectDistribution,
 } from '../../../../store/wizardSlice';
 import isRhel from '../../../../Utilities/isRhel';
@@ -44,6 +45,11 @@ const ReleaseSelect = () => {
   const releases = process.env.IS_ON_PREMISE ? ON_PREM_RELEASES : RELEASES;
 
   const handleSelect = (_event: React.MouseEvent, selection: Distributions) => {
+    if (!isRhel(selection)) {
+      dispatch(changeRegistrationType('register-later'));
+    } else {
+      dispatch(changeRegistrationType('register-now-rhc'));
+    }
     dispatch(changeDistribution(selection));
     setIsOpen(false);
   };

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -85,6 +85,7 @@ import {
   selectMetadata,
   selectFirewall,
 } from '../../../store/wizardSlice';
+import isRhel from '../../../Utilities/isRhel';
 import { FileSystemConfigurationType } from '../steps/FileSystem';
 import {
   getConversionFactor,
@@ -364,12 +365,15 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
       baseUrl: request.customizations.subscription?.['base-url'] || '',
     },
     registration: {
-      registrationType: request.customizations?.subscription
-        ? request.customizations.subscription.rhc
-          ? 'register-now-rhc'
-          : 'register-now-insights'
-        : 'register-later',
-      activationKey: request.customizations.subscription?.['activation-key'],
+      registrationType:
+        request.customizations?.subscription && isRhel(request.distribution)
+          ? request.customizations.subscription.rhc
+            ? 'register-now-rhc'
+            : 'register-now-insights'
+          : 'register-later',
+      activationKey: isRhel(request.distribution)
+        ? request.customizations.subscription?.['activation-key']
+        : undefined,
     },
     ...commonRequestToState(request),
   };

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -127,9 +127,12 @@ const selectVMwareTarget = async () => {
   await waitFor(() => user.click(vmwareImageCheckBox));
 };
 
-const goToReviewStep = async () => {
+const handleRegistration = async () => {
   await clickNext(); // Registration
   await clickRegisterLater();
+};
+
+const goToReviewStep = async () => {
   await clickNext(); // OpenSCAP
   await clickNext(); // File system customization
   await clickNext(); // Repository snapshot
@@ -308,6 +311,7 @@ describe('Step Image output', () => {
   test('revisit step button on Review works', async () => {
     await renderCreateMode();
     await selectGuestImageTarget();
+    await handleRegistration();
     await goToReviewStep();
     await clickRevisitButton();
     await screen.findByRole('heading', { name: /Image output/ });
@@ -567,6 +571,7 @@ describe('Set target using query parameter', () => {
   test('image-installer (query parameter provided)', async () => {
     await renderCreateMode({ target: 'iso' });
     expect(await screen.findByTestId('checkbox-image-installer')).toBeChecked();
+    await handleRegistration();
     await goToReviewStep();
     const targetExpandable = await screen.findByTestId(
       'target-environments-expandable'
@@ -578,6 +583,7 @@ describe('Set target using query parameter', () => {
   test('guest-image (query parameter provided)', async () => {
     await renderCreateMode({ target: 'qcow2' });
     expect(await screen.findByTestId('checkbox-guest-image')).toBeChecked();
+    await handleRegistration();
     await goToReviewStep();
     const targetExpandable = await screen.findByTestId(
       'target-environments-expandable'
@@ -596,6 +602,7 @@ describe('Distribution request generated correctly', () => {
     await renderCreateMode();
     await selectRhel8();
     await selectGuestImageTarget();
+    await handleRegistration();
     await goToReviewStep();
     // informational modal pops up in the first test only as it's tied
     // to a 'imageBuilder.saveAndBuildModalSeen' variable in localStorage
@@ -614,6 +621,7 @@ describe('Distribution request generated correctly', () => {
     await renderCreateMode();
     await selectRhel9();
     await selectGuestImageTarget();
+    await handleRegistration();
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
 
@@ -650,6 +658,7 @@ describe('Architecture request generated correctly', () => {
     await renderCreateMode();
     await selectX86_64();
     await selectGuestImageTarget();
+    await handleRegistration();
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
 
@@ -669,6 +678,7 @@ describe('Architecture request generated correctly', () => {
     await renderCreateMode();
     await selectAarch64();
     await selectGuestImageTarget();
+    await handleRegistration();
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
 

--- a/src/test/Components/CreateImageWizard/steps/Review/Review.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Review/Review.test.tsx
@@ -45,9 +45,12 @@ const setupWithCentos = async () => {
   await selectGuestImage();
 };
 
-const goToReviewStep = async () => {
+const handleRegistration = async () => {
   await clickNext(); // Registration
   await clickRegisterLater();
+};
+
+const goToReviewStep = async () => {
   await clickNext(); // OpenSCAP
   await clickNext(); // File system configuration
   await clickNext(); // Repository snapshot
@@ -73,6 +76,7 @@ describe('Step Review', () => {
 
   test('has 3 buttons', async () => {
     await setupWithRhel();
+    await handleRegistration();
     await goToReviewStep();
     await screen.findByRole('button', { name: /Create blueprint/ });
     await screen.findByRole('button', { name: /Back/ });
@@ -81,6 +85,7 @@ describe('Step Review', () => {
 
   test('clicking Back loads Image name', async () => {
     await setupWithRhel();
+    await handleRegistration();
     await goToReviewStep();
     await clickBack();
     await screen.findByRole('heading', {
@@ -90,12 +95,14 @@ describe('Step Review', () => {
 
   test('clicking Cancel loads landing page', async () => {
     await setupWithRhel();
+    await handleRegistration();
     await goToReviewStep();
     await verifyCancelButton(router);
   });
 
   test('has Registration expandable section for rhel', async () => {
     await setupWithRhel();
+    await handleRegistration();
     await goToReviewStep();
 
     await screen.findByRole('heading', { name: /Review/ });


### PR DESCRIPTION
This sets registration type to `register-later` when a non-RHEL distribution is selected.

The bug was caught on Reddit: https://www.reddit.com/r/redhat/comments/1ir6cpd/error_when_building_centos_image_on_redhat_build/

JIRA: [HMS-5515](https://issues.redhat.com/browse/HMS-5515)