### PR TITLE
Wizard: Remove strength indicator

### DIFF
--- a/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
@@ -34,7 +34,7 @@ export const PasswordValidatedInput = ({
   const environments = useAppSelector(selectImageTypes);
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
 
-  const { validationState, strength } = checkPasswordValidity(
+  const { validationState } = checkPasswordValidity(
     value,
     environments.includes('azure')
   );
@@ -44,16 +44,8 @@ export const PasswordValidatedInput = ({
     setIsPasswordVisible(!isPasswordVisible);
   };
 
-  const passStrLabel = (
-    <HelperText>
-      <HelperTextItem variant={strength.variant} icon={strength.icon}>
-        {strength.text}
-      </HelperTextItem>
-    </HelperText>
-  );
-
   return (
-    <FormGroup label="Password" isRequired labelInfo={passStrLabel}>
+    <FormGroup label="Password" isRequired>
       <>
         <InputGroup>
           <InputGroupItem isFill>


### PR DESCRIPTION
This completely removes strength indicator as it includes the same information as the second Azure password helper text.