### PR TITLE
Wizard: fix datepicker glitch after reset

### DIFF
--- a/src/Components/CreateImageWizard/steps/Snapshot/Snapshot.tsx
+++ b/src/Components/CreateImageWizard/steps/Snapshot/Snapshot.tsx
@@ -138,10 +138,7 @@ export default function Snapshot() {
                 onClick={async () => {
                   //Patternfly DatePicker seems to only clear error text if value is reset to '',
                   // if you have an invalid date (2000-01-010000) and try to reset it, it must be set to '' first
-                  dispatch(changeSnapshotDate(''));
-                  setTimeout(() => {
-                    dispatch(changeSnapshotDate(yyyyMMddFormat(new Date())));
-                  }, 1);
+                  dispatch(changeSnapshotDate(yyyyMMddFormat(new Date())));
                 }}
               >
                 Reset

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -748,10 +748,10 @@ export const wizardSlice = createSlice({
     changeSnapshotDate: (state, action: PayloadAction<string>) => {
       const yyyyMMDDRegex = /^\d{4}-\d{2}-\d{2}$/;
       const date = new Date(action.payload);
-      if (action.payload === '') {
-        state.snapshotting.snapshotDate = '';
-      } else if (yyyyMMDDRegex.test(action.payload) && !isNaN(date.getTime())) {
+      if (yyyyMMDDRegex.test(action.payload) && !isNaN(date.getTime())) {
         state.snapshotting.snapshotDate = date.toISOString();
+      } else {
+        state.snapshotting.snapshotDate = action.payload;
       }
     },
     changeTemplate: (state, action: PayloadAction<string>) => {

--- a/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
@@ -254,6 +254,12 @@ describe('repository snapshot tab - ', () => {
     });
     // reset fills in the current date, so it should not be disabled
     await clickReset();
+    // works even for invalid values
+    await updateDatePickerWithValue('xxx');
+    await waitFor(() => {
+      expect(nextBtn).toBeDisabled();
+    });
+    await clickReset();
     await waitFor(() => {
       expect(nextBtn).toBeEnabled();
     });


### PR DESCRIPTION
If the reset button is clicked, there is a glitch that shows error state for a moment. This commit removes the glitch by setting the snapshot date even for invalid values, and removes the workaround that was previously added.


https://github.com/user-attachments/assets/d47c3a82-c85e-4e1d-bc1d-c423b640ff2b

