### PR TITLE
Wizard: Prevent page refresh when hitting Enter in OpenSCAP profile selector (HMS-8768)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/ProfileSelector.tsx
@@ -274,6 +274,27 @@ const ProfileSelector = () => {
     }
   };
 
+  const onKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      
+      if (!isOpen) {
+        setIsOpen(true);
+      } else if (selectOptions.length === 1) {
+        const singleProfile = selectOptions[0];
+        const selection: OScapSelectOptionValueType = {
+          profileID: singleProfile.id,
+          toString: () => singleProfile.name || '',
+        };
+        
+        setInputValue(singleProfile.name || '');
+        setFilterValue('');
+        applyChanges(selection);
+        setIsOpen(false);
+      }
+    }
+  };
+
   const applyChanges = (selection: OScapSelectOptionValueType) => {
     if (selection.profileID === undefined) {
       // handle user has selected 'None' case
@@ -337,6 +358,7 @@ const ProfileSelector = () => {
           value={profileID ? profileID : inputValue}
           onClick={onInputClick}
           onChange={onTextInputChange}
+          onKeyDown={onKeyDown}
           autoComplete="off"
           placeholder="None"
           isExpanded={isOpen}


### PR DESCRIPTION
**Summary:**
Previously, pressing Enter while typing in the OpenSCAP profile filter caused the page to refresh due to default form submission behavior.

Fixes #2655

This fix adds `event.preventDefault()` to the onKeyDown handler to prevent that behavior and improves keyboard UX by:

- Opening the dropdown if it's currently closed
- Automatically selecting the result if there's exactly one match
- Preserving standard typeahead behavior without triggering a page reload

This ensures the wizard remains stable and keyboard-friendly during profile selection.

**BEFORE:** 

https://github.com/user-attachments/assets/104bbf31-d268-442e-94cc-033291b45417

**AFTER:**

https://github.com/user-attachments/assets/cbb9b769-de8d-4dce-a9a7-a444b7c3cb03


