### PR TITLE
Wizard: Remove `if (!value)` check from validators (HMS-5681)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -266,7 +266,8 @@ export function useHostnameValidation(): StepValidation {
   const errorMessage =
     'Invalid hostname. The hostname should be composed of up to 64 7-bit ASCII lower-case alphanumeric characters or hyphens forming a valid DNS domain name. It is recommended that this name contains only a single label, i.e. without any dots.';
 
-  const hostnameError = !isHostnameValid(hostname) ? errorMessage : '';
+  const hostnameError =
+    hostname && !isHostnameValid(hostname) ? errorMessage : '';
 
   return {
     errors: {
@@ -288,9 +289,8 @@ export function useKernelValidation(): StepValidation {
     }
   }
 
-  const kernelNameError = !isKernelNameValid(kernel.name)
-    ? 'Invalid format.'
-    : '';
+  const kernelNameError =
+    kernel.name && !isKernelNameValid(kernel.name) ? 'Invalid format.' : '';
 
   const kernelAppendError =
     invalidArgs.length > 0 ? `Invalid kernel arguments: ${invalidArgs}` : '';

--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -49,10 +49,6 @@ export const isSnapshotValid = (dateString: string) => {
 };
 
 export const isBlueprintDescriptionValid = (blueprintDescription: string) => {
-  if (!blueprintDescription) {
-    return true;
-  }
-
   return blueprintDescription.length <= 250;
 };
 
@@ -104,10 +100,6 @@ export const isNtpServerValid = (ntpServer: string) => {
 };
 
 export const isHostnameValid = (hostname: string) => {
-  if (!hostname) {
-    return true;
-  }
-
   return (
     hostname.length < 65 &&
     /^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$/.test(
@@ -117,10 +109,6 @@ export const isHostnameValid = (hostname: string) => {
 };
 
 export const isKernelNameValid = (kernelName: string) => {
-  if (!kernelName) {
-    return true;
-  }
-
   return (
     kernelName.length < 65 &&
     /^([a-z0-9]|[a-z0-9][a-z0-9-_.+]*)[a-z0-9]$/.test(kernelName) &&
@@ -129,10 +117,6 @@ export const isKernelNameValid = (kernelName: string) => {
 };
 
 export const isKernelArgumentValid = (arg: string) => {
-  if (!arg) {
-    return true;
-  }
-
   return /^[a-zA-Z0-9=-_,."']*$/.test(arg);
 };
 


### PR DESCRIPTION
This removes check for whether the value is defined from validators and moves it to the place the validator is called where needed.

JIRA: [HMS-5681](https://issues.redhat.com/browse/HMS-5681)