### PR TITLE
src: Remove timezone and locale unleash flags (HMS-5581)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -150,8 +150,6 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   const isFirstBootEnabled = useFlag('image-builder.firstboot.enabled');
   const complianceEnabled = useFlag('image-builder.compliance.enabled');
   const isUsersEnabled = useFlag('image-builder.users.enabled');
-  const isTimezoneEnabled = useFlag('image-builder.timezone.enabled');
-  const isLocaleEnabled = useFlag('image-builder.locale.enabled');
   const isHostnameEnabled = useFlag('image-builder.hostname.enabled');
   const isKernelEnabled = useFlag('image-builder.kernel.enabled');
   const isFirewallEnabled = useFlag('image-builder.firewall.enabled');
@@ -493,7 +491,6 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 id="wizard-timezone"
                 key="wizard-timezone"
                 navItem={customStatusNavItem}
-                isHidden={!isTimezoneEnabled}
                 status={timezoneValidation.disabledNext ? 'error' : 'default'}
                 footer={
                   <CustomWizardFooter
@@ -509,7 +506,6 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 id="wizard-locale"
                 key="wizard-locale"
                 navItem={customStatusNavItem}
-                isHidden={!isLocaleEnabled}
                 status={localeValidation.disabledNext ? 'error' : 'default'}
                 footer={
                   <CustomWizardFooter

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStep.tsx
@@ -102,8 +102,6 @@ const Review = () => {
   const [isExpandableFirstBoot, setIsExpandedFirstBoot] = useState(true);
   const [isExpandedUsers, setIsExpandedUsers] = useState(true);
 
-  const isTimezoneEnabled = useFlag('image-builder.timezone.enabled');
-  const isLocaleEnabled = useFlag('image-builder.locale.enabled');
   const isHostnameEnabled = useFlag('image-builder.hostname.enabled');
   const isKernelEnabled = useFlag('image-builder.kernel.enabled');
   const isFirewallEnabled = useFlag('image-builder.firewall.enabled');
@@ -387,43 +385,41 @@ const Review = () => {
           <UsersList />
         </ExpandableSection>
       )}
-      {isTimezoneEnabled &&
-        (timezone || (ntpServers && ntpServers.length > 0)) && (
-          <ExpandableSection
-            toggleContent={composeExpandable(
-              'Timezone',
-              'revisit-timezone',
-              'wizard-timezone'
-            )}
-            onToggle={(_event, isExpandedTimezone) =>
-              onToggleTimezone(isExpandedTimezone)
-            }
-            isExpanded={isExpandedTimezone}
-            isIndented
-            data-testid="timezone-expandable"
-          >
-            <TimezoneList />
-          </ExpandableSection>
-        )}
-      {isLocaleEnabled &&
-        ((languages && languages.length > 0) ||
-          (keyboard && keyboard.length > 0)) && (
-          <ExpandableSection
-            toggleContent={composeExpandable(
-              'Locale',
-              'revisit-locale',
-              'wizard-locale'
-            )}
-            onToggle={(_event, isExpandedLocale) =>
-              onToggleLocale(isExpandedLocale)
-            }
-            isExpanded={isExpandedLocale}
-            isIndented
-            data-testid="locale-expandable"
-          >
-            <LocaleList />
-          </ExpandableSection>
-        )}
+      {(timezone || (ntpServers && ntpServers.length > 0)) && (
+        <ExpandableSection
+          toggleContent={composeExpandable(
+            'Timezone',
+            'revisit-timezone',
+            'wizard-timezone'
+          )}
+          onToggle={(_event, isExpandedTimezone) =>
+            onToggleTimezone(isExpandedTimezone)
+          }
+          isExpanded={isExpandedTimezone}
+          isIndented
+          data-testid="timezone-expandable"
+        >
+          <TimezoneList />
+        </ExpandableSection>
+      )}
+      {((languages && languages.length > 0) ||
+        (keyboard && keyboard.length > 0)) && (
+        <ExpandableSection
+          toggleContent={composeExpandable(
+            'Locale',
+            'revisit-locale',
+            'wizard-locale'
+          )}
+          onToggle={(_event, isExpandedLocale) =>
+            onToggleLocale(isExpandedLocale)
+          }
+          isExpanded={isExpandedLocale}
+          isIndented
+          data-testid="locale-expandable"
+        >
+          <LocaleList />
+        </ExpandableSection>
+      )}
       {isHostnameEnabled && hostname && (
         <ExpandableSection
           toggleContent={composeExpandable(

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -35,8 +35,6 @@ export const useFlagWithEphemDefault = (
 const onPremFlag = (flag: string): boolean => {
   switch (flag) {
     case 'image-builder.users.enabled':
-    case 'image-builder.timezone.enabled':
-    case 'image-builder.locale.enabled':
     case 'image-builder.hostname.enabled':
     case 'image-builder.kernel.enabled':
     case 'image-builder.firewall.enabled':

--- a/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
@@ -50,6 +50,8 @@ const goToReviewStep = async () => {
   await clickNext(); // Snapshots
   await clickNext(); // Custom repositories
   await clickNext(); // Additional packages
+  await clickNext(); // Timezone
+  await clickNext(); // Locale
   await clickNext(); // Details
   await enterBlueprintName('Compliance test');
   await clickNext(); // Review

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -63,10 +63,6 @@ vi.mock('@unleash/proxy-client-react', () => ({
         return true;
       case 'image-builder.pkgrecs.enabled':
         return true;
-      case 'image-builder.timezone.enabled':
-        return true;
-      case 'image-builder.locale.enabled':
-        return true;
       case 'image-builder.hostname.enabled':
         return true;
       case 'image-builder.kernel.enabled':


### PR DESCRIPTION
This removes `image-builder.timezone.enabled` and `image-builder.locale.enabled` gating as both were released to production.

JIRA: [HMS-5581](https://issues.redhat.com/browse/HMS-5581)