### PR TITLE
Revert "tsconfig: Exclude `/pkg` folder during build"

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,6 +24,5 @@
         "./src/test/mocks/*"
       ]
     }
-  },
-  "exclude": ["./pkg"],
+  }
 }


### PR DESCRIPTION
Reverts osbuild/image-builder-frontend#3045

The directory needs to be excluded on webpack level. This causes a loop in webpack upon running `npm run start:stage`