### PR TITLE
Wizard: Fix overflow issues

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,16 @@ const App = () => {
     hideGlobalFilter(true);
   }, [hideGlobalFilter, updateDocumentTitle]);
 
+  // Necessary for in-page wizard overflow to behave properly
+  // The .chr-render class is defined in Insights Chrome:
+  // https://github.com/RedHatInsights/insights-chrome/blob/fe573705020ff64003ac9e6101aa978b471fe6f2/src/sass/chrome.scss#L82
+  useEffect(() => {
+    const chrRenderDiv = document.querySelector('.chr-render');
+    if (chrRenderDiv) {
+      (chrRenderDiv as HTMLElement).style.overflow = 'auto';
+    }
+  }, []);
+
   return (
     <React.Fragment>
       <NotificationsPortal />


### PR DESCRIPTION
The in-page wizard should have its footer fixed/sticky at the bottom of the page with the main body area scrollable if necessary. This is the default Patternfly behavior.

Currently, the entire wizard grows to fill its parent container. Setting the overflow property in its parent div, which has the .chr-render class defined by Insights Chrome, to overflow solves the issue and causes the wizard to behave as it should.

The Insights Chrome team is hesitant to make this change in Insights Chrome as it could break other apps layouts, and suggested using Javascript to accomplish this:
https://github.com/RedHatInsights/insights-chrome/pull/3117#discussion_r2129045341