### PR TITLE
playwright: Use better AWS Codebuild runner (HMS-6025)

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -9,7 +9,7 @@ jobs:
   playwright-tests:
     runs-on:
       - codebuild-image-builder-frontend-${{ github.run_id }}-${{ github.run_attempt }}
-      - instance-size:medium
+      - instance-size:large
       - buildspec-override:true
 
     steps:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ if (process.env.CURRENTS_PROJECT_ID && process.env.CURRENTS_RECORD_KEY) {
 export default defineConfig({
   testDir: 'playwright',
   fullyParallel: true,
-  workers: 2,
+  workers: 4,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: reporters,


### PR DESCRIPTION
This PR should decrease the flakiness in parallelization in Playwright tests by providing a larger AWS codebuild instance.