### PR TITLE
Wizard: target environments spacing (HMS-5563)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -3,6 +3,8 @@ import React, { useState } from 'react';
 import {
   Button,
   ExpandableSection,
+  Stack,
+  StackItem,
   Text,
   TextContent,
   TextList,
@@ -226,10 +228,29 @@ const Review = () => {
         isIndented
         data-testid="target-environments-expandable"
       >
-        {environments.includes('aws') && <TargetEnvAWSList />}
-        {environments.includes('gcp') && <TargetEnvGCPList />}
-        {environments.includes('azure') && <TargetEnvAzureList />}
-        {environments.includes('oci') && <TargetEnvOciList />}
+        <Stack hasGutter>
+          {environments.includes('aws') && (
+            <StackItem>
+              <TargetEnvAWSList />
+            </StackItem>
+          )}
+          {environments.includes('gcp') && (
+            <StackItem>
+              <TargetEnvGCPList />
+            </StackItem>
+          )}
+          {environments.includes('azure') && (
+            <StackItem>
+              <TargetEnvAzureList />
+            </StackItem>
+          )}
+          {environments.includes('oci') && (
+            <StackItem>
+              <TargetEnvOciList />
+            </StackItem>
+          )}
+        </Stack>
+
         {environments.includes('vsphere') && (
           <TextContent>
             <Text component={TextVariants.h3}>


### PR DESCRIPTION
Fixes #2911

The target environments in the review step of the wizard have bigger spacing.

JIRA: [HMS-5563](https://issues.redhat.com/browse/HMS-5563)