### PR TITLE
Wizard: Password placeholder (HMS-5951)

### DIFF
--- a/api/schema/imageBuilder.yaml
+++ b/api/schema/imageBuilder.yaml
@@ -2013,6 +2013,10 @@ components:
             Plaintext passwords are also supported, they will be hashed and stored using the SHA-512 algorithm.
             The password is never returned in the response.
             Empty string can be used to remove the password during update but only with ssh_key set.
+        hasPassword:
+          type: boolean
+          description: |
+            Indicates whether the user has a password set.
     Filesystem:
       type: object
       required:

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTextLists.tsx
@@ -72,13 +72,10 @@ import {
   selectLanguages,
   selectKeyboard,
   selectHostname,
-  selectUserNameByIndex,
-  selectUserPasswordByIndex,
-  selectUserSshKeyByIndex,
   selectKernel,
-  selectUserAdministrator,
   selectFirewall,
   selectServices,
+  selectUsers,
 } from '../../../../store/wizardSlice';
 import { toMonthAndYear, yyyyMMddFormat } from '../../../../Utilities/time';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
@@ -800,20 +797,12 @@ export const TimezoneList = () => {
 };
 
 export const UsersList = () => {
-  const index = 0;
-  const userNameSelector = selectUserNameByIndex(index);
-  const userName = useAppSelector(userNameSelector);
-  const userPasswordSelector = selectUserPasswordByIndex(index);
-  const userPassword = useAppSelector(userPasswordSelector);
-  const userSshKeySelector = selectUserSshKeyByIndex(index);
-  const userSshKey = useAppSelector(userSshKeySelector);
-  const userIsAdministratorSelector = selectUserAdministrator(index);
-  const userIsAdministrator = useAppSelector(userIsAdministratorSelector);
+  const users = useAppSelector(selectUsers);
 
   return (
     <TextContent>
-      <TextList component={TextListVariants.dl}>
-        <>
+      {users.map((user) => (
+        <TextList key={user.name} component={TextListVariants.dl}>
           <TextListItem
             component={TextListItemVariants.dt}
             className="pf-v5-u-min-width"
@@ -821,7 +810,7 @@ export const UsersList = () => {
             Username
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            {userName ? userName : 'None'}
+            {user.name ? user.name : 'None'}
           </TextListItem>
           <TextListItem
             component={TextListItemVariants.dt}
@@ -830,7 +819,7 @@ export const UsersList = () => {
             Password
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            {userPassword ? '●'.repeat(8) : 'None'}
+            {user.password || user.hasPassword ? '●'.repeat(8) : 'None'}
           </TextListItem>
           <TextListItem
             component={TextListItemVariants.dt}
@@ -839,7 +828,7 @@ export const UsersList = () => {
             SSH key
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            {userSshKey ? userSshKey : 'None'}
+            {user.ssh_key ? user.ssh_key : 'None'}
           </TextListItem>
           <TextListItem
             component={TextListItemVariants.dt}
@@ -848,10 +837,10 @@ export const UsersList = () => {
             Administrator
           </TextListItem>
           <TextListItem component={TextListItemVariants.dd}>
-            {userIsAdministrator ? 'True' : 'False'}
+            {user.isAdministrator ? 'True' : 'False'}
           </TextListItem>
-        </>
-      </TextList>
+        </TextList>
+      ))}
     </TextContent>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
@@ -172,6 +172,7 @@ const UserInfo = () => {
               ariaLabel="blueprint user password"
               placeholder="Enter password"
               onChange={(_e, value) => handlePasswordChange(_e, value)}
+              hasPassword={user.hasPassword}
             />
             <FormGroup label="SSH key" className="pf-v5-u-pb-md">
               <ValidatedInputAndTextArea

--- a/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
@@ -23,6 +23,7 @@ type ValidatedPasswordInput = TextInputProps & {
   placeholder: string;
   ariaLabel: string;
   onChange: (event: React.FormEvent<HTMLInputElement>, value: string) => void;
+  hasPassword: boolean;
 };
 
 export const PasswordValidatedInput = ({
@@ -30,6 +31,7 @@ export const PasswordValidatedInput = ({
   placeholder,
   ariaLabel,
   onChange,
+  hasPassword,
 }: ValidatedPasswordInput) => {
   const environments = useAppSelector(selectImageTypes);
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
@@ -52,7 +54,7 @@ export const PasswordValidatedInput = ({
             <TextInput
               isRequired
               type={isPasswordVisible ? 'text' : 'password'}
-              value={value}
+              value={hasPassword ? '•'.repeat(8) : value}
               onChange={onChange}
               aria-label={ariaLabel}
               placeholder={placeholder}
@@ -63,6 +65,7 @@ export const PasswordValidatedInput = ({
               variant="control"
               onClick={togglePasswordVisibility}
               aria-label={isPasswordVisible ? 'Hide password' : 'Show password'}
+              isDisabled={hasPassword}
             >
               {isPasswordVisible ? <EyeSlashIcon /> : <EyeIcon />}
             </Button>

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -235,6 +235,7 @@ function commonRequestToState(
         ssh_key: user.ssh_key || '',
         groups: user.groups || [],
         isAdministrator: user.groups?.includes('wheel') || false,
+        hasPassword: user.hasPassword || false,
       })) || [],
     compliance:
       compliancePolicyID !== undefined

--- a/src/store/service/imageBuilderApi.ts
+++ b/src/store/service/imageBuilderApi.ts
@@ -654,6 +654,9 @@ export type User = {
     Empty string can be used to remove the password during update but only with ssh_key set.
      */
   password?: string | undefined;
+  /** Indicates whether the user has a password set.
+   */
+  hasPassword?: boolean | undefined;
 };
 export type Services = {
   /** List of services to enable by default */

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -1017,6 +1017,7 @@ export const wizardSlice = createSlice({
         ssh_key: '',
         groups: [],
         isAdministrator: false,
+        hasPassword: false,
       };
 
       state.users.push(newUser);

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -414,31 +414,6 @@ export const selectUsers = (state: RootState) => {
   return state.wizard.users;
 };
 
-export const selectUserNameByIndex =
-  (userIndex: number) => (state: RootState) => {
-    return state.wizard.users[userIndex]?.name;
-  };
-
-export const selectUserPasswordByIndex =
-  (userIndex: number) => (state: RootState) => {
-    return state.wizard.users[userIndex]?.password;
-  };
-
-export const selectUserSshKeyByIndex =
-  (userIndex: number) => (state: RootState) => {
-    return state.wizard.users[userIndex]?.ssh_key;
-  };
-
-export const selectUserAdministrator =
-  (userIndex: number) => (state: RootState) => {
-    return state.wizard.users[userIndex]?.isAdministrator;
-  };
-
-export const selectUserGroupsByIndex =
-  (userIndex: number) => (state: RootState) => {
-    return state.wizard.users[userIndex]?.groups;
-  };
-
 export const selectKernel = (state: RootState) => {
   return state.wizard.kernel;
 };


### PR DESCRIPTION
This updates API schema and uses the `hasPassword` value to render a password placeholder in edit mode.

JIRA: [HMS-5951](https://issues.redhat.com/browse/HMS-5951)