### PR TITLE
test: Remove WSL flag from unleash test mock (HMS-6002)

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -65,8 +65,6 @@ vi.mock('@unleash/proxy-client-react', () => ({
         return true;
       case 'image-builder.firstboot.enabled':
         return true;
-      case 'image-builder.wsl.enabled':
-        return true;
       case 'image-builder.hostname.enabled':
         return true;
       case 'image-builder.kernel.enabled':


### PR DESCRIPTION
The WSL flag was removed from the codebase, this removes it from the test mock as well.

JIRA: [HMS-6002](https://issues.redhat.com/browse/HMS-6002)