### PR TITLE
fec.config: Exclude `pkg` directory during build time

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -107,6 +107,17 @@ module.exports = {
       'os-release': false,
     },
   },
+  module: {
+    rules: [
+      {
+        // running `make` on cockpit plugin creates './pkg'
+        // directory, the generated files do not pass
+        // `npm run build` outputing failures
+        // this ensures the directory is exluded during build time
+        exclude: ',/pkg',
+      },
+    ],
+  },
   routes: {
     ...(process.env.CONFIG_PORT && {
       [`${process.env.BETA ? '/beta' : ''}/config`]: {


### PR DESCRIPTION
After running `make cockpit/devel`, the generated files do not pass `npm run build`, outputing failures and making dev console and output of `npm run build` cluttered with errors.

This excludes `/pkg` folder during build time, removing the errors.