### PR TITLE
Wizard: support tailored customizations

### DIFF
--- a/api/config/imageBuilder.ts
+++ b/api/config/imageBuilder.ts
@@ -19,6 +19,7 @@ const config: ConfigFile = {
     'getPackages',
     'getOscapProfiles',
     'getOscapCustomizations',
+    'getOscapCustomizationsForPolicy',
     'createBlueprint',
     'updateBlueprint',
     'composeBlueprint',

--- a/api/schema/imageBuilder.yaml
+++ b/api/schema/imageBuilder.yaml
@@ -702,6 +702,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Customizations'
+  /oscap/{policy}/{distribution}/policy_customizations:
+    parameters:
+      - in: path
+        name: policy
+        schema:
+          type: string
+          format: uuid
+        example: '123e4567-e89b-12d3-a456-426655440000'
+        required: true
+      - in: path
+        name: distribution
+        schema:
+          $ref: '#/components/schemas/Distributions'
+        required: true
+    get:
+      summary: get the customizations for a compliance policy
+      operationId: getOscapCustomizationsForPolicy
+      tags:
+        - oscap
+      responses:
+        '200':
+          description: |
+            A customizations array updated with the needed elements.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Customizations'
   /experimental/recommendations:
     post:
       summary: List recommended packages.

--- a/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/Oscap.tsx
@@ -3,17 +3,20 @@ import React from 'react';
 import { Alert } from '@patternfly/react-core';
 
 import OscapProfileInformation from './components/OscapProfileInformation';
+import PolicySelector from './components/PolicySelector';
 import ProfileSelector from './components/ProfileSelector';
 
 import { useAppSelector } from '../../../../store/hooks';
 import {
   selectComplianceProfileID,
+  selectComplianceType,
   selectImageTypes,
 } from '../../../../store/wizardSlice';
 
 const Oscap = () => {
   const oscapProfile = useAppSelector(selectComplianceProfileID);
   const environments = useAppSelector(selectImageTypes);
+  const complianceType = useAppSelector(selectComplianceType);
 
   return (
     <>
@@ -24,7 +27,7 @@ const Oscap = () => {
           title="OpenSCAP profiles are not compatible with WSL images."
         />
       )}
-      <ProfileSelector />
+      {complianceType === 'openscap' ? <ProfileSelector /> : <PolicySelector />}
       {oscapProfile && <OscapProfileInformation />}
       {oscapProfile && (
         <Alert

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -59,7 +59,7 @@ const ComplianceSelectOption = ({ policy }: ComplianceSelectOptionPropType) => {
   ): ComplianceSelectOptionValueType => ({
     policyID,
     profileID,
-    toString: () => title,
+    toString: () => title || 'None',
   });
 
   const descr = (
@@ -89,7 +89,6 @@ const PolicySelector = () => {
   const hasWslTargetOnly = useHasSpecificTargetOnly('wsl');
   const dispatch = useAppDispatch();
   const [isOpen, setIsOpen] = useState(false);
-  const [selected, setSelected] = useState<string>('None');
 
   const {
     data: policies,
@@ -231,13 +230,11 @@ const PolicySelector = () => {
           handlePackages(oldOscapPackages, newOscapPackages);
           handleServices(response.services);
           handleKernelAppend(response.kernel?.append);
-          const compl = selection as ComplianceSelectOptionValueType;
-          setSelected(compl.toString());
           dispatch(
             changeCompliance({
-              profileID: compl.profileID,
-              policyID: compl.policyID,
-              policyTitle: compl.toString(),
+              profileID: selection.profileID,
+              policyID: selection.policyID,
+              policyTitle: selection.toString(),
             })
           );
         });
@@ -290,7 +287,7 @@ const PolicySelector = () => {
         } as React.CSSProperties
       }
     >
-      {selected}
+      {policyTitle || 'Select a policy'}
     </MenuToggle>
   );
 
@@ -301,7 +298,7 @@ const PolicySelector = () => {
         isOpen={isOpen}
         onSelect={handleSelect}
         onOpenChange={handleToggle}
-        selected={selected}
+        selected={policyID}
         toggle={toggleCompliance}
         shouldFocusFirstItemOnOpen={false}
       >

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -1,0 +1,314 @@
+import React, { useEffect, useState } from 'react';
+
+import {
+  FormGroup,
+  MenuToggle,
+  MenuToggleElement,
+  Select,
+  SelectOption,
+} from '@patternfly/react-core';
+import { v4 as uuidv4 } from 'uuid';
+
+import {
+  usePoliciesQuery,
+  PolicyRead,
+} from '../../../../../store/complianceApi';
+import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
+import {
+  Filesystem,
+  Services,
+  useGetOscapCustomizationsForPolicyQuery,
+  useLazyGetOscapCustomizationsForPolicyQuery,
+} from '../../../../../store/imageBuilderApi';
+import {
+  changeCompliance,
+  selectDistribution,
+  selectCompliancePolicyID,
+  selectCompliancePolicyTitle,
+  addPackage,
+  addPartition,
+  changeFileSystemConfigurationType,
+  removePackage,
+  clearPartitions,
+  changeEnabledServices,
+  changeMaskedServices,
+  changeDisabledServices,
+  clearKernelAppend,
+  addKernelArg,
+} from '../../../../../store/wizardSlice';
+import { useHasSpecificTargetOnly } from '../../../utilities/hasSpecificTargetOnly';
+import { parseSizeUnit } from '../../../utilities/parseSizeUnit';
+import { Partition, Units } from '../../FileSystem/FileSystemTable';
+import { removeBetaFromRelease } from '../removeBetaFromRelease';
+
+type ComplianceSelectOptionPropType = {
+  policy: PolicyRead;
+};
+
+type ComplianceSelectOptionValueType = {
+  policyID: string;
+  profileID: string;
+  toString: () => string;
+};
+
+const ComplianceSelectOption = ({ policy }: ComplianceSelectOptionPropType) => {
+  const selectObj = (
+    policyID: string,
+    profileID: string,
+    title: string
+  ): ComplianceSelectOptionValueType => ({
+    policyID,
+    profileID,
+    toString: () => title,
+  });
+
+  const descr = (
+    <>
+      Threshold: {policy.compliance_threshold}
+      <br />
+      Active systems: {policy.total_system_count}
+    </>
+  );
+
+  return (
+    <SelectOption
+      key={policy.id}
+      value={selectObj(policy.id!, policy.ref_id!, policy.title!)}
+      description={descr}
+    >
+      {policy.title}
+    </SelectOption>
+  );
+};
+
+const PolicySelector = () => {
+  const policyID = useAppSelector(selectCompliancePolicyID);
+  const policyTitle = useAppSelector(selectCompliancePolicyTitle);
+  const release = removeBetaFromRelease(useAppSelector(selectDistribution));
+  const majorVersion = release.split('-')[1];
+  const hasWslTargetOnly = useHasSpecificTargetOnly('wsl');
+  const dispatch = useAppDispatch();
+  const [isOpen, setIsOpen] = useState(false);
+  const [selected, setSelected] = useState<string>('None');
+
+  const {
+    data: policies,
+    isFetching: isFetchingPolicies,
+    isSuccess: isSuccessPolicies,
+  } = usePoliciesQuery({
+    filter: `os_major_version=${majorVersion}`,
+  });
+
+  const { data: currentProfileData } = useGetOscapCustomizationsForPolicyQuery(
+    {
+      distribution: release,
+      policy: policyID!,
+    },
+    { skip: !policyID }
+  );
+
+  const [trigger] = useLazyGetOscapCustomizationsForPolicyQuery();
+
+  useEffect(() => {
+    if (!policies || policies.data === undefined) {
+      return;
+    }
+
+    if (policyID && !policyTitle) {
+      for (const p of policies.data) {
+        const pol = p as PolicyRead;
+        if (pol.id === policyID) {
+          dispatch(
+            changeCompliance({
+              policyID: pol.id,
+              profileID: pol.ref_id,
+              policyTitle: pol.title,
+            })
+          );
+        }
+      }
+    }
+  }, [isSuccessPolicies]);
+
+  const handleToggle = () => {
+    setIsOpen(!isOpen);
+  };
+
+  const handleClear = () => {
+    dispatch(
+      changeCompliance({
+        profileID: undefined,
+        policyID: undefined,
+        policyTitle: undefined,
+      })
+    );
+    clearOscapPackages(currentProfileData?.packages || []);
+    dispatch(changeFileSystemConfigurationType('automatic'));
+    handleServices(undefined);
+    dispatch(clearKernelAppend());
+  };
+
+  const handlePackages = (
+    oldOscapPackages: string[],
+    newOscapPackages: string[]
+  ) => {
+    clearOscapPackages(oldOscapPackages);
+
+    for (const pkg of newOscapPackages) {
+      dispatch(
+        addPackage({
+          name: pkg,
+          summary: 'Required by chosen compliance policy',
+          repository: 'distro',
+        })
+      );
+    }
+  };
+
+  const clearOscapPackages = (oscapPackages: string[]) => {
+    for (const pkg of oscapPackages) {
+      dispatch(removePackage(pkg));
+    }
+  };
+
+  const handlePartitions = (oscapPartitions: Filesystem[]) => {
+    dispatch(clearPartitions());
+
+    const newPartitions = oscapPartitions.map((filesystem) => {
+      const [size, unit] = parseSizeUnit(filesystem.min_size);
+      const partition: Partition = {
+        mountpoint: filesystem.mountpoint,
+        min_size: size.toString(),
+        unit: unit as Units,
+        id: uuidv4(),
+      };
+      return partition;
+    });
+
+    if (newPartitions) {
+      dispatch(changeFileSystemConfigurationType('manual'));
+      for (const partition of newPartitions) {
+        dispatch(addPartition(partition));
+      }
+    }
+  };
+
+  const handleServices = (services: Services | undefined) => {
+    dispatch(changeEnabledServices(services?.enabled || []));
+    dispatch(changeMaskedServices(services?.masked || []));
+    dispatch(changeDisabledServices(services?.disabled || []));
+  };
+
+  const handleKernelAppend = (kernelAppend: string | undefined) => {
+    dispatch(clearKernelAppend());
+
+    if (kernelAppend) {
+      const kernelArgsArray = kernelAppend.split(' ');
+      for (const arg of kernelArgsArray) {
+        dispatch(addKernelArg(arg));
+      }
+    }
+  };
+
+  const applyChanges = (selection: ComplianceSelectOptionValueType) => {
+    if (selection.policyID === undefined) {
+      // handle user has selected 'None' case
+      handleClear();
+    } else {
+      const oldOscapPackages = currentProfileData?.packages || [];
+      trigger(
+        {
+          distribution: release,
+          policy: selection.policyID,
+        },
+        true // preferCacheValue
+      )
+        .unwrap()
+        .then((response) => {
+          const oscapPartitions = response.filesystem || [];
+          const newOscapPackages = response.packages || [];
+          handlePartitions(oscapPartitions);
+          handlePackages(oldOscapPackages, newOscapPackages);
+          handleServices(response.services);
+          handleKernelAppend(response.kernel?.append);
+          const compl = selection as ComplianceSelectOptionValueType;
+          setSelected(compl.toString());
+          dispatch(
+            changeCompliance({
+              profileID: compl.profileID,
+              policyID: compl.policyID,
+              policyTitle: compl.toString(),
+            })
+          );
+        });
+    }
+  };
+
+  const handleSelect = (
+    _event: React.MouseEvent<Element, MouseEvent>,
+    selection: string
+  ) => {
+    if (selection) {
+      applyChanges(selection as unknown as ComplianceSelectOptionValueType);
+      setIsOpen(false);
+    }
+  };
+
+  const complianceOptions = () => {
+    if (!policies || policies.data === undefined) {
+      return [];
+    }
+
+    const res = [
+      <SelectOption
+        key="compliance-none-option"
+        value={{ toString: () => 'None', compareTo: () => false }}
+      >
+        None
+      </SelectOption>,
+    ];
+    for (const p of policies.data) {
+      if (p === undefined) {
+        continue;
+      }
+      const pol = p as PolicyRead;
+      res.push(<ComplianceSelectOption key={pol.id} policy={pol} />);
+    }
+    return res;
+  };
+
+  const toggleCompliance = (toggleRef: React.Ref<MenuToggleElement>) => (
+    <MenuToggle
+      ouiaId="compliancePolicySelect"
+      ref={toggleRef}
+      onClick={() => setIsOpen(!isOpen)}
+      isExpanded={isOpen}
+      isDisabled={isFetchingPolicies || hasWslTargetOnly}
+      style={
+        {
+          width: '200px',
+        } as React.CSSProperties
+      }
+    >
+      {selected}
+    </MenuToggle>
+  );
+
+  return (
+    <FormGroup data-testid="profiles-form-group" label="Policy">
+      <Select
+        isScrollable
+        isOpen={isOpen}
+        onSelect={handleSelect}
+        onOpenChange={handleToggle}
+        selected={selected}
+        toggle={toggleCompliance}
+        shouldFocusFirstItemOnOpen={false}
+      >
+        {complianceOptions()}
+      </Select>
+    </FormGroup>
+  );
+};
+
+export default PolicySelector;

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -184,7 +184,7 @@ const PolicySelector = () => {
       return partition;
     });
 
-    if (newPartitions) {
+    if (newPartitions.length > 0) {
       dispatch(changeFileSystemConfigurationType('manual'));
       for (const partition of newPartitions) {
         dispatch(addPartition(partition));

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -223,7 +223,7 @@ const ProfileSelector = () => {
       return partition;
     });
 
-    if (newPartitions) {
+    if (newPartitions.length > 0) {
       dispatch(changeFileSystemConfigurationType('manual'));
       for (const partition of newPartitions) {
         dispatch(addPartition(partition));

--- a/src/store/service/imageBuilderApi.ts
+++ b/src/store/service/imageBuilderApi.ts
@@ -161,6 +161,14 @@ const injectedRtkApi = api.injectEndpoints({
         url: `/oscap/${queryArg.distribution}/${queryArg.profile}/customizations`,
       }),
     }),
+    getOscapCustomizationsForPolicy: build.query<
+      GetOscapCustomizationsForPolicyApiResponse,
+      GetOscapCustomizationsForPolicyApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/oscap/${queryArg.policy}/${queryArg.distribution}/policy_customizations`,
+      }),
+    }),
     recommendPackage: build.mutation<
       RecommendPackageApiResponse,
       RecommendPackageApiArg
@@ -338,6 +346,13 @@ export type GetOscapCustomizationsApiArg = {
   distribution: Distributions;
   /** Name of the profile to retrieve customizations from */
   profile: DistributionProfileItem;
+};
+export type GetOscapCustomizationsForPolicyApiResponse =
+  /** status 200 A customizations array updated with the needed elements.
+   */ Customizations;
+export type GetOscapCustomizationsForPolicyApiArg = {
+  policy: string;
+  distribution: Distributions;
 };
 export type RecommendPackageApiResponse =
   /** status 200 Return the recommended packages. */ RecommendationsResponse;
@@ -1002,6 +1017,8 @@ export const {
   useLazyGetOscapProfilesQuery,
   useGetOscapCustomizationsQuery,
   useLazyGetOscapCustomizationsQuery,
+  useGetOscapCustomizationsForPolicyQuery,
+  useLazyGetOscapCustomizationsForPolicyQuery,
   useRecommendPackageMutation,
   useFixupBlueprintMutation,
 } = injectedRtkApi;

--- a/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
@@ -198,7 +198,6 @@ describe('First boot request generated correctly', () => {
     const expectedRequest = {
       ...blueprintRequest,
       customizations: {
-        filesystem: [{ min_size: 10737418240, mountpoint: '/' }],
         openscap: {
           profile_id: 'xccdf_org.ssgproject.content_profile_standard',
         },
@@ -229,7 +228,6 @@ describe('First boot request generated correctly', () => {
     const expectedRequest = {
       ...blueprintRequest,
       customizations: {
-        filesystem: [{ min_size: 10737418240, mountpoint: '/' }],
         openscap: {
           profile_id: 'xccdf_org.ssgproject.content_profile_standard',
         },

--- a/src/test/Components/CreateImageWizard/steps/Kernel/Kernel.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Kernel/Kernel.test.tsx
@@ -337,7 +337,6 @@ describe('Kernel request generated correctly', () => {
     const expectedRequest = {
       ...blueprintRequest,
       customizations: {
-        filesystem: [{ min_size: 10737418240, mountpoint: '/' }],
         openscap: {
           profile_id: 'xccdf_org.ssgproject.content_profile_ccn_basic',
         },

--- a/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
@@ -42,7 +42,7 @@ const goToComplianceStep = async () => {
   const button = await screen.findByLabelText('Insights compliance');
   await waitFor(() => user.click(button));
   // wait until all policies are loaded
-  await screen.findByText('None');
+  await screen.findByText('Select a policy');
 };
 
 const goToReviewStep = async () => {
@@ -65,7 +65,7 @@ const goToReviewStep = async () => {
 const selectPolicy = async () => {
   const user = userEvent.setup();
 
-  const policyMenu = await screen.findByText('None');
+  const policyMenu = await screen.findByText('Select a policy');
   await waitFor(() => user.click(policyMenu));
 
   const cisl2 = await screen.findByRole('option', {
@@ -162,7 +162,8 @@ describe('Compliance edit mode', () => {
       name: /Selected/i,
     });
     user.click(selectedBtn);
-    await screen.findByText('aide');
     await screen.findByText('emacs');
+
+    expect(screen.queryByText('aide')).not.toBeInTheDocument();
   });
 });

--- a/src/test/fixtures/editMode.ts
+++ b/src/test/fixtures/editMode.ts
@@ -660,7 +660,8 @@ export const complianceCreateBlueprintRequest: CreateBlueprintRequest = {
   name: mockBlueprintNames['compliance'],
   description: mockBlueprintDescriptions['compliance'],
   customizations: {
-    packages: expectedPackagesCisL2,
+    // filter out a single package to simulate the customizations being tailored
+    packages: expectedPackagesCisL2.filter((p) => p !== 'aide'),
     openscap: {
       policy_id: '0ee9a781-b53f-4d9e-91e1-d75aed088c44',
     },

--- a/src/test/fixtures/oscap.ts
+++ b/src/test/fixtures/oscap.ts
@@ -1,3 +1,5 @@
+import { mockPolicies } from './compliance';
+
 import {
   GetOscapProfilesApiResponse,
   GetOscapCustomizationsApiResponse,
@@ -90,7 +92,6 @@ export const oscapCustomizations = (
     };
   }
   return {
-    filesystem: [{ min_size: 1073741824, mountpoint: '/tmp' }],
     openscap: {
       profile_id: 'content_profile_stig_gui',
       profile_name: 'DISA STIG with GUI for Red Hat Enterprise Linux 8',
@@ -113,4 +114,16 @@ export const oscapCustomizations = (
       enabled: ['crond', 'firewalld', 'systemd-journald', 'rsyslog', 'auditd'],
     },
   };
+};
+
+export const oscapCustomizationsPolicy = (
+  policy: string
+): GetOscapCustomizationsApiResponse => {
+  const policyData = mockPolicies.data.find((p) => p.id === policy);
+  const customizations = oscapCustomizations(policyData!.ref_id);
+  // filter out a single package to simulate the customizations being tailored
+  customizations.packages = customizations.packages!.filter(
+    (p) => p !== 'aide'
+  );
+  return customizations;
 };

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -32,6 +32,7 @@ import { mockedFeatureResponse } from '../fixtures/features';
 import {
   distributionOscapProfiles,
   oscapCustomizations,
+  oscapCustomizationsPolicy,
 } from '../fixtures/oscap';
 import {
   mockPkgRecommendations,
@@ -160,6 +161,13 @@ export const handlers = [
     ({ params }) => {
       const { profile } = params;
       return HttpResponse.json(oscapCustomizations(profile));
+    }
+  ),
+  http.get(
+    `${IMAGE_BUILDER_API}/oscap/:policy/:distribution/policy_customizations`,
+    ({ params }) => {
+      const { policy } = params;
+      return HttpResponse.json(oscapCustomizationsPolicy(policy));
     }
   ),
   http.get(`${IMAGE_BUILDER_API}/blueprints`, ({ request }) => {


### PR DESCRIPTION
This splits the policy and profile selectors as they're drifting apart.

Instead of querying the customizations attached to the profile, query
the customizations attached to the policy, as these take into account
tailoring. As a result unnecessary customizations won't be added.