### PR TITLE
build: add testing proxy to playwright CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install front-end dependencies
         run: npm ci
@@ -48,8 +48,11 @@ jobs:
 
       - name: Start front-end server
         run: |
-          npm run start:stage &
-          npx wait-on https://localhost:1337
+          npm run start:federated &
+          npx wait-on http://localhost:8003/apps/image-builder/
+
+      - name: Run testing proxy
+        run: docker run -d --network=host -e HTTPS_PROXY=$RH_PROXY_URL -v "$(pwd)/config:/config:ro,Z" --name consoledot-testing-proxy quay.io/dvagner/consoledot-testing-proxy
 
       - name: Run front-end Playwright tests
         env:

--- a/config/routes.json
+++ b/config/routes.json
@@ -1,0 +1,3 @@
+{
+  "/apps/image-builder*": { "url": "http://127.0.0.1:8003" }
+}

--- a/playwright/helpers/helpers.ts
+++ b/playwright/helpers/helpers.ts
@@ -25,6 +25,10 @@ export const closePopupsIfExist = async (page: Page) => {
     page.locator(`button[id^="pendo-close-guide-"]`), // This closes the pendo guide pop-up
     page.locator(`button[id="truste-consent-button"]`), // This closes the trusted consent pop-up
     page.getByLabel('close-notification'), // This closes a one off info notification (May be covered by the toast above, needs recheck.)
+    page
+      .locator('iframe[name="intercom-modal-frame"]')
+      .contentFrame()
+      .getByRole('button', { name: 'Close' }),
   ];
 
   for (const locator of locatorsToCheck) {


### PR DESCRIPTION
This PR switches the playwright tests in CI to use the consoledot testing
proxy instead of the development one in fec. This should result in
faster and more stable tests.