### PR TITLE
Wizard: Hide Kernel step for WSL (HMS-8759)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -624,6 +624,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
                 id="wizard-kernel"
                 key="wizard-kernel"
                 navItem={CustomStatusNavItem}
+                isHidden={hasWslTargetOnly}
                 status={kernelValidation.disabledNext ? 'error' : 'default'}
                 footer={
                   <CustomWizardFooter

--- a/src/Components/CreateImageWizard/steps/Kernel/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/index.tsx
@@ -1,17 +1,29 @@
 import React from 'react';
 
-import { Content, Form, Title } from '@patternfly/react-core';
+import { Alert, Content, Form, Title } from '@patternfly/react-core';
 
 import KernelArguments from './components/KernelArguments';
 import KernelName from './components/KernelName';
 
+import { useAppSelector } from '../../../../store/hooks';
+import { selectImageTypes } from '../../../../store/wizardSlice';
+
 const KernelStep = () => {
+  const environments = useAppSelector(selectImageTypes);
+
   return (
     <Form>
       <Title headingLevel="h1" size="xl">
         Kernel
       </Title>
       <Content>Customize kernel name and kernel arguments.</Content>
+      {environments.includes('wsl') && (
+        <Alert
+          variant="warning"
+          isInline
+          title="Kernel customizations are not applied to Windows Subsystem for Linux images"
+        />
+      )}
       <KernelName />
       <KernelArguments />
     </Form>


### PR DESCRIPTION
This hides Kernel step for WSL targets only and adds an alert with info that the customization will not be added to the WSL images if more targets are selected.

More targets including WSL:
![image](https://github.com/user-attachments/assets/81d8b910-0f96-472e-892e-0e2510d10cdc)
