### PR TITLE
Wizard: Show "Strong" label only for Azure when password meets criteria (HMS-5674)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -518,11 +518,7 @@ const getStrength = (
   rulesCount: number,
   isAzure: boolean
 ): PasswordValidationResult['strength'] => {
-  const isValidStrength = isAzure
-    ? strCount >= 6 && rulesCount >= 3
-    : strCount >= 6;
-
-  return isValidStrength
+  return isAzure && strCount >= 6 && rulesCount >= 3
     ? { variant: 'success', icon: <CheckCircleIcon />, text: 'Strong' }
     : { variant: 'default', icon: null, text: '' };
 };


### PR DESCRIPTION
Currently, we only want to display the "Strong" label when the password meets the required strength conditions and only if it is Azure target. This change ensures that the label remains hidden for non-Azure cases.

Let’s just disable it for now until we can decide on further adjustments.

JIRA: [HMS-5674](https://issues.redhat.com/browse/HMS-5674)