### PR TITLE
Wizard: make policy selector wider in Compliance step

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -283,7 +283,7 @@ const PolicySelector = () => {
       isDisabled={isFetchingPolicies || hasWslTargetOnly}
       style={
         {
-          width: '200px',
+          width: '100%',
         } as React.CSSProperties
       }
     >


### PR DESCRIPTION
When resolving conflicts, the `style: 200px` prop sneaked past me and stayed in the code. It's time to let it rest. 🪦