### PR TITLE
Wizard: MODULARITY 2 - Add retirement date column (HMS-6015)

### DIFF
--- a/api/schema/contentSources.json
+++ b/api/schema/contentSources.json
@@ -252,7 +252,7 @@
                 },
                 "type": "object"
             },
-            "api.ModuleInfoResponse": {
+            "api.PackageSourcesResponse": {
                 "properties": {
                     "arch": {
                         "description": "Architecture of the module",
@@ -266,8 +266,16 @@
                         "description": "Description of the module",
                         "type": "string"
                     },
+                    "end_date": {
+                        "description": "End date of the lifecycle",
+                        "type": "string"
+                    },
                     "name": {
                         "description": "Name of the module",
+                        "type": "string"
+                    },
+                    "start_date": {
+                        "description": "Start date of the lifecycle",
                         "type": "string"
                     },
                     "stream": {
@@ -1177,7 +1185,7 @@
                     "package_sources": {
                         "description": "List of the module streams for the package",
                         "items": {
-                            "$ref": "#/components/schemas/api.ModuleInfoResponse"
+                            "$ref": "#/components/schemas/api.PackageSourcesResponse"
                         },
                         "type": "array"
                     },

--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -33,6 +33,9 @@ import {
 } from '@patternfly/react-core';
 import { Modal } from '@patternfly/react-core';
 import {
+  CheckCircleIcon,
+  ExclamationCircleIcon,
+  ExclamationTriangleIcon,
   ExternalLinkAltIcon,
   HelpIcon,
   OptimizeIcon,
@@ -1002,6 +1005,55 @@ const Packages = () => {
     );
   };
 
+  const formatDate = (date: string | undefined) => {
+    if (!date) {
+      return <>N/A</>;
+    }
+
+    const retirementDate = new Date(date);
+
+    const currentDate = new Date();
+    const msPerDay = 1000 * 60 * 60 * 24;
+    const differenceInDays = Math.round(
+      (retirementDate.getTime() - currentDate.getTime()) / msPerDay
+    );
+
+    let icon;
+
+    switch (true) {
+      case differenceInDays < 0:
+        icon = (
+          <Icon status="danger" isInline>
+            <ExclamationCircleIcon />
+          </Icon>
+        );
+        break;
+      case differenceInDays <= 365:
+        icon = (
+          <Icon status="warning" isInline>
+            <ExclamationTriangleIcon />
+          </Icon>
+        );
+        break;
+      case differenceInDays > 365:
+        icon = (
+          <Icon status="success" isInline>
+            <CheckCircleIcon />
+          </Icon>
+        );
+        break;
+    }
+
+    return (
+      <>
+        {icon}{' '}
+        {retirementDate.toLocaleString('en-US', { month: 'short' }) +
+          ' ' +
+          retirementDate.getFullYear()}
+      </>
+    );
+  };
+
   const composePkgTable = () => {
     let rows: ReactElement[] = [];
 
@@ -1075,6 +1127,7 @@ const Packages = () => {
                     </Button>
                   </Popover>
                 </Td>
+                <Td>N/A</Td>
                 <Td>N/A</Td>
                 {grp.repository === 'distro' ? (
                   <>
@@ -1164,6 +1217,13 @@ const Packages = () => {
                 <Td>
                   {pkg.sources?.map((source) =>
                     source.type === 'module' ? source.stream : 'N/A'
+                  )}
+                </Td>
+                <Td>
+                  {pkg.sources?.map((source) =>
+                    source.type === 'module'
+                      ? formatDate(source.end_date)
+                      : 'N/A'
                   )}
                 </Td>
                 {pkg.repository === 'distro' ? (
@@ -1286,9 +1346,10 @@ const Packages = () => {
           <Tr>
             <Th aria-label="Expanded" />
             <Th aria-label="Selected" />
-            <Th width={30}>Name</Th>
+            <Th width={20}>Name</Th>
             <Th width={20}>Application stream</Th>
-            <Th width={30}>Package repository</Th>
+            <Th width={20}>Retirement date</Th>
+            <Th width={20}>Package repository</Th>
           </Tr>
         </Thead>
         {bodyContent}

--- a/src/store/service/contentSourcesApi.ts
+++ b/src/store/service/contentSourcesApi.ts
@@ -639,15 +639,19 @@ export type ApiRepositoryRpmCollectionResponse = {
   links?: ApiLinks | undefined;
   meta?: ApiResponseMetadata | undefined;
 };
-export type ApiModuleInfoResponse = {
+export type ApiPackageSourcesResponse = {
   /** Architecture of the module */
   arch?: string | undefined;
   /** Context of the module */
   context?: string | undefined;
   /** Description of the module */
   description?: string | undefined;
+  /** End date of the lifecycle */
+  end_date?: string | undefined;
   /** Name of the module */
   name?: string | undefined;
+  /** Start date of the lifecycle */
+  start_date?: string | undefined;
   /** Stream of the module */
   stream?: string | undefined;
   /** Type of rpm (can be either 'package' or 'module') */
@@ -659,7 +663,7 @@ export type ApiSearchRpmResponse = {
   /** Package name found */
   package_name?: string | undefined;
   /** List of the module streams for the package */
-  package_sources?: ApiModuleInfoResponse[] | undefined;
+  package_sources?: ApiPackageSourcesResponse[] | undefined;
   /** Summary of the package found */
   summary?: string | undefined;
 };


### PR DESCRIPTION
This adds retirement date column to the Packages table and populates it with `end_date` from content-services `searchRPMs` endpoint.

![image](https://github.com/user-attachments/assets/33cfd2d6-c976-44f7-aeb1-994dde987568)
![image](https://github.com/user-attachments/assets/810b3275-c449-47b7-8486-4380614962f1)


JIRA: [HMS-6015](https://issues.redhat.com/browse/HMS-6015)