### PR TITLE
Wizard: add EPEL 10 support

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -60,8 +60,7 @@ import {
 import {
   CONTENT_URL,
   ContentOrigin,
-  EPEL_8_REPO_DEFINITION,
-  EPEL_9_REPO_DEFINITION,
+  EPEL_10_REPO_DEFINITION,
 } from '../../../../constants';
 import { useGetArchitecturesQuery } from '../../../../store/backendApi';
 import {
@@ -92,6 +91,11 @@ import {
   removeModule,
   selectModules,
 } from '../../../../store/wizardSlice';
+import {
+  getEpelDefinitionForDistribution,
+  getEpelUrlForDistribution,
+  getEpelVersionForDistribution,
+} from '../../../../Utilities/epel';
 import useDebounce from '../../../../Utilities/useDebounce';
 
 export type PackageRepository = 'distro' | 'custom' | 'recommended' | '';
@@ -141,11 +145,8 @@ const Packages = () => {
       distribution: distribution,
     });
 
-  // select the correct version of EPEL repository
-  // the urls are copied over from the content service
-  const epelRepoUrlByDistribution = distribution.startsWith('rhel-8')
-    ? EPEL_8_REPO_DEFINITION.url
-    : EPEL_9_REPO_DEFINITION.url;
+  const epelRepoUrlByDistribution =
+    getEpelUrlForDistribution(distribution) ?? EPEL_10_REPO_DEFINITION.url;
 
   const { data: epelRepo, isSuccess: isSuccessEpelRepo } =
     useListRepositoriesQuery({
@@ -597,7 +598,8 @@ const Packages = () => {
                 <Td>{isSelectingGroup?.name}</Td>
               )}
               <Td>
-                EPEL {distribution === 'rhel-8' ? '8' : '9'} Everything x86_64
+                EPEL {getEpelVersionForDistribution(distribution)} Everything
+                x86_64
               </Td>
             </Tr>
           </Tbody>
@@ -919,9 +921,9 @@ const Packages = () => {
 
     if (epelRepo.data.length === 0) {
       const result = await createRepository({
-        apiRepositoryRequest: distribution.startsWith('rhel-8')
-          ? EPEL_8_REPO_DEFINITION
-          : EPEL_9_REPO_DEFINITION,
+        apiRepositoryRequest:
+          getEpelDefinitionForDistribution(distribution) ??
+          EPEL_10_REPO_DEFINITION,
       });
       dispatch(
         addRecommendedRepository(
@@ -1242,7 +1244,7 @@ const Packages = () => {
                       <Icon status="warning">
                         <OptimizeIcon />
                       </Icon>{' '}
-                      EPEL {distribution.startsWith('rhel-8') ? '8' : '9'}{' '}
+                      EPEL {getEpelVersionForDistribution(distribution)}{' '}
                       Everything x86_64
                     </Td>
                   </>
@@ -1329,7 +1331,7 @@ const Packages = () => {
                       <Icon status="warning">
                         <OptimizeIcon />
                       </Icon>{' '}
-                      EPEL {distribution.startsWith('rhel-8') ? '8' : '9'}{' '}
+                      EPEL {getEpelVersionForDistribution(distribution)}{' '}
                       Everything x86_64
                     </Td>
                   </>

--- a/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/ReviewStepTables.tsx
@@ -25,6 +25,7 @@ import {
   selectRecommendedRepositories,
   selectTemplate,
 } from '../../../../store/wizardSlice';
+import { getEpelVersionForDistribution } from '../../../../Utilities/epel';
 import PackageInfoNotAvailablePopover from '../Packages/components/PackageInfoNotAvailablePopover';
 
 type repoPropType = {
@@ -284,8 +285,8 @@ export const RepositoriesTable = () => {
             {recommendedRepositoriesList.length > 0 && (
               <Tr key={0}>
                 <Td className="pf-m-width-60">
-                  EPEL {distribution.startsWith('rhel-8') ? '8' : '9'}{' '}
-                  Everything x86_64
+                  EPEL {getEpelVersionForDistribution(distribution)} Everything
+                  x86_64
                 </Td>
               </Tr>
             )}

--- a/src/Utilities/epel.ts
+++ b/src/Utilities/epel.ts
@@ -1,0 +1,74 @@
+import {
+  EPEL_8_REPO_DEFINITION,
+  EPEL_9_REPO_DEFINITION,
+  EPEL_10_REPO_DEFINITION,
+} from '../constants';
+
+type EpelRepoDefinition = typeof EPEL_8_REPO_DEFINITION;
+
+/**
+ * A map associating a distribution prefix with its corresponding EPEL repository definition.
+ * The keys are prefixes (e.g., 'rhel-9') that are matched against the start of a
+ * full distribution string (e.g., 'rhel-9-beta').
+ * For new major versions of RHEL, we can add a new EPEL repository definition and an entry in the map.
+ *
+ * @see {@link EPEL_8_REPO_DEFINITION}
+ * @see {@link EPEL_9_REPO_DEFINITION}
+ * @see {@link EPEL_10_REPO_DEFINITION}
+ */
+const epelMap: ReadonlyMap<string, EpelRepoDefinition> = new Map([
+  ['rhel-10', EPEL_10_REPO_DEFINITION],
+  ['rhel-9', EPEL_9_REPO_DEFINITION],
+  ['rhel-8', EPEL_8_REPO_DEFINITION],
+]);
+
+/**
+ * Gets the key for `epelMap` from the distribution string.
+ *
+ * @param distribution The distribution string.
+ * @returns The key for `epelMap`.
+ *
+ * @example
+ * getKeyForDistribution('rhel-9-beta') // 'rhel-9'
+ * getKeyForDistribution('rhel-95') // 'rhel-9'
+ * getKeyForDistribution('rhel-8.10') // 'rhel-8'
+ * getKeyForDistribution('rhel-10') // 'rhel-10'
+ * getKeyForDistribution('rhel-11') // 'rhel-11'
+ */
+const getKeyForDistribution = (distribution: string): string =>
+  distribution.match(/^(rhel-(?:8|9|1\d)).*/)?.[1] ?? '';
+
+/**
+ * Determines the correct EPEL repository definition for a given distribution string.
+ * It works by finding a matching prefix from the `epelMap`.
+ *
+ * @param distribution The distribution string (e.g., "rhel-9-beta", "rhel-8.10", "rhel-10").
+ * @returns The matching EPEL repository definition, or `undefined` if no match is found.
+ */
+export const getEpelDefinitionForDistribution = (
+  distribution: string
+): EpelRepoDefinition | undefined =>
+  epelMap.get(getKeyForDistribution(distribution));
+
+/**
+ * Gets the URL for the EPEL repository for a given distribution string.
+ *
+ * @param distribution The distribution string.
+ * @returns The URL for the EPEL repository, or `undefined` if no match is found.
+ */
+export const getEpelUrlForDistribution = (
+  distribution: string
+): string | undefined => getEpelDefinitionForDistribution(distribution)?.url;
+
+/**
+ * Gets the version number for the EPEL repository for a given distribution string.
+ *
+ * @param distribution The distribution string.
+ * @returns The version number for the EPEL repository, or `undefined` if no match is found.
+ */
+export const getEpelVersionForDistribution = (
+  distribution: string
+): string | undefined => {
+  const split = getKeyForDistribution(distribution).split('-');
+  return split.length > 1 ? split[1] : undefined;
+};

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -251,6 +251,16 @@ export const EPEL_9_REPO_DEFINITION = {
   metadata_verification: false,
 };
 
+export const EPEL_10_REPO_DEFINITION = {
+  name: 'EPEL 10 Everything x86_64',
+  url: 'https://dl.fedoraproject.org/pub/epel/10/Everything/x86_64/',
+  distribution_versions: ['10'],
+  distribution_arch: 'x86_64',
+  gpg_key:
+    '-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQINBGV4X6kBEAC3eQxgiWuo08uc3mHo4ELux++uqTnYz/tJzEf9Ou3h36WnhumA\nNvs+Ts5h8PBx879Y9/aIX1Z20p1kf6tBCinZnEJu59n+TAAsph0+XQlV1l5YkleK\nZ2ff/Fg65k8QcLXWaIGykA/FaKznRiSurGuD6tRGhJw7DawEwBJr8QZSkRUpnH1L\nURW97Q/iKrRPiE5VEayE0y8eAL28jIIiFvR+4oJMzvCsRRB/2wYZ2MlJOW91hcYf\nmbUoXKOBD5UzsJylu7kj25K/ge8rEJ7KicOOwcdYddxsU3DxGSSfwF8AMagENcm2\nXROeXknjm84A8sNlUkFZBJwfuc7eRTiZGJrnQQVYLrkKj8Mxpq9Ts7hU51TqAWNI\nuvGDlJdYNE3D2RMqjMEsZ8ej08Thrib6xslu4NzTBkt+6QNnXL4E3hEgYtoyio60\nGswSz2ulogKg7X4JrNdJYE8/qNowyF3hoVgj5TG1/wQRq+5HlMMOLjgGu9wzLUix\nfnVfEUnzaofbrUf4/GabCaeY8xRe4tFQrvzigQ4g+kgwKKnfAeqBmPov0yljkw9z\nBYJWR5zvaw0ffg9Ing00KUSaXBXA5jSlgk1603Y+LefY1SlXsTyqohiRvGH6FI77\nHNMo72DwoJfFcYjncZUzKgXWJECR4nhVsdj6pKoOjcQ4aSuyVxtsR86ASQARAQAB\ntChGZWRvcmEgKGVwZWwxMCkgPGVwZWxAZmVkb3JhcHJvamVjdC5vcmc+iQJOBBMB\nCAA4FiEEfY0Vy/xOYmiFkfsmM9mFF+N+0VgFAmV4X6kCGw8FCwkIBwIGFQoJCAsC\nBBYCAwECHgECF4AACgkQM9mFF+N+0Vhv/A/+PlhPLSctGRCUEahE+cN4764Acc3p\nl40ZYzXRhqR0/Tc1/cSDjlA3qVTc8SPohi5OJXwCyr9EiMqKoyoDN097euqbYpyp\nyN/Pj0lBjsXwcpdDtZ21WGeQU0Khb04N68bMtJbDaxeBciTvDDQravZuPPh0m4Rg\nZ6myEoa6Aa6EK0hI1Qwi1qIWeRiuEkVT671IaKVETBW5XiUpNBXDAB/L+6DzUF9u\nscBzfsUDiPO6NrpYDtV3jwq22y6gWluIct/Ka8brwPbqK2sBfFzrHboRhfqlTGjs\n7F9qUGwIQZn/A8iozXZYQ0+JG1bhQyvjA8eN1GOcRpT+O7H7JXN49o6IG2As4+iK\nF04+qjqAu2sVfpD8mzM2VubFNllcKKiyCzRYHhSbObRCPzsudDL9GPiXeGGaCuWg\nsDkiA1MESvf2tLETAGBs/TziO4GwmXUtlKbRiq1FYm90mVq9mBxPZ/Idn+yZusNB\n0O5SXIbI8lYZw5n4XTK4b+byHRBYsOTHiTsGvjTF2Y7oSwW2CVUmL6RZ23mI4qoY\n1p5kzRS+GjT1acnTei/FTsOlIKCsjfeHx7uxCkX6xpAD8P3UtLQqfsgH0CL4vSZt\nTGO6L1InQlp4ZG3OYIomTKbD3/R0wod3U3dTqdulQMXL895u6OLTY3spY2m2MO2k\np9Dfd2pKuxK9Mys=\n=mhQZ\n-----END PGP PUBLIC KEY BLOCK-----',
+  metadata_verification: false,
+};
+
 export const DEBOUNCED_SEARCH_WAIT_TIME = 500;
 export const UNIQUE_VALIDATION_DELAY: number = 300;
 


### PR DESCRIPTION
## Summary
This adds support for the EPEL 10 repository 🔟 _(especially needed since RHEL 10 was made the default 🫣)_ 😅. Changes the way of getting the correct EPEL version for RHEL distribution to be more future proof. ✨ 

Issue Link: [[HMS-8656🔗](https://issues.redhat.com/browse/HMS-8656)]

## Testing steps
1. While building a RHEL 10 image and searching for additional packages, the "recommendations" should be coming from EPEL 10 and not 9.
2. After selecting a "recommended" package, the modal should suggest to add and on confirmation actually add EPEL 10 repo in `Repositories`.
3. Building an image with a "recommended" package and added EPEL 10 should work. 
4. The same thing should still work for RHEL 8 and 9 as it does now.