### PR TITLE
Wizard: Use SearchInput component for packages (HMS-6011)

### DIFF
--- a/playwright/test.spec.ts
+++ b/playwright/test.spec.ts
@@ -98,7 +98,10 @@ test.describe.serial('test', () => {
 
     await frame.getByRole('button', { name: 'Edit blueprint' }).click();
     await frame.getByRole('button', { name: 'Additional packages' }).click();
-    await frame.getByTestId('packages-search-input').fill('osbuild-composer');
+    await frame
+      .getByTestId('packages-search-input')
+      .locator('input')
+      .fill('osbuild-composer');
     await frame.getByTestId('packages-table').getByText('Searching');
     await frame.getByRole('gridcell', { name: 'osbuild-composer' }).first();
     await frame.getByRole('checkbox', { name: 'Select row 0' }).check();

--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -15,19 +15,16 @@ import {
   EmptyStateIcon,
   EmptyStateVariant,
   Icon,
-  InputGroup,
-  InputGroupItem,
-  InputGroupText,
   Pagination,
   PaginationVariant,
   Popover,
+  SearchInput,
   Spinner,
   Stack,
   Tab,
   Tabs,
   TabTitleText,
   Text,
-  TextInput,
   ToggleGroup,
   ToggleGroupItem,
   Toolbar,
@@ -40,7 +37,6 @@ import {
   HelpIcon,
   OptimizeIcon,
   SearchIcon,
-  TimesIcon,
 } from '@patternfly/react-icons';
 import {
   ExpandableRowContent,
@@ -1248,39 +1244,16 @@ const Packages = () => {
         <Stack>
           <ToolbarContent>
             <ToolbarItem variant="search-filter">
-              <InputGroup>
-                <InputGroupItem isFill>
-                  <InputGroupText id="search-icon">
-                    <SearchIcon />
-                  </InputGroupText>
-                  <TextInput
-                    data-ouia-component-id="packages-search-input"
-                    type="text"
-                    validated={
-                      debouncedSearchTermLengthOf1 &&
-                      !debouncedSearchTermIsGroup
-                        ? 'error'
-                        : 'default'
-                    }
-                    placeholder="Type to search"
-                    aria-label="Search packages"
-                    data-testid="packages-search-input"
-                    value={searchTerm}
-                    onChange={handleSearch}
-                  />
-                </InputGroupItem>
-                {searchTerm && (
-                  <InputGroupItem>
-                    <Button
-                      variant="control"
-                      aria-label="clear-package-search"
-                      onClick={handleClear}
-                      icon={<TimesIcon />}
-                      ouiaId="clear-package-search-button"
-                    />
-                  </InputGroupItem>
-                )}
-              </InputGroup>
+              <SearchInput
+                data-ouia-component-id="packages-search-input"
+                type="text"
+                placeholder="Type to search"
+                aria-label="Search packages"
+                data-testid="packages-search-input"
+                value={searchTerm}
+                onChange={handleSearch}
+                onClear={() => handleClear()}
+              />
             </ToolbarItem>
             <ToolbarItem>
               <ToggleGroup>


### PR DESCRIPTION
As a small simplification and also to make the UX more consistent, let's use a SearchInput widget over the custom InputGroup structure. This means the search boxes will also be consistent between the repository and package search pages.
Fixes #3133

JIRA: [HMS-6011](https://issues.redhat.com/browse/HMS-6011)