### PR TITLE
Wizard: Add group input to User step (HMS-5677)

### DIFF
--- a/src/Components/CreateImageWizard/LabelInput.tsx
+++ b/src/Components/CreateImageWizard/LabelInput.tsx
@@ -22,6 +22,7 @@ type LabelInputProps = {
   placeholder: string;
   validator: (value: string) => boolean;
   requiredList?: string[] | undefined;
+  requiredCategoryName?: string;
   list: string[] | undefined;
   item: string;
   addAction: (value: string) => UnknownAction;
@@ -36,6 +37,7 @@ const LabelInput = ({
   validator,
   list,
   requiredList,
+  requiredCategoryName,
   item,
   addAction,
   removeAction,
@@ -127,7 +129,7 @@ const LabelInput = ({
       )}
       {requiredList && requiredList.length > 0 && (
         <LabelGroup
-          categoryName="Required by OpenSCAP"
+          categoryName={requiredCategoryName}
           numLabels={20}
           className="pf-v5-u-mt-sm pf-v5-u-w-100"
         >

--- a/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
@@ -46,6 +46,7 @@ const KernelArguments = () => {
         validator={isKernelArgumentValid}
         list={kernelAppend.filter((arg) => !requiredByOpenSCAP.includes(arg))}
         requiredList={requiredByOpenSCAP}
+        requiredCategoryName="Required by OpenSCAP"
         item="Kernel argument"
         addAction={addKernelArg}
         removeAction={removeKernelArg}

--- a/src/Components/CreateImageWizard/steps/Services/components/ServicesInputs.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/components/ServicesInputs.tsx
@@ -64,6 +64,7 @@ const ServicesInput = () => {
               !oscapProfileInfo?.services?.disabled?.includes(service)
           )}
           requiredList={disabledRequiredByOpenSCAP}
+          requiredCategoryName="Required by OpenSCAP"
           item="Disabled service"
           addAction={addDisabledService}
           removeAction={removeDisabledService}
@@ -80,6 +81,7 @@ const ServicesInput = () => {
             (service) => !oscapProfileInfo?.services?.masked?.includes(service)
           )}
           requiredList={maskedRequiredByOpenSCAP}
+          requiredCategoryName="Required by OpenSCAP"
           item="Masked service"
           addAction={addMaskedService}
           removeAction={removeMaskedService}
@@ -96,6 +98,7 @@ const ServicesInput = () => {
             (service) => !enabledRequiredByOpenSCAP.includes(service)
           )}
           requiredList={enabledRequiredByOpenSCAP}
+          requiredCategoryName="Required by OpenSCAP"
           item="Enabled service"
           addAction={addEnabledService}
           removeAction={removeEnabledService}

--- a/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
@@ -15,10 +15,16 @@ import {
   setUserSshKeyByIndex,
   setUserAdministratorByIndex,
   removeUser,
+  selectUserGroupsByIndex,
+  addUserGroupByIndex,
+  removeUserGroupByIndex,
 } from '../../../../../store/wizardSlice';
+import LabelInput from '../../../LabelInput';
 import { PasswordValidatedInput } from '../../../utilities/PasswordValidatedInput';
 import { useUsersValidation } from '../../../utilities/useValidation';
 import { ValidatedInputAndTextArea } from '../../../ValidatedInput';
+import { isUserGroupValid } from '../../../validators';
+
 const UserInfo = () => {
   const dispatch = useAppDispatch();
   const index = 0;
@@ -30,6 +36,8 @@ const UserInfo = () => {
   const userSshKey = useAppSelector(userSshKeySelector);
   const userIsAdministratorSelector = selectUserAdministrator(index);
   const userIsAdministrator = useAppSelector(userIsAdministratorSelector);
+  const userGroupsSelector = selectUserGroupsByIndex(index);
+  const userGroups = useAppSelector(userGroupsSelector);
 
   const handleNameChange = (
     _e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -111,11 +119,28 @@ const UserInfo = () => {
       <FormGroup>
         <Checkbox
           label="Administrator"
-          isChecked={userIsAdministrator}
+          isChecked={userIsAdministrator || userGroups.includes('wheel')}
           onChange={(_e, value) => handleCheckboxChange(_e, value)}
           aria-label="Administrator"
           id="user Administrator"
           name="user Administrator"
+        />
+      </FormGroup>
+      <FormGroup label="Groups">
+        <LabelInput
+          ariaLabel="Add user group"
+          placeholder="Add user group"
+          validator={isUserGroupValid}
+          list={userGroups}
+          item="Group"
+          addAction={(value) =>
+            addUserGroupByIndex({ index: index, group: value })
+          }
+          removeAction={(value) =>
+            removeUserGroupByIndex({ index: index, group: value })
+          }
+          stepValidation={stepValidation}
+          fieldName="groups"
         />
       </FormGroup>
       <Tooltip position="top-start" content={'Remove user'}>

--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -67,6 +67,15 @@ export const isUserNameValid = (userName: string) => {
   return isLengthValid && isNotNumericOnly && isPatternValid;
 };
 
+export const isUserGroupValid = (group: string) => {
+  // see `man groupadd` for the exact specification
+  return (
+    group.length <= 32 &&
+    /^[a-zA-Z0-9_][a-zA-Z0-9_-]*(\$)?$/.test(group) &&
+    /[a-zA-Z]+/.test(group) // contains at least one letter
+  );
+};
+
 export const isSshKeyValid = (sshKey: string) => {
   // 1. Key types: ssh-rsa, ssh-dss, ssh-ed25519, or ecdsa-sha2-nistp(256|384|521).
   // 2. Base64-encoded key material.

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -71,6 +71,11 @@ type UserAdministratorPayload = {
   isAdministrator: boolean;
 };
 
+type UserGroupPayload = {
+  index: number;
+  group: string;
+};
+
 export type wizardState = {
   env: {
     serverUrl: string;
@@ -409,6 +414,11 @@ export const selectUserSshKeyByIndex =
 export const selectUserAdministrator =
   (userIndex: number) => (state: RootState) => {
     return state.wizard.users[userIndex]?.isAdministrator;
+  };
+
+export const selectUserGroupsByIndex =
+  (userIndex: number) => (state: RootState) => {
+    return state.wizard.users[userIndex]?.groups;
   };
 
 export const selectKernel = (state: RootState) => {
@@ -1022,6 +1032,26 @@ export const wizardSlice = createSlice({
         user.groups = user.groups.filter((group) => group !== 'wheel');
       }
     },
+    addUserGroupByIndex: (state, action: PayloadAction<UserGroupPayload>) => {
+      if (
+        !state.users[action.payload.index].groups.some(
+          (group) => group === action.payload.group
+        )
+      ) {
+        state.users[action.payload.index].groups.push(action.payload.group);
+      }
+    },
+    removeUserGroupByIndex: (
+      state,
+      action: PayloadAction<UserGroupPayload>
+    ) => {
+      const groupIndex = state.users[action.payload.index].groups.findIndex(
+        (group) => group === action.payload.group
+      );
+      if (groupIndex !== -1) {
+        state.users[action.payload.index].groups.splice(groupIndex, 1);
+      }
+    },
   },
 });
 
@@ -1112,5 +1142,7 @@ export const {
   setUserPasswordByIndex,
   setUserSshKeyByIndex,
   setUserAdministratorByIndex,
+  addUserGroupByIndex,
+  removeUserGroupByIndex,
 } = wizardSlice.actions;
 export default wizardSlice.reducer;


### PR DESCRIPTION
This adds a group input to the User step. The input is implemented as a `LabelInput`, when Administrator checkbox is checked, `wheel` group gets added and it's removal automatically unchecks the Administrator checkbox again.

Tests were also added and `LabelInput` component was updated to accept custom required category name.

JIRA: [HMS-5677](https://issues.redhat.com/browse/HMS-5677)