### PR TITLE
Race condition activation key (HMS-5651)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
@@ -164,12 +164,12 @@ const ActivationKeysList = () => {
             name: defaultActivationKeyName,
             serviceLevel: 'Self-Support',
           },
-        });
+        }).unwrap();
+
         window.localStorage.setItem(
           'imageBuilder.recentActivationKey',
           defaultActivationKeyName
         );
-        refetch();
         dispatch(changeActivationKey(defaultActivationKeyName));
       } catch (error) {
         dispatch(


### PR DESCRIPTION
If a user skips too quickly to the Review step in Wizard, the step rerenders with the newly created activation key, and the "Create blueprint" button stays disabled until the activation key loads. 

![activation_key_rerender](https://github.com/user-attachments/assets/9c191aa9-b367-400a-9cf2-0e9bed27971c)


JIRA: [HMS-5651](https://issues.redhat.com/browse/HMS-5651)