### PR TITLE
devDeps: Manually bump @currents/playwright to 1.13.2 (HMS-8600)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@babel/preset-env": "7.27.2",
         "@babel/preset-react": "7.27.1",
         "@babel/preset-typescript": "7.27.0",
-        "@currents/playwright": "1.12.4",
+        "@currents/playwright": "1.13.2",
         "@patternfly/react-icons": "5.4.2",
         "@playwright/test": "1.51.1",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "2.0.12",
@@ -2294,25 +2294,25 @@
       }
     },
     "node_modules/@currents/playwright": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/@currents/playwright/-/playwright-1.12.4.tgz",
-      "integrity": "sha512-qJ5V6nQ6l0EegLG6xssHKZCc+JS7eAIy3i9+pIKWh+8aO/4f/QnmDKSkMRAjEwYX+1SHN8Ss4O7iKyJiOclFsg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@currents/playwright/-/playwright-1.13.2.tgz",
+      "integrity": "sha512-lxYTueNH8JSOhnbpBjV+BkiMLtKQNZgbibLXLBua72jcIWKQGxTge47d70iq6NvIVIjuOB6OL7fORRRFcmdp3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.18.6",
+        "@babel/code-frame": "^7.27.1",
         "@commander-js/extra-typings": "^12.1.0",
         "@currents/commit-info": "1.0.1-beta.0",
         "async-retry": "^1.3.3",
-        "axios": "^1.8.4",
+        "axios": "^1.9.0",
         "axios-retry": "^4.5.0",
         "c12": "^1.11.2",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "date-fns": "^4.1.0",
         "debug": "^4.3.7",
-        "dotenv": "^16.0.3",
-        "execa": "^9.5.2",
+        "dotenv": "^16.5.0",
+        "execa": "^9.5.3",
         "getos": "^3.2.1",
         "https-proxy-agent": "^7.0.5",
         "istanbul-lib-coverage": "^3.2.2",
@@ -6977,9 +6977,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -8920,9 +8920,10 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
       },
@@ -10008,9 +10009,9 @@
       }
     },
     "node_modules/execa": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
-      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.3.tgz",
+      "integrity": "sha512-QFNnTvU3UjgWFy8Ef9iDHvIdcgZ344ebkwYx4/KLbR+CKQA4xBaHzv+iRpp86QfMHP8faFQLh8iOc57215y4Rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11492,9 +11493,9 @@
       }
     },
     "node_modules/human-signals": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
-      "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -21067,24 +21068,24 @@
       }
     },
     "@currents/playwright": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/@currents/playwright/-/playwright-1.12.4.tgz",
-      "integrity": "sha512-qJ5V6nQ6l0EegLG6xssHKZCc+JS7eAIy3i9+pIKWh+8aO/4f/QnmDKSkMRAjEwYX+1SHN8Ss4O7iKyJiOclFsg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@currents/playwright/-/playwright-1.13.2.tgz",
+      "integrity": "sha512-lxYTueNH8JSOhnbpBjV+BkiMLtKQNZgbibLXLBua72jcIWKQGxTge47d70iq6NvIVIjuOB6OL7fORRRFcmdp3w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.18.6",
+        "@babel/code-frame": "^7.27.1",
         "@commander-js/extra-typings": "^12.1.0",
         "@currents/commit-info": "1.0.1-beta.0",
         "async-retry": "^1.3.3",
-        "axios": "^1.8.4",
+        "axios": "^1.9.0",
         "axios-retry": "^4.5.0",
         "c12": "^1.11.2",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "date-fns": "^4.1.0",
         "debug": "^4.3.7",
-        "dotenv": "^16.0.3",
-        "execa": "^9.5.2",
+        "dotenv": "^16.5.0",
+        "execa": "^9.5.3",
         "getos": "^3.2.1",
         "https-proxy-agent": "^7.0.5",
         "istanbul-lib-coverage": "^3.2.2",
@@ -23899,9 +23900,9 @@
       "dev": true
     },
     "axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -25087,9 +25088,9 @@
       }
     },
     "dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -25806,9 +25807,9 @@
       "version": "3.3.0"
     },
     "execa": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
-      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
+      "version": "9.5.3",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.3.tgz",
+      "integrity": "sha512-QFNnTvU3UjgWFy8Ef9iDHvIdcgZ344ebkwYx4/KLbR+CKQA4xBaHzv+iRpp86QfMHP8faFQLh8iOc57215y4Rg==",
       "dev": true,
       "requires": {
         "@sindresorhus/merge-streams": "^4.0.0",
@@ -26779,9 +26780,9 @@
       }
     },
     "human-signals": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.0.tgz",
-      "integrity": "sha512-/1/GPCpDUCCYwlERiYjxoczfP0zfvZMU/OWgQPMya9AbAE24vseigFdhAMObpc8Q4lc/kjutPfUddDYyAmejnA==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
+      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
       "dev": true
     },
     "hyperdyperid": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/preset-env": "7.27.2",
     "@babel/preset-react": "7.27.1",
     "@babel/preset-typescript": "7.27.0",
-    "@currents/playwright": "1.12.4",
+    "@currents/playwright": "1.13.2",
     "@patternfly/react-icons": "5.4.2",
     "@playwright/test": "1.51.1",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "2.0.12",


### PR DESCRIPTION
This bumps @currents/playwright to version 1.13.2 to skip versions that broke github action.

JIRA: [HMS-8600](https://issues.redhat.com/browse/HMS-8600)