### PR TITLE
Wizard: Current unselected package fix

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -138,6 +138,9 @@ const Packages = () => {
       origin: ContentOrigin.EXTERNAL,
     });
 
+  const [currentlyRemovedPackages, setCurrentlyRemovedPackages] = useState<
+    IBPackageWithRepositoryInfo[]
+  >([]);
   const [isRepoModalOpen, setIsRepoModalOpen] = useState(false);
   const [isSelectingPackage, setIsSelectingPackage] = useState<
     IBPackageWithRepositoryInfo | undefined
@@ -692,6 +695,9 @@ const Packages = () => {
       }
     } else {
       const selectedPackages = [...packages];
+      if (currentlyRemovedPackages.length > 0) {
+        selectedPackages.push(...currentlyRemovedPackages);
+      }
       if (toggleSourceRepos === RepoToggle.INCLUDED) {
         return selectedPackages;
       } else {
@@ -699,6 +705,7 @@ const Packages = () => {
       }
     }
   }, [
+    currentlyRemovedPackages,
     dataCustomPackages,
     dataDistroPackages,
     dataRecommendedPackages,
@@ -808,9 +815,13 @@ const Packages = () => {
         setIsSelectingPackage(pkg);
       } else {
         dispatch(addPackage(pkg));
+        setCurrentlyRemovedPackages((prev) =>
+          prev.filter((curr) => curr.name !== pkg.name)
+        );
       }
     } else {
       dispatch(removePackage(pkg.name));
+      setCurrentlyRemovedPackages((last) => [...last, pkg]);
       if (
         isSuccessEpelRepo &&
         epelRepo?.data &&
@@ -855,12 +866,14 @@ const Packages = () => {
 
   const handleFilterToggleClick = (event: React.MouseEvent) => {
     const id = event.currentTarget.id;
+    setCurrentlyRemovedPackages([]);
     setPage(1);
     setToggleSelected(id);
   };
 
   const handleRepoToggleClick = (type: RepoToggle) => {
     if (toggleSourceRepos !== type) {
+      setCurrentlyRemovedPackages([]);
       setPage(1);
       setToggleSourceRepos(type);
     }

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -284,6 +284,49 @@ describe('Step Packages', () => {
     expect(firstPkgCheckbox.checked).toEqual(true);
   });
 
+  test('Removing packages should not immediately remove them, only uncheck checkboxes', async () => {
+    await renderCreateMode();
+    await goToPackagesStep();
+    await typeIntoSearchBox('test');
+
+    const checkboxes = await getAllCheckboxes();
+    const firstPkgCheckbox = checkboxes[0] as HTMLInputElement;
+    const secondPkgCheckbox = checkboxes[1] as HTMLInputElement;
+    const thirdPkgCheckbox = checkboxes[2] as HTMLInputElement;
+
+    // Select multiple packages
+    expect(firstPkgCheckbox.checked).toBe(false);
+    expect(secondPkgCheckbox.checked).toBe(false);
+    expect(thirdPkgCheckbox.checked).toBe(false);
+    user.click(firstPkgCheckbox);
+    user.click(secondPkgCheckbox);
+    user.click(thirdPkgCheckbox);
+    await waitFor(() => expect(firstPkgCheckbox.checked).toBe(true));
+    await waitFor(() => expect(secondPkgCheckbox.checked).toBe(true));
+    await waitFor(() => expect(thirdPkgCheckbox.checked).toBe(true));
+
+    await toggleSelected();
+
+    // Deselect packages
+    user.click(firstPkgCheckbox);
+    await waitFor(() => expect(firstPkgCheckbox.checked).toBe(false));
+    user.click(secondPkgCheckbox);
+    await waitFor(() => expect(secondPkgCheckbox.checked).toBe(false));
+
+    // Ensure packages remain but are unchecked
+    const packageRows = await getRows();
+    expect(packageRows.length).toBeGreaterThan(2);
+
+    // Toggle next and back
+    await clickNext();
+    await clickBack();
+    await toggleSelected();
+
+    // Ensure packages are removed
+    const updatedRows = await getRows();
+    expect(updatedRows.length).toBe(1);
+  });
+
   test('should display empty available state on failed search', async () => {
     await renderCreateMode();
     await goToPackagesStep();


### PR DESCRIPTION
Modify the logic of removing a package so that it remains in the selected table for possible re-addition until another package is removed or the wizard is switched to another screen.

FIX ISSUE: https://github.com/osbuild/image-builder-frontend/issues/2924