### PR TITLE
Wizard: Fix users bug - 'wheel' group removal

### DIFF
--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -1106,6 +1106,9 @@ export const wizardSlice = createSlice({
         (group) => group === action.payload.group
       );
       if (groupIndex !== -1) {
+        if (action.payload.group === 'wheel') {
+          state.users[action.payload.index].isAdministrator = false;
+        }
         state.users[action.payload.index].groups.splice(groupIndex, 1);
       }
     },


### PR DESCRIPTION
If 'wheel' group was removed the Administrator checkbox stayed check. This unchecks it.