### PR TITLE
Wizard: Fix vertical height bug

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -74,15 +74,3 @@ div.pf-v5-c-alert.pf-m-inline.pf-m-plain.pf-m-warning {
         margin-block-start: 0;
     }
 }
-
-.pf-v5-c-wizard__main {
-    flex: 1 1 auto;
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
-}
-
-.pf-v5-c-wizard__footer {
-    position: sticky;
-    bottom: 0;
-}

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -8,6 +8,7 @@ import {
   WizardStep,
   useWizardContext,
   PageSection,
+  PageSectionTypes,
 } from '@patternfly/react-core';
 import { WizardStepType } from '@patternfly/react-core/dist/esm/components/Wizard';
 import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
@@ -354,7 +355,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   return (
     <>
       <ImageBuilderHeader inWizard />
-      <PageSection>
+      <PageSection type={PageSectionTypes.wizard}>
         <Wizard
           startIndex={startIndex}
           onClose={() => navigate(resolveRelPath(''))}


### PR DESCRIPTION
Recently the wizard has started rendering such that its vertical height matches the height of its body – and therefore only occupies some fraction of the page’s vertical space for many steps. The desired behavior is for its footer to be fixed at the bottom of the viewport.

Specifying the page section type prop as ‘wizard’ resolves the issue. This is the pattern used in the Patternfly documentation for in-page wizards. See here:
https://www.patternfly.org/components/wizard/react-demos#in-page

Using CSS to adjust Patternfly component rendering is an antipattern. More custom CSS means more time spent troubleshooting rendering issues. Custom CSS related to rendering of the wizard has been removed.

There is still an annoying issue. The body of the wizard is not scrollable and will overflow. This is counter to the Patternfly examples. There doesn’t seem to be any CSS in Image Builder that would cause this to occur. Perhaps the problem is somehow inherited from Insights Chrome? In any case, this will require further investigation.