### PR TITLE
src: Fix user groups validation on import (HMS-6279)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
@@ -126,6 +126,7 @@ const UserInfo = () => {
       errors: {
         userName: stepValidation?.errors[index]?.userName,
         userSshKey: stepValidation?.errors[index]?.userSshKey,
+        groups: stepValidation?.errors[index]?.groups,
       },
       disabledNext: stepValidation.disabledNext,
     };

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -51,6 +51,7 @@ import {
   isKernelArgumentValid,
   isPortValid,
   isServiceValid,
+  isUserGroupValid,
 } from '../validators';
 
 export type StepValidation = {
@@ -494,6 +495,7 @@ export function useUsersValidation(): UsersStepValidation {
   }
 
   for (let index = 0; index < users.length; index++) {
+    const invalidGroups = [];
     const userNameError = validateUserName(users, users[index].name);
     const sshKeyError = validateSshKey(users[index].ssh_key);
     const isPasswordValid = checkPasswordValidity(
@@ -503,15 +505,28 @@ export function useUsersValidation(): UsersStepValidation {
     const passwordError =
       users[index].password && !isPasswordValid ? 'Invalid password' : '';
 
+    if (users[index].groups.length > 0) {
+      for (const g of users[index].groups) {
+        if (!isUserGroupValid(g)) {
+          invalidGroups.push(g);
+        }
+      }
+    }
+
+    const groupsError =
+      invalidGroups.length > 0 ? `Invalid user groups: ${invalidGroups}` : '';
+
     if (
       userNameError ||
       sshKeyError ||
-      (users[index].password && !isPasswordValid)
+      (users[index].password && !isPasswordValid) ||
+      groupsError
     ) {
       errors[`${index}`] = {
         userName: userNameError,
         userSshKey: sshKeyError,
         userPassword: passwordError,
+        groups: groupsError,
       };
     }
   }

--- a/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -219,15 +219,11 @@ name = "anaconda-tools"
 hostname = "--invalid-hostname--"
 fips = true
 
-[[customizations.sshkey]]
-user = "root"
-key = "ssh-rsa d"
-
 [[customizations.user]]
-name = "admin"
-password = "$6$CHO2$3rN8eviE2t50lmVyBYihTgVRHcaecmeCk31L..."
-key = "ssh-rsa d"
-groups = ["widget", "users", "wheel"]
+name = "t"
+password = "00"
+key = "KEY"
+groups = ["0000"]
 
 [customizations.services]
 enabled = ["--invalid-enabled-service"]
@@ -539,7 +535,31 @@ describe('Import modal', () => {
     await clickNext(); // Repository snapshot
     await clickNext(); // Custom Repos step
     await clickNext(); // Packages step
-    await clickNext(); // Users
+
+    // Users
+    await clickNext();
+    expect(await screen.findByText('Invalid user name')).toBeInTheDocument();
+    await waitFor(async () =>
+      user.type(await screen.findByPlaceholderText('Enter username'), 'est')
+    );
+    expect(
+      await screen.findByText('Password must be at least 6 characters long')
+    ).toBeInTheDocument();
+    await waitFor(async () =>
+      user.clear(await screen.findByPlaceholderText('Enter password'))
+    );
+    expect(await screen.findByText('Invalid SSH key')).toBeInTheDocument();
+    await waitFor(async () =>
+      user.clear(
+        await screen.findByPlaceholderText('Paste your public SSH key')
+      )
+    );
+    expect(
+      await screen.findByText(/Invalid user groups: 0000/)
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      user.click(screen.getByRole('button', { name: /close 0000/i }))
+    );
 
     // Timezone
     await clickNext();


### PR DESCRIPTION
The error for invalid user groups was not previously rendered on import. This fixes the issue and adds an import test to check that the error messages for all user fields get correctly rendered.