### PR TITLE
Wizard: fix a rerender loop in AzureResourceGroups

### DIFF
--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/AzureResourceGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/AzureResourceGroups.tsx
@@ -23,6 +23,8 @@ import {
   selectAzureSource,
 } from '../../../../../store/wizardSlice';
 
+const emptyArray: string[] = [];
+
 export const AzureResourceGroups = () => {
   const azureSource = useAppSelector(selectAzureSource);
   const azureResourceGroup = useAppSelector(selectAzureResourceGroup);
@@ -43,7 +45,9 @@ export const AzureResourceGroups = () => {
     }
   );
 
-  const resourceGroups = sourceDetails?.azure?.resource_groups || [];
+  // use a static empty array to avoid an infinite render loop in useEffect functions depending
+  // on `resourceGroups`
+  const resourceGroups = sourceDetails?.azure?.resource_groups || emptyArray;
 
   useEffect(() => {
     let filteredGroups = resourceGroups;


### PR DESCRIPTION
resourceGroup is used in useEffect, so if assigned a new array to it every time this function is called, it would cause the useEffect to run every time, leading to an infinite loop. This is because useEffect uses Object.is to determine if the value has changed, and [] creates a new array every time. Thus, we use a constant empty array to avoid this issue.

Alternatively JSON.stringify(resourceGroups), or a deep comparison could be used as a useEffect dependency, but that feels like just a waste of resources.

Without this patch, I get this warning when running the basic test for upload to azure in `AzureTarget.test.tsx`:

```
Warning: Maximum update depth exceeded. This can happen when a component calls setState inside useEffect, but useEffect either doesn't have a dependency array, or one of the dependencies changes on every render.
```