### PR TITLE
Wizard: disable adding empty user tabs (HMS-8652)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserInfo.tsx
@@ -149,6 +149,7 @@ const UserInfo = () => {
         activeKey={activeTabKey}
         onSelect={onSelect}
         onAdd={onAdd}
+        isAddButtonDisabled={stepValidation.disabledNext}
         onClose={onClose}
         ref={tabComponentRef}
       >


### PR DESCRIPTION
When creating an empty user, the "+" sign gets hidden, and only pops back up if at least user name, psswd, or ssh key is filed out.

Fixes #3114

JIRA: [HMS-8652](https://issues.redhat.com/browse/HMS-8652)