### PR TITLE
Wizard: Make popover button independent on tab (HMS-8680)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -1508,20 +1508,14 @@ const Packages = () => {
       >
         <Tab
           eventKey="included-repos"
-          title={
-            <TabTitleText>
-              Included repos <IncludedReposPopover />
-            </TabTitleText>
-          }
+          title={<TabTitleText>Included repos</TabTitleText>}
+          actions={<IncludedReposPopover />}
           aria-label="Included repositories"
         />
         <Tab
           eventKey="other-repos"
-          title={
-            <TabTitleText>
-              Other repos <OtherReposPopover />
-            </TabTitleText>
-          }
+          title={<TabTitleText>Other repos</TabTitleText>}
+          actions={<OtherReposPopover />}
           aria-label="Other repositories"
         />
       </Tabs>

--- a/src/Components/CreateImageWizard/steps/Packages/components/RepoPopovers.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/RepoPopovers.tsx
@@ -20,7 +20,6 @@ export const IncludedReposPopover = () => {
         variant="plain"
         aria-label="About included repositories"
         component="span"
-        className="pf-v6-u-p-0"
         size="sm"
         isInline
       />
@@ -45,7 +44,6 @@ export const OtherReposPopover = () => {
         variant="plain"
         aria-label="About other repositories"
         component="span"
-        className="pf-v6-u-p-0"
         size="sm"
         isInline
       />


### PR DESCRIPTION
Previously when the Included/Other repos popover button was clicked the tab changed as well. This makes the popover button independent on the selected tab.

![image](https://github.com/user-attachments/assets/63b2d0de-42cb-4058-b35d-0732f6682cc0)
![image](https://github.com/user-attachments/assets/ab15d84a-96fe-427f-ab79-c4f58a521d54)
![image](https://github.com/user-attachments/assets/ac6c2ee4-96fd-4b63-9a23-75a09cd28826)


JIRA: [HMS-8680](https://issues.redhat.com/browse/HMS-8680)