### PR TITLE
codecov: Ignore API, PW and store folders and update config (HMS-5792)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,15 +1,15 @@
 coverage:
   status:
-    patch: no
+    patch: off
     project:
       default:
         threshold: 5%
 codecov:
-  require_ci_to_pass: no
+  require_ci_to_pass: false
 comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
-  require_changes: no
+  require_changes: false
 ignore:
   - "api"
   - "playwright"

--- a/codecov.yml
+++ b/codecov.yml
@@ -10,3 +10,7 @@ comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default
   require_changes: no
+ignore:
+  - "api"
+  - "playwright"
+  - "src/store"


### PR DESCRIPTION
API, PW and  store folders contain mostly files that are copied, auto-generated or test files. We don't need to collect coverage for those.

There were previously errors in expected values, this should fix them.

JIRA: [HMS-5792](https://issues.redhat.com/browse/HMS-5792)