### PR TITLE
Wizard: Fix password placeholder (HMS-6290)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
@@ -54,10 +54,10 @@ export const PasswordValidatedInput = ({
             <TextInput
               isRequired
               type={isPasswordVisible ? 'text' : 'password'}
-              value={hasPassword ? '•'.repeat(8) : value}
+              value={value}
               onChange={onChange}
               aria-label={ariaLabel}
-              placeholder={placeholder}
+              placeholder={hasPassword ? '●'.repeat(8) : placeholder}
             />
           </InputGroupItem>
           <InputGroupItem>

--- a/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
+++ b/src/Components/CreateImageWizard/utilities/PasswordValidatedInput.tsx
@@ -65,7 +65,7 @@ export const PasswordValidatedInput = ({
               variant="control"
               onClick={togglePasswordVisibility}
               aria-label={isPasswordVisible ? 'Hide password' : 'Show password'}
-              isDisabled={hasPassword}
+              isDisabled={hasPassword && !value}
             >
               {isPasswordVisible ? <EyeSlashIcon /> : <EyeIcon />}
             </Button>


### PR DESCRIPTION
User password gets redacted from a blueprint, meaning if there was any password set, it does not render on import.

Previously a placeholder was rendered as a value of password, making the value not editable. This renders the password indication as a placeholder text, solving the issue.

JIRA: [HMS-6290](https://issues.redhat.com/browse/HMS-6290)