### PR TITLE
Wizard: Refactor SSH key input using ValidatedInputAndTextArea component (HMS-5637)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/component/UserInfo.tsx
@@ -19,7 +19,6 @@ import {
 import { useUsersValidation } from '../../../utilities/useValidation';
 import {
   HookPasswordValidatedInput,
-  HookValidatedInput,
   ValidatedInputAndTextArea,
 } from '../../../ValidatedInput';
 const UserInfo = () => {
@@ -93,7 +92,7 @@ const UserInfo = () => {
         />
       </FormGroup>
       <FormGroup isRequired label="SSH key">
-        <HookValidatedInput
+        <ValidatedInputAndTextArea
           inputType={'textArea'}
           ariaLabel="public SSH key"
           value={userSshKey || ''}


### PR DESCRIPTION
This commit refactors the SSH key field by replacing `HookValidatedInput` with the new `ValidatedInputAndTextArea` component. It also fixes a bug where the validation icon remained visible after the user cleared the `SSH key` field.

JIRA: [HMS-5637](https://issues.redhat.com/browse/HMS-5637)