### PR TITLE
    ImagesTable/BlueprintsSideBar: Add Segment tracking (HMS-5989)

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -39,6 +39,7 @@ vi.mock('@redhat-cloud-services/frontend-components/useChrome', () => ({
   default: () => ({
     analytics: {
       track: () => 'test',
+      group: () => 'test',
     },
     isBeta: () => true,
   }),


### PR DESCRIPTION
Needed so the Intercom team can decide whether or not to display an onboarding video (first time user with no images or blueprints).

Verified to be working in Segment:
![image](https://github.com/user-attachments/assets/3ea121fe-3c35-4abc-bbc9-cc3d3716c6af)
