### PR TITLE
devDeps: Manually bump eslint-plugin-react-redux from 4.2.0 to 4.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,7 @@
         "eslint-plugin-playwright": "2.2.0",
         "eslint-plugin-react": "7.37.4",
         "eslint-plugin-react-hooks": "5.1.0",
-        "eslint-plugin-react-redux": "4.2.0",
+        "eslint-plugin-react-redux": "4.2.1",
         "eslint-plugin-testing-library": "7.1.1",
         "git-revision-webpack-plugin": "5.0.0",
         "history": "5.3.0",
@@ -7960,7 +7960,9 @@
       }
     },
     "node_modules/eslint-plugin-react-redux": {
-      "version": "4.2.0",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-redux/-/eslint-plugin-react-redux-4.2.1.tgz",
+      "integrity": "sha512-3lnzzk9sFP4OegVz9MkNZj41+8sOHtLEvmv3LKdBKxNYKgKc6F0H/4Qn7hEVU7RxzNZb1Kfr+PYcAJlX9L4EJg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-playwright": "2.2.0",
     "eslint-plugin-react": "7.37.4",
     "eslint-plugin-react-hooks": "5.1.0",
-    "eslint-plugin-react-redux": "4.2.0",
+    "eslint-plugin-react-redux": "4.2.1",
     "eslint-plugin-testing-library": "7.1.1",
     "git-revision-webpack-plugin": "5.0.0",
     "history": "5.3.0",


### PR DESCRIPTION
This bumps eslint-plugin-react-redux from 4.2.0 to 4.2.1