### PR TITLE
Wizard: conflicting packages

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -1075,12 +1075,16 @@ const Packages = () => {
    * @returns Package (or group) is / is not selected
    */
   const isSelectDisabled = (pkg: IBPackageWithRepositoryInfo) => {
-    return (
-      (pkg.type === 'module' &&
-        modules.some((module) => module.name === pkg.module_name) &&
-        !modules.some((p) => p.stream === pkg.stream)) ||
-      false
-    );
+    const isModuleStreamConflict =
+      pkg.type === 'module' &&
+      modules.some((module) => module.name === pkg.module_name) &&
+      !modules.some((p) => p.stream === pkg.stream);
+
+    const isNonModuleDisabledByModule =
+      (!pkg.type || pkg.type === 'package') &&
+      modules.some((module) => module.name === pkg.name);
+
+    return isModuleStreamConflict || isNonModuleDisabledByModule;
   };
 
   const formatDate = (date: string | undefined) => {


### PR DESCRIPTION
Disable a package if it's a conflicting module stream or if it's a non-modular package whose base name is already covered by an enabled module stream.

Fixes #3274