### PR TITLE
Wizard: Fix default key creation (HMS-5623)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
@@ -164,7 +164,6 @@ const ActivationKeysList = () => {
         await createActivationKey({
           body: {
             name: defaultActivationKeyName,
-            serviceLevel: 'Self-Support',
           },
         });
         window.localStorage.setItem(


### PR DESCRIPTION
Default activation key creation was broken, resulting in `requested serviceLevel is not supported for the organization`.

This PR removes serviceLevel from the create request body, defaulting to "Not defined", same as for "Role" and "Usage".

JIRA: [HMS-5623](https://issues.redhat.com/browse/HMS-5623)