### PR TITLE
Blueprints: hiding unused activation key in when editing Blueprint (HMS-5631)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
@@ -241,7 +241,9 @@ const ActivationKeysList = () => {
           variant={SelectVariant.typeahead}
           onToggle={handleToggle}
           onSelect={setActivationKey}
-          selections={activationKey}
+          selections={
+            registrationType === 'register-later' ? '' : activationKey
+          }
           isOpen={isOpen}
           placeholderText="Select activation key"
           typeAheadAriaLabel="Select activation key"


### PR DESCRIPTION
Fixed #2960

The Select dropdown in Registration wizard step no longer shows activation key when user decides to register later.

JIRA: [HMS-5631](https://issues.redhat.com/browse/HMS-5631)