### PR TITLE
Wizard: fix imported repositories not preselected (HMS-6013)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -37,6 +37,7 @@ import {
   UploadTypes,
   User,
 } from '../../../store/imageBuilderApi';
+import { ApiRepositoryImportResponseRead } from '../../../store/service/contentSourcesApi';
 import {
   selectActivationKey,
   selectArchitecture,
@@ -394,6 +395,24 @@ export const mapRequestToState = (request: BlueprintResponse): wizardState => {
     ...commonRequestToState(request),
   };
 };
+
+export function mapToCustomRepositories(
+  repo: ApiRepositoryImportResponseRead
+): CustomRepository[] {
+  if (!repo.uuid) return [];
+  return [
+    {
+      id: repo.uuid,
+      name: repo.name,
+      baseurl: repo.url ? [repo.url] : undefined,
+      gpgkey: repo.gpg_key ? [repo.gpg_key] : undefined,
+      check_gpg: repo.metadata_verification ?? undefined,
+      check_repo_gpg: repo.metadata_verification ?? undefined,
+      module_hotfixes: repo.module_hotfixes ?? undefined,
+      enabled: true,
+    },
+  ];
+}
 
 /**
  * This function maps the blueprint response to the wizard state, used to populate the wizard with the blueprint details


### PR DESCRIPTION
This fixes a bug that was caused by using incorrect ids of imported custom repositories. Due to that bug, only in some cases the repositories were correctly preselected.

Now what works is importing both existing and non-existing custom repositories.

<details>
  <summary>Json blueprint with two custom repositories for testing</summary>
  
  ```json
{
  "content_sources": [
    {
      "distribution_arch": "x86_64",
      "distribution_versions": [
        "9"
      ],
      "gpg_key": "",
      "metadata_verification": false,
      "module_hotfixes": false,
      "name": "Centos 9",
      "origin": "external",
      "snapshot": true,
      "url": "https://nginx.org/packages/centos/9/x86_64/"
    },
    {
      "distribution_arch": "x86_64",
      "distribution_versions": [
        "any"
      ],
      "gpg_key": "",
      "metadata_verification": false,
      "module_hotfixes": false,
      "name": "Fedora 40",
      "origin": "external",
      "snapshot": true,
      "url": "https://fedora.mirror.constant.com/fedora/linux/releases/40/Everything/x86_64/os/"
    }
  ],
  "customizations": {
    "custom_repositories": [
      {
        "baseurl": [
          "https://nginx.org/packages/centos/9/x86_64/"
        ],
        "check_gpg": false,
        "id": "8b260792-d7d6-4ca4-aa83-82f6b70b0ba7",
        "name": "Centos 9"
      },
      {
        "baseurl": [
          "https://fedora.mirror.constant.com/fedora/linux/releases/40/Everything/x86_64/os/"
        ],
        "check_gpg": false,
        "id": "256c6408-bd42-4f5b-a556-3c3ccb9a9736",
        "name": "Fedora 40"
      }
    ],
    "hostname": "testsystemedited",
    "payload_repositories": [
      {
        "baseurl": "https://nginx.org/packages/centos/9/x86_64/",
        "check_gpg": false,
        "check_repo_gpg": false,
        "id": "8b260792-d7d6-4ca4-aa83-82f6b70b0ba7",
        "rhsm": false
      },
      {
        "baseurl": "https://fedora.mirror.constant.com/fedora/linux/releases/40/Everything/x86_64/os/",
        "check_gpg": false,
        "check_repo_gpg": false,
        "id": "256c6408-bd42-4f5b-a556-3c3ccb9a9736",
        "rhsm": false
      }
    ]
  },
  "description": "Testing blueprint",
  "distribution": "rhel-9",
  "metadata": {
    "exported_at": "2025-04-14 13:26:07.371057616 +0000 UTC",
    "is_on_prem": false,
    "parent_id": "9b40a3e5-e354-4fe7-9cc7-ba65b1a3f1e5"
  },
  "name": "test-0edc9232-a96a-4ba2-8f5a-7cbd925db271"
}
  ```
</details>


https://github.com/user-attachments/assets/83e54eb0-d6eb-4a04-868c-6124bcd59f6e


