### PR TITLE
Wizard: Fix 'too short' state in Packages step

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -1166,10 +1166,7 @@ const Packages = () => {
 
   const bodyContent = useMemo(() => {
     switch (true) {
-      case debouncedSearchTermLengthOf1 &&
-        !debouncedSearchTermIsGroup &&
-        transformedPackages.length === 0 &&
-        transformedGroups.length === 0:
+      case debouncedSearchTermLengthOf1 && !debouncedSearchTermIsGroup:
         return TooShort();
       case (toggleSelected === 'toggle-selected' &&
         packages.length === 0 &&


### PR DESCRIPTION
Currently, when a search term is entered and then reduced to a single character in the Wizard's packages step, the previous results are still shown.
What is expected is that the empty state hinting at the search term being too short would be shown.

The condition in bodyContent was wrong, because it assumed that the list of results would be 0 when in fact it wasn't being cleared.

Fixes #3139

