### PR TITLE
Wizard: Remove "Too many results" state

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -649,7 +649,9 @@ const Packages = () => {
         selectedPackages.push(...currentlyRemovedPackages);
       }
       if (toggleSourceRepos === RepoToggle.INCLUDED) {
-        return selectedPackages;
+        return selectedPackages.sort((a, b) =>
+          sortfn(a.name, b.name, debouncedSearchTerm)
+        );
       } else {
         return [];
       }
@@ -666,7 +668,7 @@ const Packages = () => {
     packages,
     toggleSelected,
     toggleSourceRepos,
-  ]).sort((a, b) => sortfn(a.name, b.name, debouncedSearchTerm));
+  ]);
 
   const transformedGroups = useMemo(() => {
     let combinedGroupData: GroupWithRepositoryInfo[] = [];
@@ -733,7 +735,7 @@ const Packages = () => {
     groups,
     toggleSelected,
     toggleSourceRepos,
-  ]).sort((a, b) => sortfn(a.name, b.name, debouncedSearchTerm));
+  ]);
 
   const handleSearch = async (
     event: React.FormEvent<HTMLInputElement>,

--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -253,6 +253,7 @@ const Packages = () => {
                 }
                 return repo.baseurl;
               }),
+            limit: 500,
           },
         });
       }
@@ -268,6 +269,7 @@ const Packages = () => {
             uuids: customRepositories.flatMap((repo) => {
               return repo.id;
             }),
+            limit: 500,
           },
         });
       } else {
@@ -390,27 +392,6 @@ const Packages = () => {
     );
   };
 
-  const TooManyResults = () => {
-    return (
-      <Tr>
-        <Td colSpan={5}>
-          <Bullseye>
-            <EmptyState variant={EmptyStateVariant.sm}>
-              <EmptyStateHeader
-                icon={<EmptyStateIcon icon={SearchIcon} />}
-                titleText="Too many results to display"
-                headingLevel="h4"
-              />
-              <EmptyStateBody>
-                Please make the search more specific and try again.
-              </EmptyStateBody>
-            </EmptyState>
-          </Bullseye>
-        </Td>
-      </Tr>
-    );
-  };
-
   const TooShort = () => {
     return (
       <Tr>
@@ -424,27 +405,6 @@ const Packages = () => {
               />
               <EmptyStateBody>
                 Please make the search more specific and try again.
-              </EmptyStateBody>
-            </EmptyState>
-          </Bullseye>
-        </Td>
-      </Tr>
-    );
-  };
-
-  const TooManyResultsWithExactMatch = () => {
-    return (
-      <Tr>
-        <Td colSpan={5}>
-          <Bullseye>
-            <EmptyState variant={EmptyStateVariant.sm}>
-              <EmptyStateHeader
-                titleText="Too many results to display"
-                headingLevel="h4"
-              />
-              <EmptyStateBody>
-                To see more results, please make the search more specific and
-                try again.
               </EmptyStateBody>
             </EmptyState>
           </Bullseye>
@@ -885,47 +845,6 @@ const Packages = () => {
   const computeStart = () => perPage * (page - 1);
   const computeEnd = () => perPage * page;
 
-  const handleExactMatch = () => {
-    const exactMatch = transformedPackages.find(
-      (pkg) => pkg.name === debouncedSearchTerm
-    );
-
-    if (exactMatch) {
-      return (
-        <>
-          <Tr key={`${exactMatch.name}`} data-testid="exact-match-row">
-            <Td
-              select={{
-                isSelected: packages.some((p) => p.name === exactMatch.name),
-                rowIndex: 0,
-                onSelect: (event, isSelecting) =>
-                  handleSelect(exactMatch, 0, isSelecting),
-              }}
-            />
-            <Td>{exactMatch.name}</Td>
-            <Td>{exactMatch.summary}</Td>
-            {exactMatch.repository === 'distro' ? (
-              <>
-                <Td>
-                  <RedHatRepository />
-                </Td>
-                <Td>Supported</Td>
-              </>
-            ) : (
-              <>
-                <Td>Third party repository</Td>
-                <Td>Not supported</Td>
-              </>
-            )}
-          </Tr>
-          <TooManyResultsWithExactMatch />
-        </>
-      );
-    } else {
-      return <TooManyResults />;
-    }
-  };
-
   const handleCloseModalToggle = () => {
     setIsRepoModalOpen(!isRepoModalOpen);
     setIsSelectingPackage(undefined);
@@ -1169,14 +1088,8 @@ const Packages = () => {
         packages.length > 0 &&
         groups.length > 0:
         return <TryLookingUnderIncluded />;
-      case debouncedSearchTerm && transformedPackages.length >= 100:
-        return handleExactMatch();
-      case (debouncedSearchTerm || toggleSelected === 'toggle-selected') &&
-        transformedPackages.length < 100 &&
-        transformedGroups.length < 100:
-        return composePkgTable();
       default:
-        return <></>;
+        return composePkgTable();
     }
     // Would need significant rewrite to fix this
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -230,16 +230,6 @@ describe('Step Packages', () => {
     );
   });
 
-  test('should display an exact match if found regardless of too many results', async () => {
-    await renderCreateMode();
-    await goToPackagesStep();
-    await typeIntoSearchBox('testPkg-123');
-    await screen.findByTestId('exact-match-row');
-    await screen.findByRole('heading', {
-      name: /too many results to display/i,
-    });
-  });
-
   test('search results should be sorted with most relevant results first', async () => {
     await renderCreateMode();
     await goToPackagesStep();
@@ -329,13 +319,6 @@ describe('Step Packages', () => {
     await goToPackagesStep();
     await typeIntoSearchBox('asdf');
     await screen.findByText('No results found');
-  });
-
-  test('should display too many results state for more than 100 results', async () => {
-    await renderCreateMode();
-    await goToPackagesStep();
-    await typeIntoSearchBox('te');
-    await screen.findByText('Too many results to display');
   });
 
   test('should display too short', async () => {

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -99,11 +99,12 @@ const getRows = async () => {
 
 const comparePackageSearchResults = async () => {
   const availablePackages = await getRows();
+
   await waitFor(() => expect(availablePackages).toHaveLength(3));
 
   expect(availablePackages[0]).toHaveTextContent('test');
-  expect(availablePackages[1]).toHaveTextContent('testPkg');
-  expect(availablePackages[2]).toHaveTextContent('lib-test');
+  expect(availablePackages[1]).toHaveTextContent('test-lib');
+  expect(availablePackages[2]).toHaveTextContent('testPkg');
 };
 
 const clickFirstPackageCheckbox = async () => {
@@ -341,7 +342,7 @@ describe('Step Packages', () => {
 
     await clearSearchInput();
     await typeIntoSearchBox('mock');
-    await screen.findByText(/mockPkg/);
+    await screen.findByText(/mock-lib/);
 
     user.click(checkboxes[0]);
     user.click(checkboxes[1]);
@@ -353,7 +354,7 @@ describe('Step Packages', () => {
     await toggleSelected();
     const availablePackages = await getRows();
     expect(availablePackages[0]).toHaveTextContent('test');
-    expect(availablePackages[1]).toHaveTextContent('testPkg');
+    expect(availablePackages[1]).toHaveTextContent('test-lib');
   });
 
   test('should display recommendations', async () => {

--- a/src/test/fixtures/packages.ts
+++ b/src/test/fixtures/packages.ts
@@ -18,16 +18,16 @@ export const mockSourcesPackagesResults = (
   if (!isDistroPkgSearch) {
     return [
       {
-        package_name: 'testPkg-sources',
-        summary: 'test package summary',
-      },
-      {
-        package_name: 'lib-test-sources',
-        summary: 'lib-test package summary',
-      },
-      {
         package_name: 'test-sources',
         summary: 'summary for test package',
+      },
+      {
+        package_name: 'test-sources-lib',
+        summary: 'test-lib package summary',
+      },
+      {
+        package_name: 'testPkg-sources',
+        summary: 'test package summary',
       },
     ];
   }
@@ -35,32 +35,32 @@ export const mockSourcesPackagesResults = (
   if (search === 'test') {
     return [
       {
-        package_name: 'testPkg',
-        summary: 'test package summary',
-      },
-      {
-        package_name: 'lib-test',
-        summary: 'lib-test package summary',
-      },
-      {
         package_name: 'test',
         summary: 'summary for test package',
+      },
+      {
+        package_name: 'test-lib',
+        summary: 'test-lib package summary',
+      },
+      {
+        package_name: 'testPkg',
+        summary: 'test package summary',
       },
     ];
   }
   if (search === 'mock') {
     return [
       {
-        package_name: 'mockPkg',
-        summary: 'test package summary',
-      },
-      {
-        package_name: 'lib-mock',
-        summary: 'lib-test package summary',
-      },
-      {
         package_name: 'mock',
         summary: 'summary for test package',
+      },
+      {
+        package_name: 'mock-lib',
+        summary: 'test-lib package summary',
+      },
+      {
+        package_name: 'mockPkg',
+        summary: 'test package summary',
       },
     ];
   }
@@ -88,8 +88,8 @@ export const mockSourcesGroupsResults = (
 
 export const mockPkgResultAlphaContentSources: ApiRepositoryRpm[] = [
   {
-    name: 'lib-test',
-    summary: 'lib-test package summary',
+    name: 'test-lib',
+    summary: 'test-lib package summary',
     version: '1.0',
   },
   {


### PR DESCRIPTION
This removes the "Too many results" state that was rendered when a search term returned more than 100 results.