### PR TITLE
Wizard: Parse locale codes to readable options

### DIFF
--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -28,6 +28,24 @@ import sortfn from '../../../../../Utilities/sortfn';
 import { useLocaleValidation } from '../../../utilities/useValidation';
 import { languagesList } from '../languagesList';
 
+const parseLanguageOption = (language: string) => {
+  try {
+    const [region, encoding] = language.split('.');
+    const [languageCode, countryCode] = region.split('_');
+
+    const languageName = new Intl.DisplayNames(['en'], {
+      type: 'language',
+    }).of(languageCode);
+    const countryName = new Intl.DisplayNames(['en'], { type: 'region' }).of(
+      countryCode
+    );
+
+    return `${languageName} (${countryName} - ${encoding})`;
+  } catch {
+    return language;
+  }
+};
+
 const LanguagesDropDown = () => {
   const languages = useAppSelector(selectLanguages);
   const dispatch = useAppDispatch();
@@ -42,19 +60,28 @@ const LanguagesDropDown = () => {
   const [filterValue, setFilterValue] = useState<string>('');
   const [selectOptions, setSelectOptions] = useState<string[]>(languagesList);
 
+  type ParsedLanguages = { [key: string]: string };
+
+  const parsedLanguages = languagesList.reduce((acc, language) => {
+    acc[language] = parseLanguageOption(language);
+    return acc;
+  }, {} as ParsedLanguages);
+
   useEffect(() => {
-    let filteredLanguages = languagesList;
+    let filteredLanguages = Object.entries(parsedLanguages);
 
     if (filterValue) {
-      filteredLanguages = languagesList.filter((language: string) =>
-        String(language).toLowerCase().includes(filterValue.toLowerCase())
+      filteredLanguages = filteredLanguages.filter(([, parsed]) =>
+        String(parsed).toLowerCase().includes(filterValue.toLowerCase())
       );
       if (!isOpen) {
         setIsOpen(true);
       }
     }
     setSelectOptions(
-      filteredLanguages.sort((a, b) => sortfn(a, b, filterValue))
+      filteredLanguages
+        .sort((a, b) => sortfn(a[1], b[1], filterValue))
+        .map(([raw]) => raw)
     );
 
     // This useEffect hook should run *only* on when the filter value changes.
@@ -153,7 +180,7 @@ const LanguagesDropDown = () => {
                   languages?.includes(option) && 'Language already added'
                 }
               >
-                {option}
+                {parseLanguageOption(option)}
               </SelectOption>
             ))
           ) : (
@@ -174,8 +201,12 @@ const LanguagesDropDown = () => {
       )}
       <LabelGroup numLabels={5} className="pf-v5-u-mt-sm pf-v5-u-w-100">
         {languages?.map((lang) => (
-          <Label key={lang} onClose={(e) => handleRemoveLang(e, lang)}>
-            {lang}
+          <Label
+            key={lang}
+            onClose={(e) => handleRemoveLang(e, lang)}
+            isCompact
+          >
+            {parseLanguageOption(lang)}
           </Label>
         ))}
       </LabelGroup>


### PR DESCRIPTION
This parses options in the Languages dropdown to human readable form like so: 'en_US.UTF-8' -> 'English (US, UTF-8)'

![image](https://github.com/user-attachments/assets/a632c9f9-51c6-4817-bca3-d690f60821c5)
