### PR TITLE
devDeps: Bump eslint-plugin-testing-library (HMS-8757)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -71,7 +71,7 @@
         "eslint-plugin-react": "7.37.5",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-redux": "4.2.2",
-        "eslint-plugin-testing-library": "7.2.2",
+        "eslint-plugin-testing-library": "7.5.3",
         "git-revision-webpack-plugin": "5.0.0",
         "history": "5.3.0",
         "identity-obj-proxy": "3.0.0",
@@ -9704,9 +9704,9 @@
       }
     },
     "node_modules/eslint-plugin-testing-library": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.2.2.tgz",
-      "integrity": "sha512-PaE4gwP3tMhmlcpOV0Hl21BA5SZIz3PiQYSgnHOY4rrSWZV4+r2BwbzUt2yU0xay2GtA+VNJxzKCbNMvEG2Uig==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.5.3.tgz",
+      "integrity": "sha512-sZk5hIrx0p1ehvdS2qHefKwXHiEysiQN+FMGCzES6xRNUgwI3q4KdWMeAwpPDP9u0RDkNzJpebRUnNch1sJh+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -25860,9 +25860,9 @@
       "dev": true
     },
     "eslint-plugin-testing-library": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.2.2.tgz",
-      "integrity": "sha512-PaE4gwP3tMhmlcpOV0Hl21BA5SZIz3PiQYSgnHOY4rrSWZV4+r2BwbzUt2yU0xay2GtA+VNJxzKCbNMvEG2Uig==",
+      "version": "7.5.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-testing-library/-/eslint-plugin-testing-library-7.5.3.tgz",
+      "integrity": "sha512-sZk5hIrx0p1ehvdS2qHefKwXHiEysiQN+FMGCzES6xRNUgwI3q4KdWMeAwpPDP9u0RDkNzJpebRUnNch1sJh+A==",
       "dev": true,
       "requires": {
         "@typescript-eslint/scope-manager": "^8.15.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-plugin-react": "7.37.5",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-redux": "4.2.2",
-    "eslint-plugin-testing-library": "7.2.2",
+    "eslint-plugin-testing-library": "7.5.3",
     "git-revision-webpack-plugin": "5.0.0",
     "history": "5.3.0",
     "identity-obj-proxy": "3.0.0",

--- a/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
@@ -278,7 +278,7 @@ describe('repository snapshot tab - ', () => {
 
     // wait until there's only 1 repository on the page
     await waitFor(async () => {
-      const rows = await screen.findAllByRole('row');
+      const rows = screen.getAllByRole('row');
       // header row + repo row
       expect(rows).toHaveLength(2);
     });


### PR DESCRIPTION
This bumps eslint-plugin-testing-library from 7.2.2 to 7.5.3 and updates a test to pass linter check.

JIRA: [HMS-8757](https://issues.redhat.com/browse/HMS-8757)