### PR TITLE
ImagesTable: Fix AWS regions indicator (off by one)

### DIFF
--- a/src/Components/ImagesTable/Target.tsx
+++ b/src/Components/ImagesTable/Target.tsx
@@ -27,6 +27,6 @@ export const AwsTarget = ({ compose }: AwsTargetPropTypes) => {
     return <Skeleton />;
   }
 
-  const text = `${targetOptions.aws} (${data?.data.length ?? 0 + 1})`;
+  const text = `${targetOptions.aws} (${(data?.data.length ?? 0) + 1})`;
   return <>{text}</>;
 };


### PR DESCRIPTION
The AWS regions indicator that is currently baked into each row containing an AWS image is currently off by one due to incorrect parentheses in the code.
This is now fixed, so it displays '(1)' when there is one region (which is the default, us-east-1) instead of '(0)' which was both wrong and confusing.

Before:
![image](https://github.com/user-attachments/assets/0c5a075b-540f-4976-8e4b-7961ee8f3dc7)

After:
![image](https://github.com/user-attachments/assets/a72247cb-e298-426b-8953-20ff78ee3d33)
