### PR TITLE
Wizard: Update activation keys dropdown (HMS-8825)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
@@ -7,16 +7,17 @@ import {
   Select,
   SelectList,
   SelectOption,
-  Content,
   MenuToggleElement,
   MenuToggle,
   TextInputGroup,
   TextInputGroupMain,
+  FormHelperText,
+  HelperText,
+  HelperTextItem,
 } from '@patternfly/react-core';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 
 import ManageKeysButton from './ManageKeysButton';
-import PopoverActivation from './PopoverActivation';
 
 import { CDN_PROD_URL, CDN_STAGE_URL } from '../../../../../constants';
 import { useAppDispatch, useAppSelector } from '../../../../../store/hooks';
@@ -243,13 +244,7 @@ const ActivationKeysList = () => {
 
   return (
     <>
-      <FormGroup
-        label={
-          <>
-            Activation key to use for this image <PopoverActivation />
-          </>
-        }
-      >
+      <FormGroup label="Activation key to use for this image">
         <Select
           isScrollable
           isOpen={isOpen}
@@ -261,11 +256,14 @@ const ActivationKeysList = () => {
         >
           <SelectList>{prepareSelectOptions()}</SelectList>
         </Select>
-        <Content>
-          <Content>
-            Create and manage activation keys on the <ManageKeysButton />
-          </Content>
-        </Content>
+        <FormHelperText>
+          <HelperText>
+            <HelperTextItem>
+              Image Builder provides and defaults to a no-cost activation key if
+              none exist. <ManageKeysButton />
+            </HelperTextItem>
+          </HelperText>
+        </FormHelperText>
       </FormGroup>
       {isErrorActivationKeys && (
         <Alert

--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
@@ -103,22 +103,6 @@ const ActivationKeysList = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [filterValue, activationKeys?.body]);
 
-  const setActivationKey = (
-    _event: React.MouseEvent<Element, MouseEvent>,
-    selection: string
-  ) => {
-    setIsOpen(false);
-    window.localStorage.setItem('imageBuilder.recentActivationKey', selection);
-    dispatch(changeActivationKey(selection));
-  };
-
-  const handleToggle = () => {
-    if (!isOpen) {
-      refetch();
-    }
-    setIsOpen(!isOpen);
-  };
-
   useEffect(() => {
     const isActivationKeysEmpty =
       isSuccessActivationKeys &&
@@ -168,6 +152,37 @@ const ActivationKeysList = () => {
     }
   }, [isSuccessActivationKeys]);
 
+  const setActivationKey = (selection: string) => {
+    setIsOpen(false);
+    window.localStorage.setItem('imageBuilder.recentActivationKey', selection);
+    dispatch(changeActivationKey(selection));
+  };
+
+  const handleToggle = () => {
+    if (!isOpen) {
+      refetch();
+    }
+    setIsOpen(!isOpen);
+  };
+
+  const handleSelect = (_event: React.MouseEvent, selection: string) => {
+    setActivationKey(selection);
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key !== 'Enter') return;
+
+    event.preventDefault();
+
+    if (!isOpen) {
+      setIsOpen(!isOpen);
+    }
+
+    if (selectOptions.includes(inputValue)) {
+      setActivationKey(inputValue);
+    }
+  };
+
   const onTextInputChange = (_event: React.FormEvent, value: string) => {
     setInputValue(value);
     setFilterValue(value);
@@ -214,6 +229,7 @@ const ActivationKeysList = () => {
       ref={toggleRef}
       variant="typeahead"
       onClick={handleToggle}
+      onKeyDown={handleKeyDown}
       isExpanded={isOpen}
       data-testid="activation-key-select"
       isDisabled={
@@ -249,7 +265,7 @@ const ActivationKeysList = () => {
           isScrollable
           isOpen={isOpen}
           selected={activationKey}
-          onSelect={setActivationKey}
+          onSelect={handleSelect}
           onOpenChange={handleToggle}
           toggle={toggle}
           shouldFocusFirstItemOnOpen={false}

--- a/src/Components/CreateImageWizard/steps/Registration/components/ManageKeysButton.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ManageKeysButton.tsx
@@ -16,7 +16,7 @@ const ManageKeysButton = () => {
       isInline
       href={ACTIVATION_KEYS_URL}
     >
-      Activation keys page
+      Manage Activation keys
     </Button>
   );
 };


### PR DESCRIPTION
This updates key dropdown's helper text to match recent mocks and fixes the behaviour when the Wizard got refreshed when pressing "Enter" in the dropdown's input.

Also checked other criteria:
- the input is clearable
- current selection is marked with a check in the list of options

JIRA: [HMS-8825](https://issues.redhat.com/browse/HMS-8825)

<img width="615" height="117" alt="image" src="https://github.com/user-attachments/assets/fd97b080-a9f7-43f0-8938-4bb089f06034" />
<img width="615" height="185" alt="image" src="https://github.com/user-attachments/assets/d7e80d82-f417-4887-b704-498eccf6b8bc" />
<img width="615" height="185" alt="image" src="https://github.com/user-attachments/assets/39284d87-ec3c-4c5b-ac35-bb5b07b66125" />
