### PR TITLE
dependabot: ignore playwright dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,9 @@ updates:
       time: "04:00"
     open-pull-requests-limit: 3
     rebase-strategy: "auto"
+    ignore:
+      - dependency-name: "@playwright/test"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"


### PR DESCRIPTION
Since the container embedded in our CI images is pinned, any update here
would result in the container having to be pulled again in CI
runs. Let's reduce the frequency that playwright gets updated, making it
easier to keep the container and the dependencies here somewhat in sync.