### PR TITLE
Wizard: Fix stuck page for package search

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/Packages.tsx
@@ -837,6 +837,7 @@ const Packages = () => {
     setActiveStream('');
     setActiveSortIndex(0);
     setActiveSortDirection('asc');
+    setPage(1);
   };
 
   const handleClear = async () => {


### PR DESCRIPTION
Fixes #3381

This resets the paging to page 1 when search term is updated.