### PR TITLE
Promote WSL to production stable (HMS-5950)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
@@ -29,17 +29,13 @@ import {
   selectImageTypes,
 } from '../../../../store/wizardSlice';
 import isRhel from '../../../../Utilities/isRhel';
-import {
-  useFlag,
-  useGetEnvironment,
-} from '../../../../Utilities/useGetEnvironment';
+import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
 
 const TargetEnvironment = () => {
   const arch = useAppSelector(selectArchitecture);
   const environments = useAppSelector(selectImageTypes);
   const distribution = useAppSelector(selectDistribution);
   const { isFedoraEnv } = useGetEnvironment();
-  const wslFlag = useFlag('image-builder.wsl.enabled');
 
   const { data } = useGetArchitecturesQuery(
     {
@@ -353,7 +349,7 @@ const TargetEnvironment = () => {
             data-testid="checkbox-image-installer"
           />
         )}
-        {supportedEnvironments?.includes('wsl') && wslFlag && (
+        {supportedEnvironments?.includes('wsl') && (
           <Checkbox
             label={
               <>

--- a/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
@@ -359,9 +359,7 @@ const TargetEnvironment = () => {
                   position="right"
                   headerContent={
                     <TextContent>
-                      <Text>
-                        WSL is not officially supported by Red Hat.
-                      </Text>
+                      <Text>WSL is not officially supported by Red Hat</Text>
                     </TextContent>
                   }
                   bodyContent={
@@ -374,14 +372,14 @@ const TargetEnvironment = () => {
                   }
                   footerContent={
                     <Button
-                          component="a"
-                          target="_blank"
-                          variant="link"
-                          icon={<ExternalLinkAltIcon />}
-                          iconPosition="right"
-                          isInline
-                          href="https://access.redhat.com/solutions/6338661"
-                        >
+                      component="a"
+                      target="_blank"
+                      variant="link"
+                      icon={<ExternalLinkAltIcon />}
+                      iconPosition="right"
+                      isInline
+                      href="https://access.redhat.com/solutions/6338661"
+                    >
                       Learn more
                     </Button>
                   }

--- a/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
@@ -11,7 +11,7 @@ import {
   TextVariants,
   Tile,
 } from '@patternfly/react-core';
-import { HelpIcon } from '@patternfly/react-icons';
+import { HelpIcon, ExternalLinkAltIcon } from '@patternfly/react-icons';
 
 import { useGetArchitecturesQuery } from '../../../../store/backendApi';
 import { useAppSelector, useAppDispatch } from '../../../../store/hooks';
@@ -355,7 +355,52 @@ const TargetEnvironment = () => {
         )}
         {supportedEnvironments?.includes('wsl') && wslFlag && (
           <Checkbox
-            label="WSL - Windows Subsystem for Linux (.tar.gz)"
+            label={
+              <>
+                WSL - Windows Subsystem for Linux (.tar.gz)
+                <Popover
+                  maxWidth="30rem"
+                  position="right"
+                  headerContent={
+                    <TextContent>
+                      <Text>
+                        WSL is not officially supported by Red Hat.
+                      </Text>
+                    </TextContent>
+                  }
+                  bodyContent={
+                    <TextContent>
+                      <Text>
+                        Unfortunately Windows Subsystem for Linux is currently
+                        not supported by Red Hat.
+                      </Text>
+                    </TextContent>
+                  }
+                  footerContent={
+                    <Button
+                          component="a"
+                          target="_blank"
+                          variant="link"
+                          icon={<ExternalLinkAltIcon />}
+                          iconPosition="right"
+                          isInline
+                          href="https://access.redhat.com/solutions/6338661"
+                        >
+                      Learn more
+                    </Button>
+                  }
+                >
+                  <Button
+                    className="pf-v5-u-pl-sm pf-v5-u-pt-0 pf-v5-u-pb-0"
+                    variant="plain"
+                    aria-label="About WSL file"
+                    isInline
+                  >
+                    <HelpIcon />
+                  </Button>
+                </Popover>
+              </>
+            }
             isChecked={environments.includes('wsl')}
             onChange={() => {
               handleToggleEnvironment('wsl');


### PR DESCRIPTION
This simple pull request promotes WSL images to production stable.

It also adds a Popover to reflect that this image type is currently not supported by Red Hat. The Popover and text reflect the UX mockup.

![image](https://github.com/user-attachments/assets/c6d0052e-867e-4e01-9f94-6579364285a4)

/jira-epic HMS-5949

JIRA: [HMS-5950](https://issues.redhat.com/browse/HMS-5950)