### PR TITLE
Wizard: Fix OpenSCAP select width (HMS-5845)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -512,6 +512,9 @@ const ProfileSelector = () => {
           onOpenChange={handleToggle}
           toggle={toggleOpenSCAP}
           shouldFocusFirstItemOnOpen={false}
+          popperProps={{
+            maxWidth: '50vw',
+          }}
         >
           <SelectList>
             {isFetching && (


### PR DESCRIPTION
This adds a maxWidth prop to the OpenSCAP select. Previously the options overflowed on the right side of the screen.

Before:
![image](https://github.com/user-attachments/assets/a07b4176-3bb3-4a68-87c9-c0ebdee77d9b)

After:
![image](https://github.com/user-attachments/assets/afc1a1d0-2259-4b2d-9047-1940e1c6c7fb)


JIRA: [HMS-5845](https://issues.redhat.com/browse/HMS-5845)