### PR TITLE
Wizard: Make RHEL 10 the default distribution

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -90,9 +90,9 @@ export const UNIT_GIB = 1024 ** 3;
 
 // Use a Map() to ensure order is preserved (order is not gauranteed by an Object())
 export const RELEASES = new Map([
+  [RHEL_10, 'Red Hat Enterprise Linux (RHEL) 10'],
   [RHEL_9, 'Red Hat Enterprise Linux (RHEL) 9'],
   [RHEL_8, 'Red Hat Enterprise Linux (RHEL) 8'],
-  [RHEL_10, 'Red Hat Enterprise Linux (RHEL) 10'],
   [RHEL_9_BETA, 'Red Hat Enterprise Linux (RHEL) 9 Beta'],
   [RHEL_10_BETA, 'Red Hat Enterprise Linux (RHEL) 10 Beta'],
   [CENTOS_9, 'CentOS Stream 9'],

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -32,7 +32,7 @@ import type {
 } from '../Components/CreateImageWizard/steps/TargetEnvironment/Gcp';
 import type { V1ListSourceResponseItem } from '../Components/CreateImageWizard/types';
 import { generateDefaultName } from '../Components/CreateImageWizard/utilities/useGenerateDefaultName';
-import { RHEL_9, X86_64 } from '../constants';
+import { RHEL_10, X86_64 } from '../constants';
 import { yyyyMMddFormat } from '../Utilities/time';
 
 import type { RootState } from '.';
@@ -183,7 +183,7 @@ export const initialState: wizardState = {
   },
   wizardMode: 'create',
   architecture: X86_64,
-  distribution: RHEL_9,
+  distribution: RHEL_10,
   imageTypes: [],
   aws: {
     accountId: '',
@@ -252,7 +252,7 @@ export const initialState: wizardState = {
     keyboard: '',
   },
   details: {
-    blueprintName: generateDefaultName(RHEL_9, X86_64),
+    blueprintName: generateDefaultName(RHEL_10, X86_64),
     isCustomName: false,
     blueprintDescription: '',
   },


### PR DESCRIPTION
As agreed with PM, let's make RHEL 10 the default distribution.
This PR does that and also changes the sort order in the distribution dropdown to reflect the new default (and frankly, now it's simply in descending order, which pleases my OCD).

I have an additional commit here that also shows the lifecycle for RHEL 9. I'll put that in a separate PR though. I was thinking about this mainly because of the feedback we got from the user study and customers liking this.