### PR TITLE
Wizard: Add support for multiple users (HMS-5911)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Users/components/RemoveUserModal.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/RemoveUserModal.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { Button, Modal } from '@patternfly/react-core';
 
+import calculateNewIndex from './calculateNewIndex';
+
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import { removeUser, selectUsers } from '../../../../../store/wizardSlice';
 
@@ -12,6 +14,7 @@ type RemoveUserModalProps = {
   tabIndex: number;
   setIndex: React.Dispatch<React.SetStateAction<number>>;
   isOpen: boolean;
+  userName: string;
 };
 
 const RemoveUserModal = ({
@@ -21,6 +24,7 @@ const RemoveUserModal = ({
   tabIndex,
   setIndex,
   isOpen,
+  userName,
 }: RemoveUserModalProps) => {
   const dispatch = useAppDispatch();
   const users = useAppSelector(selectUsers);
@@ -30,16 +34,11 @@ const RemoveUserModal = ({
   };
 
   const onConfirm = () => {
-    const tabIndexNum = tabIndex;
-    let nextTabIndex = activeTabKey;
-
-    if (tabIndexNum < activeTabKey) {
-      // if a preceding tab is closing, keep focus on the new index of the current tab
-      nextTabIndex = activeTabKey - 1 > 0 ? activeTabKey - 1 : 0;
-    } else if (activeTabKey === users.length - 1) {
-      // if the closing tab is the last tab, focus the preceding tab
-      nextTabIndex = users.length - 2 > 0 ? users.length - 2 : 0;
-    }
+    const nextTabIndex = calculateNewIndex(
+      tabIndex,
+      activeTabKey,
+      users.length
+    );
 
     setActiveTabKey(nextTabIndex);
     setIndex(nextTabIndex);
@@ -49,7 +48,7 @@ const RemoveUserModal = ({
 
   return (
     <Modal
-      title="Remove user?"
+      title={`Remove user${userName ? ` ${userName}` : ''}?`}
       isOpen={isOpen}
       onClose={onClose}
       width="50%"

--- a/src/Components/CreateImageWizard/steps/Users/components/RemoveUserModal.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/RemoveUserModal.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import { Button, Modal } from '@patternfly/react-core';
+
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
+import { removeUser, selectUsers } from '../../../../../store/wizardSlice';
+
+type RemoveUserModalProps = {
+  setShowRemoveUserModal: React.Dispatch<React.SetStateAction<boolean>>;
+  activeTabKey: number;
+  setActiveTabKey: React.Dispatch<React.SetStateAction<number>>;
+  tabIndex: number;
+  setIndex: React.Dispatch<React.SetStateAction<number>>;
+  isOpen: boolean;
+};
+
+const RemoveUserModal = ({
+  setShowRemoveUserModal,
+  activeTabKey,
+  setActiveTabKey,
+  tabIndex,
+  setIndex,
+  isOpen,
+}: RemoveUserModalProps) => {
+  const dispatch = useAppDispatch();
+  const users = useAppSelector(selectUsers);
+
+  const onClose = () => {
+    setShowRemoveUserModal(!isOpen);
+  };
+
+  const onConfirm = () => {
+    const tabIndexNum = tabIndex;
+    let nextTabIndex = activeTabKey;
+
+    if (tabIndexNum < activeTabKey) {
+      // if a preceding tab is closing, keep focus on the new index of the current tab
+      nextTabIndex = activeTabKey - 1 > 0 ? activeTabKey - 1 : 0;
+    } else if (activeTabKey === users.length - 1) {
+      // if the closing tab is the last tab, focus the preceding tab
+      nextTabIndex = users.length - 2 > 0 ? users.length - 2 : 0;
+    }
+
+    setActiveTabKey(nextTabIndex);
+    setIndex(nextTabIndex);
+    dispatch(removeUser(tabIndex));
+    setShowRemoveUserModal(!isOpen);
+  };
+
+  return (
+    <Modal
+      title="Remove user?"
+      isOpen={isOpen}
+      onClose={onClose}
+      width="50%"
+      actions={[
+        <Button key="confirm" variant="primary" onClick={onConfirm}>
+          Remove user
+        </Button>,
+        <Button key="cancel" variant="link" onClick={onClose}>
+          Cancel
+        </Button>,
+      ]}
+      ouiaId="removeUserModal"
+    >
+      This action is permanent and cannot be undone. Once deleted all
+      information about the user will be lost.
+    </Modal>
+  );
+};
+
+export default RemoveUserModal;

--- a/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
@@ -1,21 +1,26 @@
-import React from 'react';
+import React, { useState } from 'react';
 
-import { Button, FormGroup, Checkbox, Tooltip } from '@patternfly/react-core';
-import { ExternalLinkAltIcon, TrashIcon } from '@patternfly/react-icons';
+import {
+  Button,
+  FormGroup,
+  Checkbox,
+  Tabs,
+  Tab,
+  TabTitleText,
+} from '@patternfly/react-core';
+import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+
+import RemoveUserModal from './RemoveUserModal';
 
 import { GENERATING_SSH_KEY_PAIRS_URL } from '../../../../../constants';
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
 import {
-  selectUserAdministrator,
-  selectUserNameByIndex,
-  selectUserPasswordByIndex,
-  selectUserSshKeyByIndex,
   setUserNameByIndex,
   setUserPasswordByIndex,
   setUserSshKeyByIndex,
   setUserAdministratorByIndex,
-  removeUser,
-  selectUserGroupsByIndex,
+  addUser,
+  selectUsers,
   addUserGroupByIndex,
   removeUserGroupByIndex,
 } from '../../../../../store/wizardSlice';
@@ -27,17 +32,29 @@ import { isUserGroupValid } from '../../../validators';
 
 const UserInfo = () => {
   const dispatch = useAppDispatch();
-  const index = 0;
-  const userNameSelector = selectUserNameByIndex(index);
-  const userName = useAppSelector(userNameSelector);
-  const userPasswordSelector = selectUserPasswordByIndex(index);
-  const userPassword = useAppSelector(userPasswordSelector);
-  const userSshKeySelector = selectUserSshKeyByIndex(index);
-  const userSshKey = useAppSelector(userSshKeySelector);
-  const userIsAdministratorSelector = selectUserAdministrator(index);
-  const userIsAdministrator = useAppSelector(userIsAdministratorSelector);
-  const userGroupsSelector = selectUserGroupsByIndex(index);
-  const userGroups = useAppSelector(userGroupsSelector);
+  const users = useAppSelector(selectUsers);
+  const stepValidation = useUsersValidation();
+
+  const [index, setIndex] = useState(0);
+  const [activeTabKey, setActiveTabKey] = useState(0);
+  const [tabIndex, setTabIndex] = useState(0);
+  const [showRemoveUserModal, setShowRemoveUserModal] = useState(false);
+
+  const onSelect = (event: React.MouseEvent, tabIndex: number) => {
+    setActiveTabKey(tabIndex);
+    setIndex(tabIndex);
+  };
+
+  const onAdd = () => {
+    setActiveTabKey(users.length);
+    setIndex(index + 1);
+    dispatch(addUser());
+  };
+
+  const onClose = (_event: React.MouseEvent, tabIndex: number) => {
+    setShowRemoveUserModal(true);
+    setTabIndex(tabIndex);
+  };
 
   const handleNameChange = (
     _e: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>,
@@ -60,8 +77,6 @@ const UserInfo = () => {
     dispatch(setUserSshKeyByIndex({ index: index, sshKey: value }));
   };
 
-  const stepValidation = useUsersValidation();
-
   const handleCheckboxChange = (
     _event: React.FormEvent<HTMLInputElement>,
     value: boolean
@@ -71,88 +86,111 @@ const UserInfo = () => {
     );
   };
 
-  const onRemoveUserClick = () => {
-    dispatch(removeUser(index));
+  const getValidationByIndex = (index: number) => {
+    return {
+      errors: {
+        userName: stepValidation?.errors[index]?.userName,
+        userSshKey: stepValidation?.errors[index]?.userSshKey,
+      },
+      disabledNext: stepValidation.disabledNext,
+    };
   };
 
   return (
     <>
-      <FormGroup isRequired label="Username">
-        <ValidatedInputAndTextArea
-          ariaLabel="blueprint user name"
-          value={userName || ''}
-          placeholder="Enter username"
-          onChange={(_e, value) => handleNameChange(_e, value)}
-          stepValidation={stepValidation}
-          fieldName="userName"
-        />
-      </FormGroup>
-      <PasswordValidatedInput
-        value={userPassword || ''}
-        ariaLabel="blueprint user password"
-        placeholder="Enter password"
-        onChange={(_e, value) => handlePasswordChange(_e, value)}
+      <RemoveUserModal
+        setShowRemoveUserModal={setShowRemoveUserModal}
+        activeTabKey={activeTabKey}
+        setActiveTabKey={setActiveTabKey}
+        tabIndex={tabIndex}
+        setIndex={setIndex}
+        isOpen={showRemoveUserModal}
       />
-      <FormGroup isRequired label="SSH key">
-        <ValidatedInputAndTextArea
-          inputType={'textArea'}
-          ariaLabel="public SSH key"
-          value={userSshKey || ''}
-          type={'text'}
-          onChange={(_e, value) => handleSshKeyChange(_e, value)}
-          placeholder="Paste your public SSH key"
-          stepValidation={stepValidation}
-          fieldName="userSshKey"
-        />
-        <Button
-          component="a"
-          target="_blank"
-          variant="link"
-          icon={<ExternalLinkAltIcon />}
-          iconPosition="right"
-          href={GENERATING_SSH_KEY_PAIRS_URL}
-          className="pf-v5-u-pl-0"
-        >
-          Learn more about SSH keys
-        </Button>
-      </FormGroup>
-      <FormGroup>
-        <Checkbox
-          label="Administrator"
-          isChecked={userIsAdministrator || userGroups.includes('wheel')}
-          onChange={(_e, value) => handleCheckboxChange(_e, value)}
-          aria-label="Administrator"
-          id="user Administrator"
-          name="user Administrator"
-        />
-      </FormGroup>
-      <FormGroup label="Groups">
-        <LabelInput
-          ariaLabel="Add user group"
-          placeholder="Add user group"
-          validator={isUserGroupValid}
-          list={userGroups}
-          item="Group"
-          addAction={(value) =>
-            addUserGroupByIndex({ index: index, group: value })
-          }
-          removeAction={(value) =>
-            removeUserGroupByIndex({ index: index, group: value })
-          }
-          stepValidation={stepValidation}
-          fieldName="groups"
-        />
-      </FormGroup>
-      <Tooltip position="top-start" content={'Remove user'}>
-        <FormGroup>
-          <Button
-            aria-label="remove user"
-            onClick={onRemoveUserClick}
-            variant="tertiary"
-            icon={<TrashIcon />}
-          ></Button>
-        </FormGroup>
-      </Tooltip>
+      <Tabs
+        aria-label="Users tabs"
+        activeKey={activeTabKey}
+        onSelect={onSelect}
+        onAdd={onAdd}
+        onClose={onClose}
+      >
+        {users.map((user, index) => (
+          <Tab
+            aria-label={`User ${user.name} tab`}
+            key={user.name}
+            eventKey={index}
+            title={<TabTitleText>{user.name || 'New user'}</TabTitleText>}
+          >
+            <FormGroup isRequired label="Username" className="pf-v5-u-pb-md">
+              <ValidatedInputAndTextArea
+                ariaLabel="blueprint user name"
+                value={user.name || ''}
+                placeholder="Enter username"
+                onChange={(_e, value) => handleNameChange(_e, value)}
+                stepValidation={getValidationByIndex(index)}
+                fieldName="userName"
+              />
+            </FormGroup>
+            <PasswordValidatedInput
+              value={user.password || ''}
+              ariaLabel="blueprint user password"
+              placeholder="Enter password"
+              onChange={(_e, value) => handlePasswordChange(_e, value)}
+            />
+            <FormGroup label="SSH key" className="pf-v5-u-pb-md">
+              <ValidatedInputAndTextArea
+                inputType={'textArea'}
+                ariaLabel="public SSH key"
+                value={user.ssh_key || ''}
+                type={'text'}
+                onChange={(_e, value) => handleSshKeyChange(_e, value)}
+                placeholder="Paste your public SSH key"
+                stepValidation={getValidationByIndex(index)}
+                fieldName="userSshKey"
+              />
+              <Button
+                component="a"
+                target="_blank"
+                variant="link"
+                icon={<ExternalLinkAltIcon />}
+                iconPosition="right"
+                href={GENERATING_SSH_KEY_PAIRS_URL}
+                className="pf-v5-u-pl-0"
+              >
+                Learn more about SSH keys
+              </Button>
+            </FormGroup>
+            <FormGroup className="pf-v5-u-pb-md">
+              <Checkbox
+                label="Administrator"
+                isChecked={
+                  user.isAdministrator || user.groups.includes('wheel')
+                }
+                onChange={(_e, value) => handleCheckboxChange(_e, value)}
+                aria-label="Administrator"
+                id="user Administrator"
+                name="user Administrator"
+              />
+            </FormGroup>
+            <FormGroup label="Groups">
+              <LabelInput
+                ariaLabel="Add user group"
+                placeholder="Add user group"
+                validator={isUserGroupValid}
+                list={user.groups}
+                item="Group"
+                addAction={(value) =>
+                  addUserGroupByIndex({ index: index, group: value })
+                }
+                removeAction={(value) =>
+                  removeUserGroupByIndex({ index: index, group: value })
+                }
+                stepValidation={getValidationByIndex(index)}
+                fieldName="groups"
+              />
+            </FormGroup>
+          </Tab>
+        ))}
+      </Tabs>
     </>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Users/components/calculateNewIndex.ts
+++ b/src/Components/CreateImageWizard/steps/Users/components/calculateNewIndex.ts
@@ -1,0 +1,20 @@
+function calculateNewIndex(
+  tabIndex: number,
+  activeTabKey: number,
+  usersLength: number
+) {
+  const tabIndexNum = tabIndex;
+  let nextTabIndex = activeTabKey;
+
+  if (tabIndexNum < activeTabKey) {
+    // if a preceding tab is closing, keep focus on the new index of the current tab
+    nextTabIndex = activeTabKey - 1 > 0 ? activeTabKey - 1 : 0;
+  } else if (activeTabKey === usersLength - 1) {
+    // if the closing tab is the last tab, focus the preceding tab
+    nextTabIndex = usersLength - 2 >= 0 ? usersLength - 2 : 0;
+  }
+
+  return nextTabIndex;
+}
+
+export default calculateNewIndex;

--- a/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
@@ -45,7 +45,7 @@ export const PasswordValidatedInput = ({
   };
 
   return (
-    <FormGroup label="Password" isRequired>
+    <FormGroup label="Password" className="pf-v5-u-pb-md">
       <>
         <InputGroup>
           <InputGroupItem isFill>

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -487,6 +487,7 @@ export function useUsersValidation(): UsersStepValidation {
       users[index].password,
       environments.includes('azure')
     ).isValid;
+    const passwordError = !isPasswordValid ? 'Invalid password' : '';
 
     if (
       userNameError ||
@@ -496,7 +497,7 @@ export function useUsersValidation(): UsersStepValidation {
       errors[`${index}`] = {
         userName: userNameError,
         userSshKey: sshKeyError,
-        userPassword: !isPasswordValid ? 'Invalid password' : '',
+        userPassword: passwordError,
       };
     }
   }

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
@@ -10,30 +10,6 @@ const getSourceDropdown = async () => {
   return sourceDropdown;
 };
 
-export const addTargetEnvAzure = async () => {
-  const user = userEvent.setup();
-  expect(
-    await screen.findByRole('radio', {
-      name: /use an account configured from sources\./i,
-    })
-  ).toHaveFocus();
-  const azureSourceDropdown = await getSourceDropdown();
-  await waitFor(() => user.click(azureSourceDropdown));
-  const azureSource = await screen.findByRole('option', {
-    name: /azureSource1/i,
-  });
-  await waitFor(() => user.click(azureSource));
-
-  const resourceGroupDropdown = await screen.findByPlaceholderText(
-    /select resource group/i
-  );
-  await waitFor(() => user.click(resourceGroupDropdown));
-  await waitFor(async () =>
-    user.click(await screen.findByLabelText('Resource group myResourceGroup1'))
-  );
-  await clickNext();
-};
-
 const selectAllEnvironments = async () => {
   const user = userEvent.setup();
 
@@ -134,7 +110,28 @@ describe('Keyboard accessibility', () => {
     await clickNext();
 
     // Target environment azure
-    await addTargetEnvAzure();
+    expect(
+      await screen.findByRole('radio', {
+        name: /use an account configured from sources\./i,
+      })
+    ).toHaveFocus();
+    const azureSourceDropdown = await getSourceDropdown();
+    await waitFor(() => user.click(azureSourceDropdown));
+    const azureSource = await screen.findByRole('option', {
+      name: /azureSource1/i,
+    });
+    await waitFor(() => user.click(azureSource));
+
+    const resourceGroupDropdown = await screen.findByPlaceholderText(
+      /select resource group/i
+    );
+    await waitFor(() => user.click(resourceGroupDropdown));
+    await waitFor(async () =>
+      user.click(
+        await screen.findByLabelText('Resource group myResourceGroup1')
+      )
+    );
+    await clickNext();
 
     // Registration
     await screen.findByText(

--- a/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
@@ -26,6 +26,8 @@ const validUserName = 'best';
 const validSshKey = 'ssh-rsa d';
 const validPassword = 'validPassword';
 const invalidPassword = 'inval';
+const rachelPasswd = 'rachelPass';
+const chandlerPasswd = 'chandlerPass';
 
 const goToUsersStep = async () => {
   await clickNext(); // Registration
@@ -156,10 +158,10 @@ const addUserName = async (userName: string) => {
   await waitFor(() => expect(enterUserName).toHaveValue(userName));
 };
 
-const addPasswordByUserIndex = async (password: string, index: number) => {
+const addPasswordByUserIndex = async (value: string, index: number) => {
   const user = userEvent.setup();
   const passwordInputs = screen.getAllByPlaceholderText(/enter password/i);
-  await waitFor(() => user.type(passwordInputs[index], password));
+  await waitFor(() => user.type(passwordInputs[index], value));
 };
 
 const getAdminCheckbox = async () => {
@@ -436,7 +438,7 @@ describe('User request generated correctly', () => {
           {
             name: 'rachel',
             ssh_key: 'ssh-rsa rachel',
-            password: 'rachelPass',
+            password: rachelPasswd,
             groups: ['wheel', 'users', 'widget'],
           },
           {
@@ -445,7 +447,7 @@ describe('User request generated correctly', () => {
           {
             name: 'chandler',
             ssh_key: 'ssh-rsa chandler',
-            password: 'chandlerPass',
+            password: chandlerPasswd,
             groups: ['group'],
           },
         ],

--- a/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
@@ -67,9 +67,13 @@ const clickAddUser = async () => {
 
 const clickRemoveUser = async () => {
   const user = userEvent.setup();
-  const addUser = await screen.findByRole('button', { name: /remove user/i });
-  expect(addUser).toBeEnabled();
-  await waitFor(() => user.click(addUser));
+  const removeUser = await screen.findByRole('button', { name: /close tab/i });
+  expect(removeUser).toBeEnabled();
+  await waitFor(() => user.click(removeUser));
+  const removeUserModalButton = await screen.findByRole('button', {
+    name: /Remove user/,
+  });
+  await waitFor(() => user.click(removeUserModalButton));
 };
 
 const addSshKey = async (sshKey: string) => {

--- a/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
@@ -407,7 +407,7 @@ describe('User request generated correctly', () => {
     await addUserGroupByUserIndex('users', 0);
     await addUserGroupByUserIndex('widget', 0);
     await closeNthTab(0);
-    await waitFor(() => expect(screen.getByText(/add a user to your image/i)));
+    await screen.findByText(/add a user to your image/i);
     await goToReviewStep();
     const receivedRequest = await interceptBlueprintRequest(CREATE_BLUEPRINT);
 


### PR DESCRIPTION
This adds support for multiple users in the Wizard. The users are rendered in tabs and can be both added and removed. When clicking on remove button, modal pops up to inform user that the changes cannot be undone.

JIRA: [HMS-5911](https://issues.redhat.com/browse/HMS-5911)