### PR TITLE
Wizard: Return of the testid (HMS-5632)

### DIFF
--- a/src/Components/CreateImageWizard/ValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedInput.tsx
@@ -16,7 +16,7 @@ import { EyeIcon, EyeSlashIcon } from '@patternfly/react-icons';
 import type { StepValidation } from './utilities/useValidation';
 
 type ValidatedTextInputPropTypes = TextInputProps & {
-  dataTestId?: string | undefined;
+  dataTestId?: string;
   ouiaId?: string;
   ariaLabel: string | undefined;
   helperText: string | undefined;
@@ -43,6 +43,7 @@ type ValidationInputProp = TextInputProps &
     value: string;
     placeholder: string;
     stepValidation: StepValidation;
+    dataTestId?: string;
     fieldName: string;
     inputType?: 'textInput' | 'textArea';
     ariaLabel: string;
@@ -115,6 +116,7 @@ export const ValidatedInputAndTextArea = ({
   stepValidation,
   fieldName,
   placeholder,
+  dataTestId,
   onChange,
   ariaLabel,
   inputType = 'textInput',
@@ -148,6 +150,7 @@ export const ValidatedInputAndTextArea = ({
           onBlur={handleBlur}
           placeholder={placeholder}
           aria-label={ariaLabel}
+          data-testid={dataTestId}
         />
       ) : (
         <TextInput
@@ -157,6 +160,7 @@ export const ValidatedInputAndTextArea = ({
           onBlur={handleBlur}
           placeholder={placeholder}
           aria-label={ariaLabel}
+          data-testid={dataTestId}
         />
       )}
       {hasError && <ErrorMessage errorMessage={errorMessage} />}

--- a/src/Components/CreateImageWizard/steps/Details/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Details/index.tsx
@@ -60,6 +60,7 @@ const DetailsStep = () => {
       <FormGroup isRequired label="Blueprint name" fieldId="blueprint-name">
         <ValidatedInputAndTextArea
           ariaLabel="blueprint name"
+          dataTestId="blueprint"
           value={blueprintName}
           isDisabled={false}
           onChange={handleNameChange}


### PR DESCRIPTION
This adds `data-testid` back to the blueprint name input.

JIRA: [HMS-5632](https://issues.redhat.com/browse/HMS-5632)