### PR TITLE
src: Remove `ouia-id`s (HMS-6012)

### DIFF
--- a/src/Components/Blueprints/BlueprintActionsMenu.tsx
+++ b/src/Components/Blueprints/BlueprintActionsMenu.tsx
@@ -48,7 +48,6 @@ export const BlueprintActionsMenu: React.FunctionComponent<
   };
   return (
     <Dropdown
-      ouiaId={`blueprints-dropdown`}
       isOpen={showBlueprintActionsMenu}
       onSelect={onSelect}
       onOpenChange={(showBlueprintActionsMenu: boolean) =>

--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -36,7 +36,6 @@ const BlueprintCard = ({ blueprint }: blueprintProps) => {
     <>
       <Card
         isSelected={blueprint.id === selectedBlueprintId}
-        ouiaId={`blueprint-card-${blueprint.id}`}
         data-testid={`blueprint-card`}
         isCompact
         isClickable

--- a/src/Components/Blueprints/BlueprintsSideBar.tsx
+++ b/src/Components/Blueprints/BlueprintsSideBar.tsx
@@ -155,7 +155,6 @@ const BlueprintsSidebar = () => {
               <Flex justifyContent={{ default: 'justifyContentCenter' }}>
                 <FlexItem>
                   <Button
-                    ouiaId={`clear-selected-blueprint-button`}
                     variant="link"
                     isDisabled={!selectedBlueprintId}
                     onClick={handleClickViewAll}

--- a/src/Components/Blueprints/BuildImagesButton.tsx
+++ b/src/Components/Blueprints/BuildImagesButton.tsx
@@ -193,7 +193,6 @@ export const BuildImagesButtonEmptyState = ({
   };
   return (
     <Button
-      ouiaId="build-images-button"
       onClick={onBuildHandler}
       isDisabled={!selectedBlueprintId}
       isLoading={imageBuildLoading}

--- a/src/Components/Blueprints/EditBlueprintButton.tsx
+++ b/src/Components/Blueprints/EditBlueprintButton.tsx
@@ -13,7 +13,6 @@ export const EditBlueprintButton = () => {
 
   return (
     <Button
-      ouiaId="edit-blueprint-button"
       onClick={() =>
         navigate(resolveRelPath(`imagewizard/${selectedBlueprintId}`))
       }

--- a/src/Components/Blueprints/ImportBlueprintModal.tsx
+++ b/src/Components/Blueprints/ImportBlueprintModal.tsx
@@ -243,7 +243,6 @@ export const ImportBlueprintModal: React.FunctionComponent<
         </>
       }
       onClose={onImportClose}
-      ouiaId="import-blueprint-modal"
     >
       <Form>
         <FormGroup fieldId="checkbox-import-custom-repositories">
@@ -302,7 +301,6 @@ export const ImportBlueprintModal: React.FunctionComponent<
                 state: { blueprint: importedBlueprint },
               })
             }
-            ouiaId="import-blueprint-finish"
             data-testid="import-blueprint-finish"
           >
             Review and finish

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -114,7 +114,6 @@ export const CustomWizardFooter = ({
   return (
     <WizardFooterWrapper>
       <Button
-        ouiaId={nextBtnID}
         variant="primary"
         onClick={() => {
           if (!process.env.IS_ON_PREMISE) {
@@ -131,7 +130,6 @@ export const CustomWizardFooter = ({
         Next
       </Button>
       <Button
-        ouiaId={backBtnID}
         variant="secondary"
         onClick={() => {
           if (!process.env.IS_ON_PREMISE) {
@@ -149,7 +147,6 @@ export const CustomWizardFooter = ({
       </Button>
       {optional && (
         <Button
-          ouiaId={reviewAndFinishBtnID}
           variant="tertiary"
           onClick={() => {
             if (!process.env.IS_ON_PREMISE) {
@@ -167,7 +164,6 @@ export const CustomWizardFooter = ({
         </Button>
       )}
       <Button
-        ouiaId={cancelBtnID}
         variant="link"
         onClick={() => {
           if (!process.env.IS_ON_PREMISE) {

--- a/src/Components/CreateImageWizard/ValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedInput.tsx
@@ -13,7 +13,6 @@ import type { StepValidation } from './utilities/useValidation';
 
 type ValidatedTextInputPropTypes = TextInputProps & {
   dataTestId?: string;
-  ouiaId?: string;
   ariaLabel: string | undefined;
   helperText: string | undefined;
   validator: (value: string | undefined) => boolean;
@@ -137,7 +136,6 @@ export const ErrorMessage = ({ errorMessage }: ErrorMessageProps) => {
 
 export const ValidatedInput = ({
   dataTestId,
-  ouiaId,
   ariaLabel,
   helperText,
   validator,
@@ -164,7 +162,6 @@ export const ValidatedInput = ({
       <TextInput
         value={value}
         data-testid={dataTestId}
-        ouiaId={ouiaId || ''}
         type="text"
         onChange={onChange!}
         validated={handleValidation()}

--- a/src/Components/CreateImageWizard/steps/FileSystem/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/FileSystemConfiguration.tsx
@@ -81,7 +81,6 @@ const FileSystemConfiguration = () => {
       <FileSystemTable />
       <TextContent>
         <Button
-          ouiaId="add-partition"
           data-testid="file-system-add-partition"
           className="pf-v5-u-text-align-left"
           variant="link"

--- a/src/Components/CreateImageWizard/steps/FileSystem/FileSystemPartition.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/FileSystemPartition.tsx
@@ -24,7 +24,6 @@ const FileSystemPartition = () => {
     <FormGroup>
       <Radio
         id="automatic file system config radio"
-        ouiaId="automatic-configure-fsc-radio"
         label={
           <>
             <Label isCompact color="blue">
@@ -42,7 +41,6 @@ const FileSystemPartition = () => {
       />
       <Radio
         id="manual file system config radio"
-        ouiaId="manual-configure-fsc-radio"
         label="Manually configure partitions"
         name="fsc-radio-manual"
         description="Manually configure the file system of your image by adding, removing, and editing partitions"

--- a/src/Components/CreateImageWizard/steps/FileSystem/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/FileSystemTable.tsx
@@ -147,7 +147,6 @@ const Row = ({ partition, onDragEnd, onDragStart, onDrop }: RowPropTypes) => {
           variant="link"
           icon={<MinusCircleIcon />}
           onClick={() => handleRemovePartition(partition.id)}
-          ouiaId="remove-mount-point"
           isDisabled={partition.mountpoint === '/'}
         />
       </Td>
@@ -193,7 +192,6 @@ const MountpointPrefix = ({ partition }: MountpointPrefixPropTypes) => {
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ouiaId="mount-point"
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
@@ -250,7 +248,6 @@ const MountpointSuffix = ({ partition }: MountpointSuffixPropTypes) => {
         );
       }}
       aria-label="mountpoint suffix"
-      ouiaId="mount-suffix"
     />
   );
 };
@@ -289,7 +286,6 @@ const MinimumSize = ({ partition }: MinimumSizePropTypes) => {
           : ''
       }
       type="text"
-      ouiaId="size"
       stepValidation={stepValidation}
       fieldName={`min-size-${partition.id}`}
       placeholder="File system"
@@ -339,7 +335,6 @@ const SizeUnit = ({ partition }: SizeUnitPropTypes) => {
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ouiaId="unit"
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}
@@ -511,7 +506,6 @@ const FileSystemTable = () => {
   return (
     <Table
       className={isDragging ? styles.modifiers.dragOver : ''}
-      ouiaId="partition_table_v2"
       aria-label="File system table"
       variant="compact"
       data-testid="fsc-table"

--- a/src/Components/CreateImageWizard/steps/ImageOutput/ArchSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/ArchSelect.tsx
@@ -57,7 +57,6 @@ const ArchSelect = () => {
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ouiaId="arch_select"
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}

--- a/src/Components/CreateImageWizard/steps/ImageOutput/ReleaseSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/ReleaseSelect.tsx
@@ -144,7 +144,6 @@ const ReleaseSelect = () => {
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ouiaId="release_select"
       ref={toggleRef}
       onClick={onToggleClick}
       isExpanded={isOpen}

--- a/src/Components/CreateImageWizard/steps/Oscap/components/OnPremWarning.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/OnPremWarning.tsx
@@ -25,7 +25,6 @@ const OscapOnPremWarning = () => {
           isInline
           variant="warning"
           title="The packages required to apply security profiles by using OpenSCAP are missing on this host. Install them with the following command"
-          ouiaId="oscap-unavailable-alert"
         />
       </FormGroup>
       <FormGroup>

--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -448,7 +448,6 @@ const ProfileSelector = () => {
 
   const toggleOpenSCAP = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ouiaId="profileSelect"
       data-testid="profileSelect"
       ref={toggleRef}
       variant="typeahead"
@@ -483,7 +482,6 @@ const ProfileSelector = () => {
 
   const toggleCompliance = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ouiaId="compliancePolicySelect"
       ref={toggleRef}
       onClick={() => setIsOpen(!isOpen)}
       isExpanded={isOpen}

--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -477,7 +477,6 @@ const Packages = () => {
                     <EmptyStateActions>
                       <Button
                         variant="primary"
-                        ouiaId="search-other-repositories"
                         onClick={() => setActiveTabKey(Repos.OTHER)}
                       >
                         Search other repositories
@@ -556,7 +555,6 @@ const Packages = () => {
             isLoading={createLoading}
             isDisabled={createLoading}
             onClick={handleConfirmModalToggle}
-            ouiaId="Add-listed-repos"
           >
             Add listed repositories
           </Button>,
@@ -564,7 +562,6 @@ const Packages = () => {
             Back
           </Button>,
         ]}
-        ouiaId="Custom-repos-warning-modal"
       >
         You have selected packages that belong to custom repositories. By
         continuing, you are acknowledging and consenting to adding the following
@@ -1245,7 +1242,6 @@ const Packages = () => {
           <ToolbarContent>
             <ToolbarItem variant="search-filter">
               <SearchInput
-                data-ouia-component-id="packages-search-input"
                 type="text"
                 placeholder="Type to search"
                 aria-label="Search packages"

--- a/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
@@ -222,7 +222,6 @@ const ActivationKeysList = () => {
       isDisabled={
         !isSuccessActivationKeys || registrationType === 'register-later'
       }
-      ouiaId="activation_key_select"
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -86,11 +86,7 @@ export const CreateSaveAndBuildBtn = ({
 
   return (
     <DropdownList>
-      <DropdownItem
-        onClick={onSaveAndBuild}
-        ouiaId="wizard-create-build-btn"
-        isDisabled={isDisabled}
-      >
+      <DropdownItem onClick={onSaveAndBuild} isDisabled={isDisabled}>
         Create blueprint and build image(s)
       </DropdownItem>
     </DropdownList>

--- a/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
@@ -80,11 +80,7 @@ export const EditSaveAndBuildBtn = ({
 
   return (
     <DropdownList>
-      <DropdownItem
-        onClick={onSaveAndBuild}
-        ouiaId="wizard-edit-build-btn"
-        isDisabled={isDisabled}
-      >
+      <DropdownItem onClick={onSaveAndBuild} isDisabled={isDisabled}>
         Save changes and build image(s)
       </DropdownItem>
     </DropdownList>

--- a/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/Footer.tsx
@@ -100,7 +100,6 @@ const ReviewWizardFooter = () => {
               }}
             />
           )}
-          ouiaId="wizard-finish-dropdown"
           shouldFocusToggleOnSelect
         >
           {composeId ? (
@@ -119,14 +118,10 @@ const ReviewWizardFooter = () => {
           )}
         </Dropdown>
       </div>
-      <Button
-        ouiaId="wizard-back-btn"
-        variant="secondary"
-        onClick={goToPrevStep}
-      >
+      <Button variant="secondary" onClick={goToPrevStep}>
         Back
       </Button>
-      <Button ouiaId="wizard-cancel-btn" variant="link" onClick={close}>
+      <Button variant="link" onClick={close}>
         Cancel
       </Button>
     </WizardFooterWrapper>

--- a/src/Components/CreateImageWizard/steps/Snapshot/Snapshot.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/Snapshot.tsx
@@ -64,7 +64,6 @@ export default function Snapshot() {
       <FormGroup>
         <Radio
           id="use latest snapshot radio"
-          ouiaId="use-latest-snapshot-radio"
           name="use-latest-snapshot"
           label="Disable repeatable build"
           description="Use the newest repository content available when building this image"
@@ -73,7 +72,6 @@ export default function Snapshot() {
         />
         <Radio
           id="use snapshot date radio"
-          ouiaId="use-snapshot-date-radio"
           name="use-snapshot-date"
           label="Enable repeatable build"
           description="Build this image with the repository content of a selected date"

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Aws/AwsSourcesSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Aws/AwsSourcesSelect.tsx
@@ -143,7 +143,6 @@ export const AwsSourcesSelect = () => {
       onClick={handleToggle}
       isExpanded={isOpen}
       isDisabled={!isSuccess || isLoading}
-      ouiaId="source_select"
     >
       <TextInputGroup isPlain>
         <TextInputGroupMain

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/AzureHyperVSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/AzureHyperVSelect.tsx
@@ -46,7 +46,6 @@ export const AzureHyperVSelect = () => {
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ouiaId="hyperv_gen_select"
       ref={toggleRef}
       data-testid="azure-hyper-v-generation-select"
       onClick={() => setIsOpen(!isOpen)}

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/AzureResourceGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/AzureResourceGroups.tsx
@@ -102,7 +102,6 @@ export const AzureResourceGroups = () => {
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ouiaId="resource_group_select"
       ref={toggleRef}
       variant="typeahead"
       onClick={() => setIsOpen(!isOpen)}

--- a/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/AzureSourcesSelect.tsx
+++ b/src/Components/CreateImageWizard/steps/TargetEnvironment/Azure/AzureSourcesSelect.tsx
@@ -150,7 +150,6 @@ export const AzureSourcesSelect = () => {
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (
     <MenuToggle
-      ouiaId="source_select"
       ref={toggleRef}
       variant="typeahead"
       onClick={handleToggle}

--- a/src/Components/CreateImageWizard/steps/Users/components/RemoveUserModal.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/RemoveUserModal.tsx
@@ -60,7 +60,6 @@ const RemoveUserModal = ({
           Cancel
         </Button>,
       ]}
-      ouiaId="removeUserModal"
     >
       This action is permanent and cannot be undone. Once deleted all
       information about the user will be lost.

--- a/src/Components/ImagesTable/ImageDetails.tsx
+++ b/src/Components/ImagesTable/ImageDetails.tsx
@@ -162,7 +162,6 @@ export const AwsDetails = ({ compose }: AwsDetailsPropTypes) => {
               hoverTip="Copy"
               clickTip="Copied"
               variant="inline-compact"
-              ouiaId="aws-uuid"
               onClick={() => {
                 analytics.track(`${AMPLITUDE_MODULE_NAME} - Button Clicked`, {
                   module: AMPLITUDE_MODULE_NAME,
@@ -274,7 +273,6 @@ export const AzureDetails = ({ compose }: AzureDetailsPropTypes) => {
               hoverTip="Copy"
               clickTip="Copied"
               variant="inline-compact"
-              ouiaId="azure-uuid"
             >
               {compose.id}
             </ClipboardCopy>
@@ -361,7 +359,6 @@ export const GcpDetails = ({ compose }: GcpDetailsPropTypes) => {
               hoverTip="Copy"
               clickTip="Copied"
               variant="inline-compact"
-              ouiaId="gcp-uuid"
             >
               {compose.id}
             </ClipboardCopy>
@@ -442,7 +439,6 @@ export const OciDetails = ({ compose }: OciDetailsPropTypes) => {
               hoverTip="Copy"
               clickTip="Copied"
               variant="inline-compact"
-              ouiaId="gcp-uuid"
             >
               {compose.id}
             </ClipboardCopy>
@@ -496,7 +492,6 @@ export const AwsS3Details = ({ compose }: AwsS3DetailsPropTypes) => {
               hoverTip="Copy"
               clickTip="Copied"
               variant="inline-compact"
-              ouiaId="other-targets-uuid"
             >
               {compose.id}
             </ClipboardCopy>
@@ -529,7 +524,6 @@ export const LocalDetails = ({ compose }: LocalDetailsPropTypes) => {
               hoverTip="Copy"
               clickTip="Copied"
               variant="inline-compact"
-              ouiaId="other-targets-uuid"
             >
               {compose.id}
             </ClipboardCopy>

--- a/src/Components/ImagesTable/ImagesTableToolbar.tsx
+++ b/src/Components/ImagesTable/ImagesTableToolbar.tsx
@@ -167,7 +167,6 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
             }}
             isInline
             title={`The selected blueprint has errors.`}
-            ouiaId="blueprint-errors-alert"
             actionLinks={
               <AlertActionLink
                 onClick={async () => {
@@ -202,7 +201,6 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
             }}
             isInline
             title={`The selected blueprint is at version ${selectedBlueprintVersion}, the latest images are at version ${latestImageVersion}. Build images to synchronize with the latest version.`}
-            ouiaId="blueprint-out-of-sync-alert"
             actionLinks={
               <AlertActionLink
                 onClick={() => setShowDiffModal(true)}
@@ -224,7 +222,6 @@ const ImagesTableToolbar: React.FC<imagesTableToolbarProps> = ({
               isInline
               variant="warning"
               title="CentOS Stream 8 is no longer supported, building images from this blueprint will fail. Edit blueprint to update the release to CentOS Stream 9."
-              ouiaId="centos-8-blueprint-alert"
             />
           )}
         <ToolbarContent>

--- a/src/Components/ImagesTable/Instance.tsx
+++ b/src/Components/ImagesTable/Instance.tsx
@@ -316,7 +316,6 @@ export const OciInstance = ({ compose, isExpired }: OciInstancePropTypes) => {
                 hoverTip="Copy"
                 clickTip="Copied"
                 variant="inline-compact"
-                ouiaId="oci-link"
                 isBlock
               >
                 {options?.url || ''}

--- a/src/Components/sharedComponents/ImageBuilderHeader.tsx
+++ b/src/Components/sharedComponents/ImageBuilderHeader.tsx
@@ -150,7 +150,6 @@ export const ImageBuilderHeader = ({
                 {importExportFlag && (
                   <Button
                     data-testid="import-blueprint-button"
-                    ouiaId="import-blueprint-button"
                     variant="secondary"
                     icon={<BetaLabel />}
                     iconPosition="end"


### PR DESCRIPTION
Since we're moving away from IQE the `ouia-id` atributes should be no longer needed. This removes them from the entire code base.

JIRA: [HMS-6012](https://issues.redhat.com/browse/HMS-6012)