### PR TITLE
Wizard: Show lifecycle information for RHEL9

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/ReleaseLifecycle.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/ReleaseLifecycle.tsx
@@ -17,6 +17,7 @@ import {
   RHEL_8,
   RHEL_8_FULL_SUPPORT,
   RHEL_8_MAINTENANCE_SUPPORT,
+  RHEL_9,
   RHEL_9_FULL_SUPPORT,
   RHEL_9_MAINTENANCE_SUPPORT,
   RHEL_10_FULL_SUPPORT,
@@ -135,7 +136,7 @@ const ReleaseLifecycle = () => {
     setIsExpanded(isExpanded);
   };
 
-  if (release === RHEL_8) {
+  if (release === RHEL_8 || release === RHEL_9) {
     return (
       <ExpandableSection
         toggleText={

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -63,6 +63,15 @@ const selectRhel8 = async () => {
   await waitFor(() => user.click(rhel8));
 };
 
+const selectRhel10 = async () => {
+  const user = userEvent.setup();
+  await openReleaseMenu();
+  const rhel10 = await screen.findByRole('option', {
+    name: /red hat enterprise linux \(rhel\) 10 full support ends: may 2030 \| maintenance support ends: may 2035/i,
+  });
+  await waitFor(() => user.click(rhel10));
+};
+
 const selectCentos9 = async () => {
   const user = userEvent.setup();
   await openReleaseMenu();
@@ -227,13 +236,16 @@ describe('Step Image output', () => {
     expect(showOptionsButton).not.toBeInTheDocument();
   });
 
-  test('release lifecycle chart appears only when RHEL 8 is chosen', async () => {
+  test('release lifecycle chart appears for RHEL 8 and RHEL 9', async () => {
     await renderCreateMode();
 
     await selectRhel8();
     await screen.findByTestId('release-lifecycle-chart');
 
     await selectRhel9();
+    await screen.findByTestId('release-lifecycle-chart');
+
+    await selectRhel10();
     await waitFor(() =>
       expect(
         screen.queryByTestId('release-lifecycle-chart')


### PR DESCRIPTION
Since we want to nudge customers to default to RHEL 10, it may make sense to show them the shorter lifecycle of RHEL 9 when they select it.

This is a follow-up of #3337 