### PR TITLE
tsconfig: Exclude `/pkg` folder during build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,5 +24,6 @@
         "./src/test/mocks/*"
       ]
     }
-  }
+  },
+  "exclude": ["./pkg"],
 }


### PR DESCRIPTION
After running `make cockpit/devel`, the generated files do not pass `npm run build`, outputing failures and making dev console and output of `npm run build` cluttered with errors.

This excludes `/pkg` folder during build time, removing the errors.