### PR TITLE
Wizard: Fix wizard height (HMS-8696)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.scss
+++ b/src/Components/CreateImageWizard/CreateImageWizard.scss
@@ -53,3 +53,8 @@ div.pf-v6-c-alert.pf-m-inline.pf-m-plain.pf-m-warning {
         margin-block-start: 0;
     }
 }
+
+// Ensures the wizard takes up the entire height of the page in Firefox as well
+.pf-v6-c-wizard {
+    flex: 1;
+}


### PR DESCRIPTION
This adds a style to make sure the Wizard takes up the entire height of the page also in Firefox.

All the credit for figuring this out goes to @lucasgarfield, I've just opened the PR

JIRA: [HMS-8696](https://issues.redhat.com/browse/HMS-8696)