### PR TITLE
ImagesTable: fix main section alignment

### DIFF
--- a/src/Components/ImagesTable/ImagesTable.tsx
+++ b/src/Components/ImagesTable/ImagesTable.tsx
@@ -11,6 +11,7 @@ import {
   Bullseye,
   Badge,
   Button,
+  PageSection,
 } from '@patternfly/react-core';
 import { OnSetPage } from '@patternfly/react-core/dist/esm/components/Pagination/Pagination';
 import {
@@ -233,7 +234,7 @@ const ImagesTable = () => {
   }
 
   return (
-    <>
+    <PageSection>
       <ImagesTableToolbar
         itemCount={itemCount}
         perPage={perPage}
@@ -296,7 +297,7 @@ const ImagesTable = () => {
           </ToolbarItem>
         </ToolbarContent>
       </Toolbar>
-    </>
+    </PageSection>
   );
 };
 


### PR DESCRIPTION
With the change to PF6 the list of items in the table section was not padded properly, we can fix this by wrapping the code in a `PageSection` component.