### PR TITLE
Wizard: add/rm firstboot service based on state

### DIFF
--- a/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
+++ b/src/Components/CreateImageWizard/steps/FirstBoot/index.tsx
@@ -12,8 +12,11 @@ import {
   HelperTextItem,
 } from '@patternfly/react-core';
 
+import { FIRST_BOOT_SERVICE } from '../../../../constants';
 import { useAppDispatch, useAppSelector } from '../../../../store/hooks';
 import {
+  addEnabledService,
+  removeEnabledService,
   selectFirstBootScript,
   setFirstBootScript,
 } from '../../../../store/wizardSlice';
@@ -74,6 +77,11 @@ const FirstBootStep = () => {
           isLanguageLabelVisible
           language={language}
           onCodeChange={(code) => {
+            if (!selectedScript && !!code) {
+              dispatch(addEnabledService(FIRST_BOOT_SERVICE));
+            } else if (!!selectedScript && !code) {
+              dispatch(removeEnabledService(FIRST_BOOT_SERVICE));
+            }
             // In case the user is on windows
             dispatch(setFirstBootScript(code.replace('\r\n', '\n')));
           }}

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -5,7 +5,6 @@ import { parseSizeUnit } from './parseSizeUnit';
 
 import {
   CENTOS_9,
-  FIRST_BOOT_SERVICE,
   FIRST_BOOT_SERVICE_DATA,
   RHEL_8,
   RHEL_9,
@@ -559,20 +558,7 @@ const getCustomizations = (state: RootState, orgID: string): Customizations => {
 
 const getServices = (state: RootState): Services | undefined => {
   const services = selectServices(state);
-  let enabledSvcs = services.enabled || [];
-  const includeFBSvc: boolean =
-    !!selectFirstBootScript(state) &&
-    !services.enabled?.includes(FIRST_BOOT_SERVICE);
-  if (includeFBSvc) {
-    enabledSvcs = [...enabledSvcs, FIRST_BOOT_SERVICE];
-  }
-  if (
-    (!selectFirstBootScript(state) ||
-      selectFirstBootScript(state).length === 0) &&
-    enabledSvcs.includes(FIRST_BOOT_SERVICE)
-  ) {
-    enabledSvcs = enabledSvcs.filter((s) => s !== FIRST_BOOT_SERVICE);
-  }
+  const enabledSvcs = services.enabled || [];
   if (
     enabledSvcs.length === 0 &&
     services.masked.length === 0 &&


### PR DESCRIPTION
I noticed there is a bug that does not show a relevant list of services that we create on user's behalf.

How to reproduce:
1. start creating a blueprint with a first boot script
2. go to the review step - the custom-first-boot service is not displayed there, but we are adding it on user's behalf
3. click on "Edit blueprint"
4. go to First boot step and remove the script
5. go to the review step - the custom-first-boot service is displayed there, but we will remove it after clicking "edit"


Overall, I thought that the code in requestMapper was a bit unclear, and I needed to do something similar for the Satellite follow-up, so I was digging deeper, and found a small bug.
Let me know what you think. I tried to prevent the code from removing/adding service in case we just edit an existing script.