### PR TITLE
Wizard: MODULARITY 2 - Update sorting to reflect currently selected stream (HMS-6014)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -361,7 +361,7 @@ const Packages = () => {
     return (
       <Tbody>
         <Tr>
-          <Td colSpan={5}>
+          <Td colSpan={6}>
             <Bullseye>
               <EmptyState variant={EmptyStateVariant.sm}>
                 <EmptyStateHeader icon={<EmptyStateIcon icon={SearchIcon} />} />
@@ -390,7 +390,7 @@ const Packages = () => {
     return (
       <Tbody>
         <Tr>
-          <Td colSpan={5}>
+          <Td colSpan={6}>
             <Bullseye>
               <EmptyState variant={EmptyStateVariant.sm}>
                 <EmptyStateHeader icon={<EmptyStateIcon icon={Spinner} />} />
@@ -411,7 +411,7 @@ const Packages = () => {
     return (
       <Tbody>
         <Tr>
-          <Td colSpan={5}>
+          <Td colSpan={6}>
             <Bullseye>
               <EmptyState variant={EmptyStateVariant.sm}>
                 <EmptyStateHeader
@@ -434,7 +434,7 @@ const Packages = () => {
     return (
       <Tbody>
         <Tr>
-          <Td colSpan={5}>
+          <Td colSpan={6}>
             <Bullseye>
               <EmptyState variant={EmptyStateVariant.sm}>
                 <EmptyStateHeader
@@ -465,7 +465,7 @@ const Packages = () => {
       return (
         <Tbody>
           <Tr>
-            <Td colSpan={5}>
+            <Td colSpan={6}>
               <Bullseye>
                 <EmptyState variant={EmptyStateVariant.sm}>
                   <EmptyStateHeader
@@ -513,7 +513,7 @@ const Packages = () => {
       return (
         <Tbody>
           <Tr>
-            <Td colSpan={5}>
+            <Td colSpan={6}>
               <Bullseye>
                 <EmptyState variant={EmptyStateVariant.sm}>
                   <EmptyStateHeader
@@ -1223,7 +1223,7 @@ const Packages = () => {
                 )}
               </Tr>
               <Tr isExpanded={isGroupExpanded(grp.name)}>
-                <Td colSpan={5}>
+                <Td colSpan={6}>
                   <ExpandableRowContent>
                     {
                       <DescriptionList>
@@ -1312,7 +1312,7 @@ const Packages = () => {
                 )}
               </Tr>
               <Tr isExpanded={isPkgExpanded(pkg)}>
-                <Td colSpan={5}>
+                <Td colSpan={6}>
                   <ExpandableRowContent>
                     {
                       <DescriptionList>

--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -171,6 +171,7 @@ const Packages = () => {
   const [activeTabKey, setActiveTabKey] = useState(Repos.INCLUDED);
 
   const [searchTerm, setSearchTerm] = useState('');
+  const [activeStream, setActiveStream] = useState<string>('');
   const [
     searchCustomRpms,
     {
@@ -796,11 +797,17 @@ const Packages = () => {
     setSearchTerm(selection);
     setActiveTabKey(Repos.INCLUDED);
     setToggleSelected('toggle-available');
+    setActiveStream('');
+    setActiveSortIndex(0);
+    setActiveSortDirection('asc');
   };
 
   const handleClear = async () => {
     setSearchTerm('');
     setActiveTabKey(Repos.INCLUDED);
+    setActiveStream('');
+    setActiveSortIndex(0);
+    setActiveSortDirection('asc');
   };
 
   const handleSelect = (
@@ -820,6 +827,9 @@ const Packages = () => {
       } else {
         dispatch(addPackage(pkg));
         if (pkg.type === 'module') {
+          setActiveStream(pkg.stream || '');
+          setActiveSortIndex(2);
+          setPage(1);
           dispatch(
             addModule({
               name: pkg.module_name || '',
@@ -1000,6 +1010,13 @@ const Packages = () => {
       return (bValue as number) - (aValue as number);
     }
     // String sort
+    // if active stream is set, sort it to the top
+    if (aValue === activeStream) {
+      return -1;
+    }
+    if (bValue === activeStream) {
+      return 1;
+    }
     if (activeSortDirection === 'asc') {
       // handle packages with undefined stream
       if (!aValue) {
@@ -1009,15 +1026,16 @@ const Packages = () => {
         return 1;
       }
       return (aValue as string).localeCompare(bValue as string);
+    } else {
+      // handle packages with undefined stream
+      if (!aValue) {
+        return 1;
+      }
+      if (!bValue) {
+        return -1;
+      }
+      return (bValue as string).localeCompare(aValue as string);
     }
-    // handle packages with undefined stream
-    if (!aValue) {
-      return 1;
-    }
-    if (!bValue) {
-      return -1;
-    }
-    return (bValue as string).localeCompare(aValue as string);
   });
 
   const getSortParams = (columnIndex: number) => ({

--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -683,6 +683,15 @@ const Packages = () => {
         ];
       });
 
+    // group by name, but sort by application stream in descending order
+    unpackedData.sort((a, b) => {
+      if (a.name === b.name) {
+        return (b.stream ?? '').localeCompare(a.stream ?? '');
+      } else {
+        return a.name.localeCompare(b.name);
+      }
+    });
+
     if (toggleSelected === 'toggle-available') {
       if (activeTabKey === Repos.INCLUDED) {
         return unpackedData.filter((pkg) => pkg.repository !== 'recommended');

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -500,10 +500,10 @@ describe('Step Packages', () => {
       const rows = await screen.findAllByRole('row');
       rows.shift();
       expect(rows).toHaveLength(2);
-      expect(rows[0]).toHaveTextContent('1.22');
-      expect(rows[1]).toHaveTextContent('1.24');
-      expect(rows[0]).toHaveTextContent('May 2025');
-      expect(rows[1]).toHaveTextContent('May 2027');
+      expect(rows[0]).toHaveTextContent('1.24');
+      expect(rows[1]).toHaveTextContent('1.22');
+      expect(rows[0]).toHaveTextContent('May 2027');
+      expect(rows[1]).toHaveTextContent('May 2025');
     });
 
     test('only one stream gets selected, other should be disabled', async () => {
@@ -584,7 +584,7 @@ describe('Packages request generated correctly', () => {
       ...blueprintRequest,
       customizations: {
         packages: ['testModule'],
-        enabled_modules: [{ name: 'testModule', stream: '1.22' }],
+        enabled_modules: [{ name: 'testModule', stream: '1.24' }],
       },
     };
 


### PR DESCRIPTION
Rebased on: https://github.com/osbuild/image-builder-frontend/pull/3178

This updates the sort logic to reflect currently selected application stream. For example if `nodejs` with application stream 22 gets selected, results for other modules with the same application stream should be prioritized before the rest of results.

![image](https://github.com/user-attachments/assets/c2b3a9c7-bfd1-4a29-840b-722bb531c0ed)

![stream-sort](https://github.com/user-attachments/assets/4e16038d-49ab-4fef-83ba-97c8545a3bdf)
