### PR TITLE
devDeps: Manually bump msw

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,7 @@
         "madge": "8.0.0",
         "mini-css-extract-plugin": "2.9.2",
         "moment": "2.30.1",
-        "msw": "2.7.3",
+        "msw": "2.7.5",
         "npm-run-all": "4.1.5",
         "path-browserify": "1.0.1",
         "postcss-scss": "4.0.9",
@@ -13342,9 +13342,9 @@
       "license": "MIT"
     },
     "node_modules/msw": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.3.tgz",
-      "integrity": "sha512-+mycXv8l2fEAjFZ5sjrtjJDmm2ceKGjrNbBr1durRg6VkU9fNUE/gsmQ51hWbHqs+l35W1iM+ZsmOD9Fd6lspw==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.5.tgz",
+      "integrity": "sha512-00MyTlY3TJutBa5kiU+jWiz2z5pNJDYHn2TgPkGkh92kMmNH43RqvMXd8y/7HxNn8RjzUbvZWYZjcS36fdb6sw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -27619,9 +27619,9 @@
       "version": "2.1.3"
     },
     "msw": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.3.tgz",
-      "integrity": "sha512-+mycXv8l2fEAjFZ5sjrtjJDmm2ceKGjrNbBr1durRg6VkU9fNUE/gsmQ51hWbHqs+l35W1iM+ZsmOD9Fd6lspw==",
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/msw/-/msw-2.7.5.tgz",
+      "integrity": "sha512-00MyTlY3TJutBa5kiU+jWiz2z5pNJDYHn2TgPkGkh92kMmNH43RqvMXd8y/7HxNn8RjzUbvZWYZjcS36fdb6sw==",
       "dev": true,
       "requires": {
         "@bundled-es-modules/cookie": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "madge": "8.0.0",
     "mini-css-extract-plugin": "2.9.2",
     "moment": "2.30.1",
-    "msw": "2.7.3",
+    "msw": "2.7.5",
     "npm-run-all": "4.1.5",
     "path-browserify": "1.0.1",
     "postcss-scss": "4.0.9",

--- a/src/mockServiceWorker.js
+++ b/src/mockServiceWorker.js
@@ -8,7 +8,7 @@
  * - Please do NOT serve this file on production.
  */
 
-const PACKAGE_VERSION = '2.7.3'
+const PACKAGE_VERSION = '2.7.5'
 const INTEGRITY_CHECKSUM = '00729d72e3b82faf54ca8b9621dbb96f'
 const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
 const activeClientIds = new Set()


### PR DESCRIPTION
This bumps msw from 2.7.3 to 2.7.5, the manual bump is needed, because dependabot doesn't want to touch `mockServiceWorker.js`. But the file gets updated when running `npm i`.