### PR TITLE
on-prem: add OpenSCAP customizations (HMS-5824)

### DIFF
--- a/playwright/test.spec.ts
+++ b/playwright/test.spec.ts
@@ -23,9 +23,10 @@ test.describe.serial('test', () => {
       });
       await page.getByTestId('automatically-register-checkbox').uncheck();
       await frame.getByRole('button', { name: 'Next', exact: true }).click();
-      await frame.getByRole('heading', { name: 'Compliance' });
-      await frame.getByRole('button', { name: 'Next', exact: true }).click();
     }
+
+    await frame.getByRole('heading', { name: 'Compliance' });
+    await frame.getByRole('button', { name: 'Next', exact: true }).click();
 
     await frame.getByRole('heading', { name: 'File system configuration' });
     await frame.getByRole('button', { name: 'Next', exact: true }).click();

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -406,9 +406,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 name={complianceEnabled ? 'Compliance' : 'OpenSCAP'}
                 id="step-oscap"
                 key="step-oscap"
-                isHidden={
-                  distribution === RHEL_10_BETA || !!process.env.IS_ON_PREMISE
-                }
+                isHidden={distribution === RHEL_10_BETA}
                 navItem={customStatusNavItem}
                 footer={
                   <CustomWizardFooter disableNext={false} optional={true} />

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -22,7 +22,6 @@ import ImageOutputStep from './steps/ImageOutput';
 import KernelStep from './steps/Kernel';
 import LocaleStep from './steps/Locale';
 import OscapStep from './steps/Oscap';
-import OscapOnPremWarning from './steps/Oscap/OnPremWarning';
 import PackagesStep from './steps/Packages';
 import RegistrationStep from './steps/Registration';
 import RepositoriesStep from './steps/Repositories';
@@ -82,7 +81,6 @@ import {
 import isRhel from '../../Utilities/isRhel';
 import { resolveRelPath } from '../../Utilities/path';
 import { useFlag } from '../../Utilities/useGetEnvironment';
-import { useOnPremOpenSCAPAvailable } from '../../Utilities/useOnPremOpenSCAP';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
 type CustomWizardFooterPropType = {
@@ -156,8 +154,6 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   const isKernelEnabled = useFlag('image-builder.kernel.enabled');
   const isFirewallEnabled = useFlag('image-builder.firewall.enabled');
   const isServicesStepEnabled = useFlag('image-builder.services.enabled');
-
-  const onPremOpenSCAPAvailable = useOnPremOpenSCAPAvailable();
 
   // IMPORTANT: Ensure the wizard starts with a fresh initial state
   useEffect(() => {
@@ -416,11 +412,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                   <CustomWizardFooter disableNext={false} optional={true} />
                 }
               >
-                {process.env.IS_ON_PREMISE && !onPremOpenSCAPAvailable ? (
-                  <OscapOnPremWarning />
-                ) : (
-                  <OscapStep />
-                )}
+                <OscapStep />
               </WizardStep>,
               <WizardStep
                 name="File system configuration"

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -22,6 +22,7 @@ import ImageOutputStep from './steps/ImageOutput';
 import KernelStep from './steps/Kernel';
 import LocaleStep from './steps/Locale';
 import OscapStep from './steps/Oscap';
+import OscapOnPremWarning from './steps/Oscap/OnPremWarning';
 import PackagesStep from './steps/Packages';
 import RegistrationStep from './steps/Registration';
 import RepositoriesStep from './steps/Repositories';
@@ -81,6 +82,7 @@ import {
 import isRhel from '../../Utilities/isRhel';
 import { resolveRelPath } from '../../Utilities/path';
 import { useFlag } from '../../Utilities/useGetEnvironment';
+import { useOnPremOpenSCAPAvailable } from '../../Utilities/useOnPremOpenSCAP';
 import { ImageBuilderHeader } from '../sharedComponents/ImageBuilderHeader';
 
 type CustomWizardFooterPropType = {
@@ -154,6 +156,8 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   const isKernelEnabled = useFlag('image-builder.kernel.enabled');
   const isFirewallEnabled = useFlag('image-builder.firewall.enabled');
   const isServicesStepEnabled = useFlag('image-builder.services.enabled');
+
+  const onPremOpenSCAPAvailable = useOnPremOpenSCAPAvailable();
 
   // IMPORTANT: Ensure the wizard starts with a fresh initial state
   useEffect(() => {
@@ -412,7 +416,11 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                   <CustomWizardFooter disableNext={false} optional={true} />
                 }
               >
-                <OscapStep />
+                {process.env.IS_ON_PREMISE && !onPremOpenSCAPAvailable ? (
+                  <OscapOnPremWarning />
+                ) : (
+                  <OscapStep />
+                )}
               </WizardStep>,
               <WizardStep
                 name="File system configuration"

--- a/src/Components/CreateImageWizard/steps/Oscap/OnPremSpinner.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/OnPremSpinner.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { Form, FormGroup, Spinner, Title } from '@patternfly/react-core';
+
+const OscapOnPremSpinner = () => {
+  return (
+    <Form>
+      <Title headingLevel="h1" size="xl">
+        OpenSCAP profile
+      </Title>
+      <FormGroup>
+        <Spinner size="xl" />
+      </FormGroup>
+    </Form>
+  );
+};
+
+export default OscapOnPremSpinner;

--- a/src/Components/CreateImageWizard/steps/Oscap/OnPremWarning.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/OnPremWarning.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+
+import {
+  Alert,
+  ClipboardCopy,
+  CodeBlock,
+  CodeBlockCode,
+  Form,
+  FormGroup,
+  Title,
+} from '@patternfly/react-core';
+
+const OscapOnPremWarning = () => {
+  return (
+    <Form>
+      <Title headingLevel="h1" size="xl">
+        OpenSCAP profile
+      </Title>
+      <FormGroup>
+        <Alert
+          style={{
+            margin:
+              '0 var(--pf-v5-c-toolbar__content--PaddingRight) 0 var(--pf-v5-c-toolbar__content--PaddingLeft)',
+          }}
+          isInline
+          variant="warning"
+          title="The packages required to apply security profiles by using OpenSCAP are missing on this host. Install them with the following command"
+          ouiaId="oscap-unavailable-alert"
+        />
+      </FormGroup>
+      <FormGroup>
+        <CodeBlock>
+          <CodeBlockCode>
+            <ClipboardCopy
+              hoverTip="Copy"
+              clickTip="Copied"
+              variant="inline-compact"
+            >
+              sudo dnf install openscap-scanner scap-security-guide
+            </ClipboardCopy>
+          </CodeBlockCode>
+        </CodeBlock>
+      </FormGroup>
+    </Form>
+  );
+};
+
+export default OscapOnPremWarning;

--- a/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
@@ -29,6 +29,7 @@ import {
   useGetOscapProfilesQuery,
   useGetOscapCustomizationsQuery,
   useLazyGetOscapCustomizationsQuery,
+  useBackendPrefetch,
 } from '../../../../store/backendApi';
 import { usePoliciesQuery, PolicyRead } from '../../../../store/complianceApi';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
@@ -99,6 +100,7 @@ const ProfileSelector = () => {
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
   const complianceType = useAppSelector(selectComplianceType);
+  const prefetchProfile = useBackendPrefetch('getOscapCustomizations');
 
   const {
     data: profiles,
@@ -138,6 +140,18 @@ const ProfileSelector = () => {
   );
 
   const [trigger] = useLazyGetOscapCustomizationsQuery();
+
+  // prefetch the profiles customizations for on-prem
+  // and save the results to the cache, since the request
+  // is quite slow
+  if (process.env.IS_ON_PREMISE) {
+    profiles?.forEach((profile) => {
+      prefetchProfile({
+        distribution: release,
+        profile: profile,
+      });
+    });
+  }
 
   useEffect(() => {
     if (!policies || policies.data === undefined) {

--- a/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
@@ -7,6 +7,7 @@ import {
   TextContent,
   Text,
   Button,
+  Spinner,
 } from '@patternfly/react-core';
 import {
   Select,
@@ -290,6 +291,10 @@ const ProfileSelector = () => {
   };
 
   const options = () => {
+    if (isFetching) {
+      return [<OScapLoadingOption key="oscap-loading-option" />];
+    }
+
     if (profiles) {
       return [<OScapNoneOption key="oscap-none-option" />].concat(
         profiles.map((profile_id, index) => {
@@ -322,7 +327,6 @@ const ProfileSelector = () => {
     >
       {complianceType === 'openscap' && (
         <Select
-          loadingVariant={isFetching ? 'spinner' : undefined}
           ouiaId="profileSelect"
           variant={SelectVariant.typeahead}
           onToggle={handleToggle}
@@ -335,6 +339,9 @@ const ProfileSelector = () => {
           typeAheadAriaLabel="Select a profile"
           isDisabled={!isSuccess || hasWslTargetOnly}
           onFilter={(_event, value) => {
+            if (isFetching) {
+              return [<OScapLoadingOption key="oscap-loading-option" />];
+            }
             if (profiles) {
               return [<OScapNoneOption key="oscap-none-option" />].concat(
                 profiles.map((profile_id, index) => {
@@ -386,6 +393,16 @@ const ProfileSelector = () => {
 const OScapNoneOption = () => {
   return (
     <SelectOption value={{ toString: () => 'None', compareTo: () => false }} />
+  );
+};
+
+const OScapLoadingOption = () => {
+  return (
+    <SelectOption
+      value={{ toString: () => 'Loading...', compareTo: () => false }}
+    >
+      <Spinner size="lg" />
+    </SelectOption>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
@@ -24,7 +24,11 @@ import {
   RHEL_10_BETA,
   RHEL_10,
 } from '../../../../constants';
-import { useGetOscapProfilesQuery } from '../../../../store/backendApi';
+import {
+  useGetOscapProfilesQuery,
+  useGetOscapCustomizationsQuery,
+  useLazyGetOscapCustomizationsQuery,
+} from '../../../../store/backendApi';
 import { usePoliciesQuery, PolicyRead } from '../../../../store/complianceApi';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
@@ -32,8 +36,6 @@ import {
   DistributionProfileItem,
   Filesystem,
   OpenScapProfile,
-  useGetOscapCustomizationsQuery,
-  useLazyGetOscapCustomizationsQuery,
   Services,
 } from '../../../../store/imageBuilderApi';
 import {

--- a/src/Components/CreateImageWizard/steps/Oscap/OscapProfileInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/OscapProfileInformation.tsx
@@ -12,12 +12,10 @@ import {
 } from '@patternfly/react-core';
 
 import { RELEASES } from '../../../../constants';
+import { useGetOscapCustomizationsQuery } from '../../../../store/backendApi';
 import { PolicyRead, usePolicyQuery } from '../../../../store/complianceApi';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
-import {
-  OpenScapProfile,
-  useGetOscapCustomizationsQuery,
-} from '../../../../store/imageBuilderApi';
+import { OpenScapProfile } from '../../../../store/imageBuilderApi';
 import {
   changeCompliance,
   selectCompliancePolicyID,

--- a/src/Components/CreateImageWizard/steps/Oscap/OscapProfileInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/OscapProfileInformation.tsx
@@ -10,7 +10,6 @@ import {
   TextListItemVariants,
   TextListVariants,
 } from '@patternfly/react-core';
-import { useFlag } from '@unleash/proxy-client-react';
 
 import { RELEASES } from '../../../../constants';
 import { PolicyRead, usePolicyQuery } from '../../../../store/complianceApi';
@@ -25,6 +24,7 @@ import {
   selectComplianceProfileID,
   selectDistribution,
 } from '../../../../store/wizardSlice';
+import { useFlag } from '../../../../Utilities/useGetEnvironment';
 
 type OscapProfileInformationOptionPropType = {
   allowChangingCompliancePolicy?: boolean;

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -10,6 +10,8 @@ import {
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 
+import OscapOnPremSpinner from './OnPremSpinner';
+import OscapOnPremWarning from './OnPremWarning';
 import { Oscap, removeBetaFromRelease } from './Oscap';
 
 import {
@@ -36,8 +38,9 @@ import {
   clearKernelAppend,
 } from '../../../../store/wizardSlice';
 import { useFlag } from '../../../../Utilities/useGetEnvironment';
+import { useOnPremOpenSCAPAvailable } from '../../../../Utilities/useOnPremOpenSCAP';
 
-const OscapStep = () => {
+const OscapContent = () => {
   const dispatch = useAppDispatch();
   const complianceEnabled = useFlag('image-builder.compliance.enabled');
   const complianceType = useAppSelector(selectComplianceType);
@@ -158,5 +161,21 @@ const OscapStep = () => {
     </Form>
   );
 };
+
+const OnPremOscapStep = () => {
+  const [onPremOpenSCAPAvailable, isLoading] = useOnPremOpenSCAPAvailable();
+
+  if (isLoading) {
+    return <OscapOnPremSpinner />;
+  }
+
+  if (!onPremOpenSCAPAvailable) {
+    return <OscapOnPremWarning />;
+  }
+
+  return <OscapContent />;
+};
+
+const OscapStep = process.env.IS_ON_PREMISE ? OnPremOscapStep : OscapContent;
 
 export default OscapStep;

--- a/src/Components/CreateImageWizard/steps/Oscap/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/index.tsx
@@ -16,9 +16,11 @@ import {
   COMPLIANCE_AND_VULN_SCANNING_URL,
   COMPLIANCE_URL,
 } from '../../../../constants';
-import { useBackendPrefetch } from '../../../../store/backendApi';
+import {
+  useBackendPrefetch,
+  useGetOscapCustomizationsQuery,
+} from '../../../../store/backendApi';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
-import { useGetOscapCustomizationsQuery } from '../../../../store/imageBuilderApi';
 import {
   ComplianceType,
   selectComplianceProfileID,

--- a/src/Utilities/useOnPremOpenSCAP.tsx
+++ b/src/Utilities/useOnPremOpenSCAP.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import cockpit from 'cockpit';
+
+export const useOnPremOpenSCAPAvailable = () => {
+  const [packagesAvailable, setPackagesAvailable] = useState(false);
+
+  useEffect(() => {
+    const checkPackages = async () => {
+      try {
+        const openSCAPAvailable = await cockpit.spawn(
+          ['rpm', '-qa', 'openscap-scanner'],
+          {}
+        );
+
+        const ssgAvailable = await cockpit.spawn(
+          ['rpm', '-qa', 'scap-security-guide'],
+          {}
+        );
+
+        setPackagesAvailable(openSCAPAvailable !== '' && ssgAvailable !== '');
+      } catch {
+        // this doesn't change the value,
+        // but we need to handle the error
+        // so just set the value to false
+        setPackagesAvailable(false);
+      }
+    };
+
+    if (process.env.IS_ON_PREMISE) {
+      checkPackages();
+    }
+  }, []);
+
+  return packagesAvailable;
+};

--- a/src/store/backendApi.ts
+++ b/src/store/backendApi.ts
@@ -35,6 +35,14 @@ export const useGetOscapProfilesQuery = process.env.IS_ON_PREMISE
   ? cockpitQueries.useGetOscapProfilesQuery
   : serviceQueries.useGetOscapProfilesQuery;
 
+export const useGetOscapCustomizationsQuery = process.env.IS_ON_PREMISE
+  ? cockpitQueries.useGetOscapCustomizationsQuery
+  : serviceQueries.useGetOscapCustomizationsQuery;
+
+export const useLazyGetOscapCustomizationsQuery = process.env.IS_ON_PREMISE
+  ? cockpitQueries.useLazyGetOscapCustomizationsQuery
+  : serviceQueries.useLazyGetOscapCustomizationsQuery;
+
 export const useComposeBlueprintMutation = process.env.IS_ON_PREMISE
   ? cockpitQueries.useComposeBlueprintMutation
   : serviceQueries.useComposeBlueprintMutation;

--- a/src/test/Components/CreateImageWizard/steps/Hostname/Hostname.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Hostname/Hostname.test.tsx
@@ -31,8 +31,8 @@ const goToHostnameStep = async () => {
   if (!process.env.IS_ON_PREMISE) {
     await clickNext(); // Registration
     await clickRegisterLater();
-    await clickNext(); // OpenSCAP
   }
+  await clickNext(); // OpenSCAP
   await clickNext(); // File system configuration
   if (!process.env.IS_ON_PREMISE) {
     await clickNext(); // Snapshots


### PR DESCRIPTION
This PR adds the following:
- enables the OpenSCAP step for on-prem
- adds a warning if the `openscap-scanner` and `scap-security-guide` packages aren't installed on the host
- this implementation runs the `oscap` tool on the host to fetch the available profiles and eventual customizations

JIRA: [HMS-5824](https://issues.redhat.com/browse/HMS-5824)