### PR TITLE
src: Remove width limiting for Wizard and ImagesTable (HMS-5657)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -294,7 +294,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   return (
     <>
       <ImageBuilderHeader inWizard />
-      <PageSection isWidthLimited isCenterAligned>
+      <PageSection>
         <Wizard
           startIndex={startIndex}
           onClose={() => navigate(resolveRelPath(''))}

--- a/src/Components/CreateImageWizard/steps/Kernel/components/KernelName.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/components/KernelName.tsx
@@ -120,7 +120,6 @@ const KernelName = () => {
       variant="typeahead"
       onClick={onToggleClick}
       isExpanded={isOpen}
-      isFullWidth
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain

--- a/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
@@ -105,7 +105,6 @@ const KeyboardDropDown = () => {
       variant="typeahead"
       onClick={onToggleClick}
       isExpanded={isOpen}
-      isFullWidth
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain

--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -110,7 +110,6 @@ const LanguagesDropDown = () => {
       variant="typeahead"
       onClick={onToggleClick}
       isExpanded={isOpen}
-      isFullWidth
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain

--- a/src/Components/CreateImageWizard/steps/Timezone/components/TimezoneDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/components/TimezoneDropDown.tsx
@@ -102,7 +102,6 @@ const TimezoneDropDown = () => {
       variant="typeahead"
       onClick={onToggleClick}
       isExpanded={isOpen}
-      isFullWidth
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain

--- a/src/Components/LandingPage/LandingPage.tsx
+++ b/src/Components/LandingPage/LandingPage.tsx
@@ -59,7 +59,7 @@ export const LandingPage = () => {
 
   const imageList = (
     <>
-      <PageSection isWidthLimited isCenterAligned>
+      <PageSection>
         {showAlert && <NewAlert setShowAlert={setShowAlert} />}
         <Sidebar hasBorder className="pf-v5-u-background-color-100">
           <SidebarPanel

--- a/src/Components/ShareImageModal/RegionsSelect.tsx
+++ b/src/Components/ShareImageModal/RegionsSelect.tsx
@@ -158,7 +158,6 @@ const RegionsSelect = ({ composeId, handleClose }: RegionsSelectPropTypes) => {
       onClick={handleToggle}
       innerRef={toggleRef}
       isExpanded={isOpen}
-      isFullWidth
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain


### PR DESCRIPTION
This removes `isWidthLimited` prop from Page component in Wizard and ImagesTable.

JIRA: [HMS-5657](https://issues.redhat.com/browse/HMS-5657)

Before:
![image](https://github.com/user-attachments/assets/ae825b91-0876-48cd-8d84-f8205ff1beed)
![image](https://github.com/user-attachments/assets/67f09393-4837-40c6-8f40-0e871bcfd02e)

After:
![Screenshot From 2025-03-18 13-00-47](https://github.com/user-attachments/assets/0bd607f0-62c8-4223-809e-1d073871bcbf)
![Screenshot From 2025-03-18 13-01-41](https://github.com/user-attachments/assets/a4a4e9c6-2e6b-4eec-a3aa-db5c1e9ac83b)
