### PR TITLE
Wizard: Fix target env cards clickability

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/TargetEnvironment.tsx
@@ -64,6 +64,7 @@ const TargetEnvironmentCard = ({
       isSelected={isSelected}
       isDisabled={isDisabled}
       isSelectable
+      isClickable
       isLarge
     >
       <CardHeader


### PR DESCRIPTION
The cards are now broken, this should make them selectable again.