### PR TITLE
Wizard: send template name in image request (HMS-6299)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Snapshot/components/Templates.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/components/Templates.tsx
@@ -20,6 +20,7 @@ import {
   selectDistribution,
   selectTemplate,
   changeTemplate,
+  changeTemplateName,
 } from '../../../../../store/wizardSlice';
 import { releaseToVersion } from '../../../../../Utilities/releaseToVersion';
 import { Error } from '../../Repositories/components/Error';
@@ -53,9 +54,15 @@ const Templates = () => {
     { refetchOnMountOrArgChange: 60 }
   );
 
-  const handleRowSelect = (templateUuid: string | undefined): void => {
+  const handleRowSelect = (
+    templateUuid: string | undefined,
+    templateName: string | undefined
+  ): void => {
     if (templateUuid) {
       dispatch(changeTemplate(templateUuid));
+    }
+    if (templateName) {
+      dispatch(changeTemplateName(templateName));
     }
   };
 
@@ -123,7 +130,7 @@ const Templates = () => {
                             variant: 'radio',
                             isSelected: uuid === templateUuid,
                             rowIndex: rowIndex,
-                            onSelect: () => handleRowSelect(uuid),
+                            onSelect: () => handleRowSelect(uuid, name),
                           }}
                         />
                         <Td dataLabel={'Name'}>{name}</Td>

--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -87,6 +87,7 @@ import {
   selectMetadata,
   selectFirewall,
   selectTemplate,
+  selectTemplateName,
   selectSatelliteCaCertificate,
   selectSatelliteRegistrationCommand,
   selectModules,
@@ -307,6 +308,7 @@ function commonRequestToState(
       useLatest: !snapshot_date && !request.image_requests[0]?.content_template,
       snapshotDate: snapshot_date,
       template: request.image_requests[0]?.content_template || '',
+      templateName: request.image_requests[0]?.content_template_name || '',
     },
     repositories: {
       customRepositories: request.customizations?.custom_repositories || [],
@@ -457,6 +459,7 @@ const getImageRequests = (state: RootState): ImageRequest[] => {
   const snapshotDate = selectSnapshotDate(state);
   const useLatest = selectUseLatest(state);
   const template = selectTemplate(state);
+  const templateName = selectTemplateName(state);
   return imageTypes.map((type) => ({
     architecture: selectArchitecture(state),
     image_type: type,
@@ -466,6 +469,7 @@ const getImageRequests = (state: RootState): ImageRequest[] => {
     },
     snapshot_date: !useLatest && !template ? snapshotDate : undefined,
     content_template: template || undefined,
+    content_template_name: templateName || undefined,
   }));
 };
 

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -130,6 +130,7 @@ export type wizardState = {
     useLatest: boolean;
     snapshotDate: string;
     template: string;
+    templateName: string;
   };
   users: UserWithAdditionalInfo[];
   firstBoot: {
@@ -226,6 +227,7 @@ export const initialState: wizardState = {
     useLatest: true,
     snapshotDate: '',
     template: '',
+    templateName: '',
   },
   repositories: {
     customRepositories: [],
@@ -396,6 +398,10 @@ export const selectSnapshotDate = (state: RootState) => {
 
 export const selectTemplate = (state: RootState) => {
   return state.wizard.snapshotting.template;
+};
+
+export const selectTemplateName = (state: RootState) => {
+  return state.wizard.snapshotting.templateName;
 };
 
 export const selectCustomRepositories = (state: RootState) => {
@@ -750,6 +756,9 @@ export const wizardSlice = createSlice({
     },
     changeTemplate: (state, action: PayloadAction<string>) => {
       state.snapshotting.template = action.payload;
+    },
+    changeTemplateName: (state, action: PayloadAction<string>) => {
+      state.snapshotting.templateName = action.payload;
     },
     importCustomRepositories: (
       state,
@@ -1156,6 +1165,7 @@ export const {
   changeUseLatest,
   changeSnapshotDate,
   changeTemplate,
+  changeTemplateName,
   changeCustomRepositories,
   importCustomRepositories,
   changePayloadRepositories,


### PR DESCRIPTION
Supports these changes to image-builder-crc: https://github.com/osbuild/image-builder-crc/pull/1600, which require the template name



JIRA: [HMS-6299](https://issues.redhat.com/browse/HMS-6299)