### PR TITLE
Wizard: Remove repository column from packages table (HMS-8701)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/PackageRecommendations.tsx
@@ -221,9 +221,8 @@ const PackageRecommendations = () => {
                 <Table variant="compact">
                   <Thead>
                     <Tr>
-                      <Th width={20}>Package name</Th>
-                      <Th width={35}>Description</Th>
-                      <Th width={25}>Package repository</Th>
+                      <Th width={35}>Package name</Th>
+                      <Th width={45}>Description</Th>
                       <Th width={20}>
                         <Button
                           variant="link"
@@ -252,7 +251,6 @@ const PackageRecommendations = () => {
                               .map((p) => p.summary)}
                           </Td>
                         )}
-                        <Td>Red Hat</Td>
                         <Td>
                           <Button
                             variant="link"

--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -36,7 +36,6 @@ import {
   ExclamationTriangleIcon,
   ExternalLinkAltIcon,
   HelpIcon,
-  OptimizeIcon,
   SearchIcon,
 } from '@patternfly/react-icons';
 import {
@@ -360,7 +359,7 @@ const Packages = () => {
     return (
       <Tbody>
         <Tr>
-          <Td colSpan={6}>
+          <Td colSpan={5}>
             <Bullseye>
               <EmptyState icon={SearchIcon} variant={EmptyStateVariant.sm}>
                 {toggleSelected === 'toggle-available' ? (
@@ -388,7 +387,7 @@ const Packages = () => {
     return (
       <Tbody>
         <Tr>
-          <Td colSpan={6}>
+          <Td colSpan={5}>
             <Bullseye>
               <EmptyState icon={Spinner} variant={EmptyStateVariant.sm}>
                 <EmptyStateBody>
@@ -408,7 +407,7 @@ const Packages = () => {
     return (
       <Tbody>
         <Tr>
-          <Td colSpan={6}>
+          <Td colSpan={5}>
             <Bullseye>
               <EmptyState
                 headingLevel="h4"
@@ -431,7 +430,7 @@ const Packages = () => {
     return (
       <Tbody>
         <Tr>
-          <Td colSpan={6}>
+          <Td colSpan={5}>
             <Bullseye>
               <EmptyState
                 headingLevel="h4"
@@ -462,7 +461,7 @@ const Packages = () => {
       return (
         <Tbody>
           <Tr>
-            <Td colSpan={6}>
+            <Td colSpan={5}>
               <Bullseye>
                 <EmptyState
                   headingLevel="h4"
@@ -510,7 +509,7 @@ const Packages = () => {
       return (
         <Tbody>
           <Tr>
-            <Td colSpan={6}>
+            <Td colSpan={5}>
               <Bullseye>
                 <EmptyState
                   headingLevel="h4"
@@ -1230,32 +1229,9 @@ const Packages = () => {
                 </Td>
                 <Td>N/A</Td>
                 <Td>N/A</Td>
-                {grp.repository === 'distro' ? (
-                  <>
-                    <Td>Red Hat</Td>
-                  </>
-                ) : grp.repository === 'custom' ? (
-                  <>
-                    <Td>Third party repository</Td>
-                  </>
-                ) : grp.repository === 'recommended' ? (
-                  <>
-                    <Td>
-                      <Icon status="warning">
-                        <OptimizeIcon />
-                      </Icon>{' '}
-                      EPEL {getEpelVersionForDistribution(distribution)}{' '}
-                      Everything x86_64
-                    </Td>
-                  </>
-                ) : (
-                  <>
-                    <Td className="not-available">Not available</Td>
-                  </>
-                )}
               </Tr>
               <Tr isExpanded={isGroupExpanded(grp.name)}>
-                <Td colSpan={6}>
+                <Td colSpan={5}>
                   <ExpandableRowContent>
                     {
                       <DescriptionList>
@@ -1317,32 +1293,9 @@ const Packages = () => {
                 <Td>{pkg.name}</Td>
                 <Td>{pkg.stream ? pkg.stream : 'N/A'}</Td>
                 <Td>{pkg.end_date ? formatDate(pkg.end_date) : 'N/A'}</Td>
-                {pkg.repository === 'distro' ? (
-                  <>
-                    <Td>Red Hat</Td>
-                  </>
-                ) : pkg.repository === 'custom' ? (
-                  <>
-                    <Td>Third party repository</Td>
-                  </>
-                ) : pkg.repository === 'recommended' ? (
-                  <>
-                    <Td>
-                      <Icon status="warning">
-                        <OptimizeIcon />
-                      </Icon>{' '}
-                      EPEL {getEpelVersionForDistribution(distribution)}{' '}
-                      Everything x86_64
-                    </Td>
-                  </>
-                ) : (
-                  <>
-                    <Td className="not-available">Not available</Td>
-                  </>
-                )}
               </Tr>
               <Tr isExpanded={isPkgExpanded(pkg)}>
-                <Td colSpan={6}>
+                <Td colSpan={5}>
                   <ExpandableRowContent>
                     {
                       <DescriptionList>
@@ -1440,16 +1393,15 @@ const Packages = () => {
           <Tr>
             <Th aria-label="Expanded" />
             <Th aria-label="Selected" />
-            <Th sort={getSortParams(0)} width={20}>
+            <Th sort={getSortParams(0)} width={30}>
               Name
             </Th>
             <Th sort={getSortParams(2)} width={20}>
               Application stream
             </Th>
-            <Th sort={getSortParams(3)} width={20}>
+            <Th sort={getSortParams(3)} width={30}>
               Retirement date
             </Th>
-            <Th width={20}>Package repository</Th>
           </Tr>
         </Thead>
         {bodyContent}

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
@@ -218,38 +218,19 @@ export const PackagesTable = () => {
               <Th>
                 Description <PackageInfoNotAvailablePopover />
               </Th>
-              <Th>Package repository</Th>
             </Tr>
           </Thead>
           <Tbody>
             {packages.map((pkg, pkgIndex) => (
               <Tr key={pkgIndex}>
-                <Td className="pf-m-width-30">{pkg.name}</Td>
+                <Td>{pkg.name}</Td>
                 <Td>{pkg.summary ? pkg.summary : 'Not available'}</Td>
-                <Td className="pf-m-width-30">
-                  {pkg.repository === 'distro'
-                    ? 'Red Hat repository'
-                    : pkg.repository === 'custom'
-                    ? 'Custom repository'
-                    : pkg.repository === 'recommended'
-                    ? 'EPEL Everything x86_64'
-                    : 'Not available'}
-                </Td>
               </Tr>
             ))}
             {groups.map((grp, grpIndex) => (
               <Tr key={grpIndex}>
-                <Td className="pf-m-width-30">@{grp.name}</Td>
+                <Td>@{grp.name}</Td>
                 <Td>{grp.description ? grp.description : 'Not available'}</Td>
-                <Td className="pf-m-width-30">
-                  {grp.repository === 'distro'
-                    ? 'Red Hat repository'
-                    : grp.repository === 'custom'
-                    ? 'Custom repository'
-                    : grp.repository === 'recommended'
-                    ? 'EPEL Everything x86_64'
-                    : 'Not available'}
-                </Td>
               </Tr>
             ))}
           </Tbody>


### PR DESCRIPTION
This removes the column with repository information from package table as it could be confusing and misleading.