### PR TITLE
Wizard: show a specific error message when description validation fails

### DIFF
--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -42,7 +42,6 @@ import { timezones } from '../steps/Timezone/timezonesList';
 import {
   getDuplicateMountPoints,
   isBlueprintNameValid,
-  isBlueprintDescriptionValid,
   isMountpointMinSizeValid,
   isSnapshotValid,
   isHostnameValid,
@@ -598,9 +597,11 @@ export function useDetailsValidation(): StepValidation {
     return { errors: { name: '' }, disabledNext: false };
   }
 
-  const descriptionError = !isBlueprintDescriptionValid(description)
-    ? 'Invalid description'
-    : '';
+  let descriptionError = '';
+  const maxDescriptionLength = 250;
+  if (description.length > maxDescriptionLength) {
+    descriptionError = `Description is too long (max ${maxDescriptionLength} characters)`;
+  }
 
   return {
     errors: {

--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -48,10 +48,6 @@ export const isSnapshotValid = (dateString: string) => {
   return !isNaN(date.getTime()) && isSnapshotDateValid(date);
 };
 
-export const isBlueprintDescriptionValid = (blueprintDescription: string) => {
-  return blueprintDescription.length <= 250;
-};
-
 export const isFileSystemConfigValid = (partitions: Partition[]) => {
   const duplicates = getDuplicateMountPoints(partitions);
   return duplicates.length === 0;


### PR DESCRIPTION
Prior to this commit, the wizard showed "Invalid description" when the description was too long. This was rather unhelpful for users.

The actual size check happens in validators.ts, but the functions there just return a boolean value, even if they check for multiple criteria.

I'm not entirely sure, why the validation functions live in a separate file, so I decided to move this specific condition to useValidation.tsx so the condition, and the relevant user-facing error message can be defined next to each other.

Fixes #3036