### PR TITLE
Wizard: Fix blueprint name update on Architecture/Distribution changes (HMS-5556)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Details/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/index.tsx
@@ -16,8 +16,8 @@ import {
   changeBlueprintName,
   selectBlueprintDescription,
   selectBlueprintName,
+  setIsCustomName,
 } from '../../../../store/wizardSlice';
-import { useGenerateDefaultName } from '../../utilities/useGenerateDefaultName';
 import { useDetailsValidation } from '../../utilities/useValidation';
 import { ValidatedInputAndTextArea } from '../../ValidatedInput';
 
@@ -26,13 +26,12 @@ const DetailsStep = () => {
   const blueprintName = useAppSelector(selectBlueprintName);
   const blueprintDescription = useAppSelector(selectBlueprintDescription);
 
-  useGenerateDefaultName();
-
   const handleNameChange = (
     _event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
     name: string
   ) => {
     dispatch(changeBlueprintName(name));
+    dispatch(setIsCustomName());
   };
 
   const handleDescriptionChange = (

--- a/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 
 import { Text, Form, Title } from '@patternfly/react-core';
 
@@ -8,12 +8,30 @@ import ReleaseLifecycle from './ReleaseLifecycle';
 import ReleaseSelect from './ReleaseSelect';
 import TargetEnvironment from './TargetEnvironment';
 
-import { useAppSelector } from '../../../../store/hooks';
-import { selectDistribution } from '../../../../store/wizardSlice';
+import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
+import {
+  changeBlueprintName,
+  selectArchitecture,
+  selectBlueprintName,
+  selectDistribution,
+  selectIsCustomName,
+} from '../../../../store/wizardSlice';
 import DocumentationButton from '../../../sharedComponents/DocumentationButton';
+import { generateDefaultName } from '../../utilities/useGenerateDefaultName';
 
 const ImageOutputStep = () => {
+  const dispatch = useAppDispatch();
+  const blueprintName = useAppSelector(selectBlueprintName);
   const distribution = useAppSelector(selectDistribution);
+  const arch = useAppSelector(selectArchitecture);
+  const isCustomName = useAppSelector(selectIsCustomName);
+
+  useEffect(() => {
+    const defaultName = generateDefaultName(distribution, arch);
+    if (!isCustomName && blueprintName !== defaultName) {
+      dispatch(changeBlueprintName(defaultName));
+    }
+  }, [dispatch, distribution, arch, isCustomName]);
 
   return (
     <Form>

--- a/src/Components/CreateImageWizard/steps/Review/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/index.tsx
@@ -9,13 +9,10 @@ import {
   selectBlueprintDescription,
   selectBlueprintName,
 } from '../../../../store/wizardSlice';
-import { useGenerateDefaultName } from '../../utilities/useGenerateDefaultName';
 
 const ReviewStep = () => {
   const blueprintName = useAppSelector(selectBlueprintName);
   const blueprintDescription = useAppSelector(selectBlueprintDescription);
-
-  useGenerateDefaultName();
 
   return (
     <Form>

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -222,6 +222,7 @@ function commonRequestToState(
   return {
     details: {
       blueprintName: request.name || '',
+      isCustomName: true,
       blueprintDescription: request.description || '',
     },
     users:

--- a/src/Components/CreateImageWizard/utilities/useGenerateDefaultName.ts
+++ b/src/Components/CreateImageWizard/utilities/useGenerateDefaultName.ts
@@ -1,15 +1,6 @@
-import { useEffect } from 'react';
-
-import { useAppDispatch, useAppSelector } from '../../../store/hooks';
 import { Distributions, ImageRequest } from '../../../store/imageBuilderApi';
-import {
-  changeBlueprintName,
-  selectArchitecture,
-  selectBlueprintName,
-  selectDistribution,
-} from '../../../store/wizardSlice';
 
-const generateDefaultName = (
+export const generateDefaultName = (
   distribution: Distributions,
   arch: ImageRequest['architecture']
 ) => {
@@ -23,20 +14,4 @@ const generateDefaultName = (
   const dateTimeString = `${month}${day}${year}-${hours}${minutes}`;
 
   return `${distribution}-${arch}-${dateTimeString}`;
-};
-
-export const useGenerateDefaultName = () => {
-  const dispatch = useAppDispatch();
-  const blueprintName = useAppSelector(selectBlueprintName);
-  const distribution = useAppSelector(selectDistribution);
-  const arch = useAppSelector(selectArchitecture);
-
-  useEffect(() => {
-    if (!blueprintName) {
-      dispatch(changeBlueprintName(generateDefaultName(distribution, arch)));
-    }
-    // This useEffect hook should run *only* on mount and therefore has an empty
-    // dependency array. eslint's exhaustive-deps rule does not support this use.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 };

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -30,6 +30,7 @@ import type {
   GcpShareMethod,
 } from '../Components/CreateImageWizard/steps/TargetEnvironment/Gcp';
 import type { V1ListSourceResponseItem } from '../Components/CreateImageWizard/types';
+import { generateDefaultName } from '../Components/CreateImageWizard/utilities/useGenerateDefaultName';
 import { RHEL_9, X86_64 } from '../constants';
 
 import type { RootState } from '.';
@@ -140,6 +141,7 @@ export type wizardState = {
   locale: Locale;
   details: {
     blueprintName: string;
+    isCustomName: boolean;
     blueprintDescription: string;
   };
   timezone: Timezone;
@@ -226,7 +228,8 @@ export const initialState: wizardState = {
     keyboard: '',
   },
   details: {
-    blueprintName: '',
+    blueprintName: generateDefaultName(RHEL_9, X86_64),
+    isCustomName: false,
     blueprintDescription: '',
   },
   timezone: {
@@ -422,6 +425,10 @@ export const selectKeyboard = (state: RootState) => {
 
 export const selectBlueprintName = (state: RootState) => {
   return state.wizard.details.blueprintName;
+};
+
+export const selectIsCustomName = (state: RootState) => {
+  return state.wizard.details.isCustomName;
 };
 
 export const selectMetadata = (state: RootState) => {
@@ -815,6 +822,9 @@ export const wizardSlice = createSlice({
     changeBlueprintName: (state, action: PayloadAction<string>) => {
       state.details.blueprintName = action.payload;
     },
+    setIsCustomName: (state) => {
+      state.details.isCustomName = true;
+    },
     changeBlueprintDescription: (state, action: PayloadAction<string>) => {
       state.details.blueprintDescription = action.payload;
     },
@@ -1069,6 +1079,7 @@ export const {
   clearLanguages,
   changeKeyboard,
   changeBlueprintName,
+  setIsCustomName,
   changeBlueprintDescription,
   loadWizardState,
   setFirstBootScript,

--- a/src/test/Components/CreateImageWizard/steps/Details/Details.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Details/Details.test.tsx
@@ -17,7 +17,7 @@ import {
   renderEditMode,
 } from '../../wizardTestUtils';
 
-const goToDetailsStep = async () => {
+export const goToDetailsStep = async () => {
   await clickNext(); // OpenSCAP
   await clickNext(); // File system configuration
   await clickNext(); // Repository snapshot


### PR DESCRIPTION
This commit resolves an issue where the blueprint name did not update when the user changed the Architecture or Distribution.
Additionally, it sets an initial value for blueprintName in the WizardSlice.

FIX ISSUE: https://github.com/osbuild/image-builder-frontend/issues/2929

JIRA: [HMS-5556](https://issues.redhat.com/browse/HMS-5556)