### PR TITLE
test: Add mock handler for `repository_parameters`

### DIFF
--- a/src/test/fixtures/repositories.ts
+++ b/src/test/fixtures/repositories.ts
@@ -680,3 +680,38 @@ export const mockPopularRepo = (repo_id: string) => {
     };
   }
 };
+
+export const mockRepositoryParameters = {
+  distribution_versions: [
+    {
+      name: 'Any',
+      label: 'any',
+    },
+    {
+      name: 'el8',
+      label: '8',
+    },
+    {
+      name: 'el9',
+      label: '9',
+    },
+    {
+      name: 'el10',
+      label: '10',
+    },
+  ],
+  distribution_arches: [
+    {
+      name: 'Any',
+      label: 'any',
+    },
+    {
+      name: 'aarch64',
+      label: 'aarch64',
+    },
+    {
+      name: 'x86_64',
+      label: 'x86_64',
+    },
+  ],
+};

--- a/src/test/mocks/handlers.js
+++ b/src/test/mocks/handlers.js
@@ -41,6 +41,7 @@ import {
 } from '../fixtures/packages';
 import {
   mockPopularRepo,
+  mockRepositoryParameters,
   mockRepositoryResults,
 } from '../fixtures/repositories';
 import { mockSourcesByProvider, mockUploadInfo } from '../fixtures/sources';
@@ -131,6 +132,9 @@ export const handlers = [
   http.get(`${CONTENT_SOURCES_API}/repositories/:repo_id`, ({ params }) => {
     const { repo_id } = params;
     return HttpResponse.json(mockPopularRepo(repo_id));
+  }),
+  http.get(`${CONTENT_SOURCES_API}/repository_parameters`, () => {
+    return HttpResponse.json(mockRepositoryParameters());
   }),
   http.get(`${IMAGE_BUILDER_API}/composes`, ({ request }) => {
     return HttpResponse.json(composesEndpoint(new URL(request.url)));


### PR DESCRIPTION
This adds mock handler for newly used `repository_parameters` end point, ensuring the warning about missing handler is not being printed to test output when runnning `npm run test`.