### PR TITLE
Wizard: Sort activation keys list (HMS-6291)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/ActivationKeysList.tsx
@@ -31,6 +31,7 @@ import {
   selectActivationKey,
   selectRegistrationType,
 } from '../../../../store/wizardSlice';
+import sortfn from '../../../../Utilities/sortfn';
 import { useGetEnvironment } from '../../../../Utilities/useGetEnvironment';
 import { generateRandomId } from '../../utilities/generateRandomId';
 
@@ -91,7 +92,7 @@ const ActivationKeysList = () => {
     }
 
     if (filteredKeys) {
-      setSelectOptions(filteredKeys);
+      setSelectOptions(filteredKeys.sort((a, b) => sortfn(a, b, filterValue)));
     }
 
     // This useEffect hook should run *only* on when the filter value

--- a/src/Utilities/sortfn.ts
+++ b/src/Utilities/sortfn.ts
@@ -1,4 +1,14 @@
-const sortfn = (a: string, b: string, searchTerm: string) => {
+const sortfn = (
+  a: string | undefined,
+  b: string | undefined,
+  searchTerm: string
+) => {
+  if (!a) {
+    return -1;
+  }
+  if (!b) {
+    return 1;
+  }
   const x = a.toLowerCase();
   const y = b.toLowerCase();
   // check exact match first


### PR DESCRIPTION
This sorts the activation keys list by name.

The `sortFn` function was also updated to handle undefined values.

JIRA: [HMS-6291](https://issues.redhat.com/browse/HMS-6291)