### PR TITLE
Wizard: encode satellite cmd properly

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -473,9 +473,7 @@ const getSatelliteCommand = (files?: File[]): string => {
   const satelliteCommandFile = files?.find(
     (file) => file.path === '/usr/local/sbin/register-satellite'
   );
-  return satelliteCommandFile?.data
-    ? decodeURIComponent(atob(satelliteCommandFile.data))
-    : '';
+  return satelliteCommandFile?.data ? atob(satelliteCommandFile.data) : '';
 };
 
 const uploadTypeByTargetEnv = (imageType: ImageTypes): UploadTypes => {
@@ -587,7 +585,8 @@ const getCustomizations = (state: RootState, orgID: string): Customizations => {
     });
     files.push({
       path: '/usr/local/sbin/register-satellite',
-      data: btoa(encodeURIComponent(satCmd)),
+      data: btoa(satCmd),
+      mode: '0774',
       data_encoding: 'base64',
       ensure_parents: true,
     });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -263,23 +263,23 @@ WantedBy=graphical.target
 export const FIRST_BOOT_SERVICE = 'custom-first-boot';
 
 export const SATELLITE_SERVICE_DATA = btoa(`[Unit]
-  Description=Custom first boot script
-  ConditionFileIsExecutable=/usr/local/sbin/register-satellite
-  ConditionPathExists=!/var/local/.register-satellite-done
-  Wants=network-online.target
-  After=network-online.target
-  After=osbuild-first-boot.service
+Description=Register satellite first boot script
+ConditionFileIsExecutable=/usr/local/sbin/register-satellite
+ConditionPathExists=!/var/local/.register-satellite-done
+Wants=network-online.target
+After=network-online.target
+After=osbuild-first-boot.service
 
-  [Service]
-  Type=oneshot
-  ExecStart=/usr/local/sbin/register-satellite
-  ExecStartPost=/usr/bin/touch /var/local/.register-satellite-done
-  RemainAfterExit=yes
+[Service]
+Type=oneshot
+ExecStart=/bin/bash -x /usr/local/sbin/register-satellite
+ExecStartPost=/usr/bin/touch /var/local/.register-satellite-done
+RemainAfterExit=yes
 
-  [Install]
-  WantedBy=basic.target
-  WantedBy=multi-user.target
-  WantedBy=graphical.target
+[Install]
+WantedBy=basic.target
+WantedBy=multi-user.target
+WantedBy=graphical.target
 `);
 
 export const SATELLITE_SERVICE = 'register-satellite';


### PR DESCRIPTION
I know nothing about the modern JS/TS, review with care. Problems:

* The file /usr/local/sbin/register-satellite is not executable.
* The file does not have a shebang.
* The file contents is for some reason all URL encoded.
* Finally, the file is missing an end newline.

/epic https://issues.redhat.com/browse/HMS-6296