### PR TITLE
test: Move `user` definition to wizard test utils (HMS-8912)

### DIFF
--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../fixtures/blueprints';
 import { server } from '../../mocks/server';
 import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
+import { user } from '../CreateImageWizard/wizardTestUtils';
 
 const selectBlueprintById = async (bpId: string) => {
   const user = userEvent.setup();
@@ -22,7 +23,6 @@ const selectBlueprintById = async (bpId: string) => {
 };
 
 const selectBlueprintByNameAndId = async (name: string, bpId: string) => {
-  const user = userEvent.setup();
   const search = await screen.findByRole('textbox', {
     name: /search input/i,
   });
@@ -44,7 +44,6 @@ describe('Blueprints', () => {
     vi.clearAllMocks();
   });
 
-  const user = userEvent.setup();
   const blueprintNameWithComposes = 'Dark Chocolate';
   const blueprintIdWithComposes = '677b010b-e95e-4694-9813-d11d847f1bfc';
   const blueprintIdWithMultipleTargets = 'c1cfa347-4c37-49b5-8e73-6aa1d1746cfa';

--- a/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
+++ b/src/test/Components/Blueprints/ImportBlueprintModal.test.tsx
@@ -1,9 +1,8 @@
 import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import { FIRSTBOOT_PATH, FIRSTBOOT_SERVICE_PATH } from '../../../constants';
 import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
-import { clickNext } from '../CreateImageWizard/wizardTestUtils';
+import { clickNext, user } from '../CreateImageWizard/wizardTestUtils';
 
 const BLUEPRINT_JSON = `{
   "customizations": {
@@ -273,7 +272,6 @@ disabled = ["--invalid-disabled-service"]
 `;
 
 const uploadFile = async (filename: string, content: string): Promise<void> => {
-  const user = userEvent.setup();
   const fileInput: HTMLElement | null =
     // eslint-disable-next-line testing-library/no-node-access
     document.querySelector('input[type="file"]');
@@ -288,8 +286,6 @@ describe('Import modal', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-
-  const user = userEvent.setup();
 
   test('renders import component', async () => {
     renderCustomRoutesWithReduxRouter();

--- a/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
+++ b/src/test/Components/CreateImageWizard/CreateImageWizard.test.tsx
@@ -1,7 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
-import { clickNext, renderCreateMode } from './wizardTestUtils';
+import { clickNext, renderCreateMode, user } from './wizardTestUtils';
 
 const getSourceDropdown = async () => {
   const sourceDropdown = await screen.findByPlaceholderText(/select source/i);
@@ -11,8 +10,6 @@ const getSourceDropdown = async () => {
 };
 
 const selectAllEnvironments = async () => {
-  const user = userEvent.setup();
-
   await waitFor(() =>
     user.click(screen.getByRole('button', { name: /Amazon Web Services/i }))
   );
@@ -30,8 +27,6 @@ const selectAllEnvironments = async () => {
 };
 
 const testTile = async (tile: HTMLElement) => {
-  const user = userEvent.setup();
-
   tile.focus();
   await waitFor(() => user.keyboard(' '));
   expect(tile).toHaveClass('pf-v6-c-card__clickable-action');
@@ -78,8 +73,6 @@ describe('Keyboard accessibility', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-
-  const user = userEvent.setup();
 
   test('autofocus on each step first input element', async () => {
     await renderCreateMode();

--- a/src/test/Components/CreateImageWizard/steps/Details/Details.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Details/Details.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
@@ -16,6 +15,7 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
 } from '../../wizardTestUtils';
 
 export const goToDetailsStep = async () => {
@@ -38,7 +38,6 @@ export const goToDetailsStep = async () => {
 const enterBlueprintDescription = async (
   description: string = 'Now with extra carmine!'
 ) => {
-  const user = userEvent.setup({ delay: null });
   const blueprintDescription = await screen.findByRole('textbox', {
     name: /blueprint description/i,
   });
@@ -53,7 +52,6 @@ const goToReviewStep = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('image-details-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-details'

--- a/src/test/Components/CreateImageWizard/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FileSystemConfiguration/FileSystemConfiguration.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import {
   CREATE_BLUEPRINT,
@@ -22,10 +21,10 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
 } from '../../wizardTestUtils';
 
 const selectGuestImage = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -33,7 +32,6 @@ const selectGuestImage = async () => {
 };
 
 const selectImageInstaller = async () => {
-  const user = userEvent.setup();
   const imageInstallerCheckbox = await screen.findByRole('checkbox', {
     name: /Bare metal installer/i,
   });
@@ -48,19 +46,16 @@ const goToFileSystemConfigurationStep = async () => {
 };
 
 const clickManuallyConfigurePartitions = async () => {
-  const user = userEvent.setup();
   const button = await screen.findByText(/manually configure partitions/i);
   await waitFor(() => user.click(button));
 };
 
 const addPartition = async () => {
-  const user = userEvent.setup();
   const button = await screen.findByRole('button', { name: /add partition/i });
   await waitFor(() => user.click(button));
 };
 
 const customizePartition = async () => {
-  const user = userEvent.setup();
   const row = await getRow(2);
   const minSize = await within(row).findByRole('textbox', {
     name: /mountpoint suffix/i,
@@ -74,7 +69,6 @@ const getRow = async (row: number) => {
 };
 
 const changePartitionSize = async () => {
-  const user = userEvent.setup();
   const row = await getRow(1);
   const minSize = await within(row).findByRole('textbox', {
     name: /minimum partition size/i,
@@ -83,7 +77,6 @@ const changePartitionSize = async () => {
 };
 
 const changePartitionUnitsToKiB = async () => {
-  const user = userEvent.setup();
   const row = await getRow(1);
   const units = await within(row).findByText('GiB');
   await waitFor(() => user.click(units));
@@ -92,7 +85,6 @@ const changePartitionUnitsToKiB = async () => {
 };
 
 const changePartitionUnitsToMiB = async () => {
-  const user = userEvent.setup();
   const row = await getRow(1);
   const units = await within(row).findByText('GiB');
   await waitFor(() => user.click(units));
@@ -118,7 +110,6 @@ const goToReviewStep = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId(
     'file-system-configuration-expandable'
   );
@@ -132,8 +123,6 @@ describe('Step File system configuration', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-
-  const user = userEvent.setup();
 
   test('clicking Review and finish leads to Review', async () => {
     await renderCreateMode();

--- a/src/test/Components/CreateImageWizard/steps/Firewall/Firewall.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Firewall/Firewall.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
@@ -16,13 +15,13 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
 let router: RemixRouter | undefined = undefined;
 
 const goToFirewallStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -51,13 +50,11 @@ const goToReviewStep = async () => {
 };
 
 const addPort = async (port: string) => {
-  const user = userEvent.setup();
   const portsInput = await screen.findByPlaceholderText(/add port/i);
   await waitFor(() => user.type(portsInput, port.concat(' ')));
 };
 
 const addEnabledFirewallService = async (service: string) => {
-  const user = userEvent.setup();
   const enabledServicesInput = await screen.findByPlaceholderText(
     /add enabled service/i
   );
@@ -65,7 +62,6 @@ const addEnabledFirewallService = async (service: string) => {
 };
 
 const addDisabledFirewallService = async (service: string) => {
-  const user = userEvent.setup();
   const disabledServiceInput = await screen.findByPlaceholderText(
     /add disabled service/i
   );
@@ -73,7 +69,6 @@ const addDisabledFirewallService = async (service: string) => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('firewall-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-firewall'

--- a/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/FirstBoot/Firstboot.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import {
   CREATE_BLUEPRINT,
@@ -31,10 +30,10 @@ import {
   renderEditMode,
   selectGuestImageTarget,
   selectRhel9,
+  user,
 } from '../../wizardTestUtils';
 
 const goToFirstBootStep = async (): Promise<void> => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -57,7 +56,6 @@ const goToFirstBootStep = async (): Promise<void> => {
 };
 
 const selectSimplifiedOscapProfile = async () => {
-  const user = userEvent.setup();
   const selectProfileDropdown = await screen.findByPlaceholderText(/none/i);
   await waitFor(() => user.click(selectProfileDropdown));
 
@@ -81,7 +79,6 @@ const goFromOscapToFirstBoot = async () => {
 };
 
 const openCodeEditor = async (): Promise<void> => {
-  const user = userEvent.setup();
   const startBtn = await screen.findByRole('button', {
     name: /Start from scratch/i,
   });
@@ -89,7 +86,6 @@ const openCodeEditor = async (): Promise<void> => {
 };
 
 const uploadFile = async (scriptName: string): Promise<void> => {
-  const user = userEvent.setup();
   const fileInput: HTMLElement | null =
     // eslint-disable-next-line testing-library/no-node-access
     document.querySelector('input[type="file"]');
@@ -100,14 +96,13 @@ const uploadFile = async (scriptName: string): Promise<void> => {
   }
 };
 
-const goToReviewStep = async (): Promise<void> => {
+const goToReviewStep = async () => {
   await clickNext(); // Details
   await enterBlueprintName();
   await clickNext(); // Review
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('firstboot-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-first-boot'
@@ -266,7 +261,6 @@ describe('First Boot edit mode', () => {
   });
 
   test('enabled service gets removed when first boot script is removed', async () => {
-    const user = userEvent.setup();
     const id = mockBlueprintIds['firstBoot'];
     await renderEditMode(id);
 
@@ -274,6 +268,7 @@ describe('First Boot edit mode', () => {
     const firstBootNavItem = await screen.findAllByRole('button', {
       name: /first boot/i,
     });
+    await waitFor(() => expect(firstBootNavItem[0]).toBeEnabled());
     await waitFor(() => user.click(firstBootNavItem[0]));
 
     // upload empty script file and go to Review

--- a/src/test/Components/CreateImageWizard/steps/Hostname/Hostname.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Hostname/Hostname.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
@@ -17,13 +16,13 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
 let router: RemixRouter | undefined = undefined;
 
 const goToHostnameStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -59,19 +58,16 @@ const goToReviewStep = async () => {
 };
 
 const enterHostname = async (hostname: string) => {
-  const user = userEvent.setup({ delay: null });
   const hostnameInput = await screen.findByPlaceholderText(/Add a hostname/i);
   await waitFor(() => user.type(hostnameInput, hostname));
 };
 
 const clearHostname = async () => {
-  const user = userEvent.setup();
   const hostnameInput = await screen.findByPlaceholderText(/Add a hostname/i);
   await waitFor(() => user.clear(hostnameInput));
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('hostname-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-hostname'

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import {
   AARCH64,
@@ -38,6 +37,7 @@ import {
   renderCreateMode,
   renderEditMode,
   selectRhel9,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 import { goToDetailsStep } from '../Details/Details.test';
@@ -45,7 +45,6 @@ import { goToDetailsStep } from '../Details/Details.test';
 let router: RemixRouter | undefined = undefined;
 
 const clickShowOptions = async () => {
-  const user = userEvent.setup();
   const showOptions = await screen.findByRole('option', {
     name: /show options for further development of rhel/i,
   });
@@ -53,7 +52,6 @@ const clickShowOptions = async () => {
 };
 
 const selectRhel8 = async () => {
-  const user = userEvent.setup();
   await openReleaseMenu();
   const rhel8 = await screen.findByRole('option', {
     name: /red hat enterprise linux \(rhel\) 8 full support ends: may 2024 \| maintenance support ends: may 2029/i,
@@ -62,7 +60,6 @@ const selectRhel8 = async () => {
 };
 
 const selectRhel10 = async () => {
-  const user = userEvent.setup();
   await openReleaseMenu();
   const rhel10 = await screen.findByRole('option', {
     name: /red hat enterprise linux \(rhel\) 10 full support ends: may 2030 \| maintenance support ends: may 2035/i,
@@ -71,7 +68,6 @@ const selectRhel10 = async () => {
 };
 
 const selectCentos9 = async () => {
-  const user = userEvent.setup();
   await openReleaseMenu();
   await clickShowOptions();
   const centos9 = await screen.findByRole('option', {
@@ -81,13 +77,11 @@ const selectCentos9 = async () => {
 };
 
 const openArchitectureMenu = async () => {
-  const user = userEvent.setup();
   const archMenu = screen.getByTestId('arch_select');
   await waitFor(() => user.click(archMenu));
 };
 
 const selectX86_64 = async () => {
-  const user = userEvent.setup();
   await openArchitectureMenu();
   const x86_64 = await screen.findByRole('option', {
     name: 'x86_64',
@@ -96,7 +90,6 @@ const selectX86_64 = async () => {
 };
 
 const selectAarch64 = async () => {
-  const user = userEvent.setup();
   await openArchitectureMenu();
   const aarch64 = await screen.findByRole('option', {
     name: 'aarch64',
@@ -105,7 +98,6 @@ const selectAarch64 = async () => {
 };
 
 const selectGuestImageTarget = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -131,7 +123,6 @@ const enterNameAndGoToReviewStep = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('image-output-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-image-output'
@@ -144,8 +135,6 @@ describe('Step Image output', () => {
     vi.clearAllMocks();
     router = undefined;
   });
-
-  const user = userEvent.setup();
 
   test('clicking Next loads Registration', async () => {
     await renderCreateMode();
@@ -609,8 +598,6 @@ describe('Check step consistency', () => {
     vi.clearAllMocks();
   });
 
-  const user = userEvent.setup();
-
   test('going back and forth with selected options only keeps the one compatible', async () => {
     await renderCreateMode();
     await selectX86_64();
@@ -700,8 +687,6 @@ describe('Set target using query parameter', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-
-  const user = userEvent.setup();
 
   test('no target by default (no query parameter)', async () => {
     await renderCreateMode();

--- a/src/test/Components/CreateImageWizard/steps/Kernel/Kernel.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Kernel/Kernel.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import {
   CREATE_BLUEPRINT,
@@ -21,6 +20,7 @@ import {
   renderCreateMode,
   renderEditMode,
   selectRhel9,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
@@ -29,7 +29,6 @@ let router: RemixRouter | undefined = undefined;
 const CUSTOM_NAME = 'custom-kernel-name';
 
 const goToKernelStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -49,7 +48,6 @@ const goToKernelStep = async () => {
 };
 
 const goToOpenSCAPStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -85,12 +83,10 @@ const getKernelNameOptions = async () => {
 };
 
 const openKernelNameOptions = async (dropdown: Element) => {
-  const user = userEvent.setup();
   await waitFor(() => user.click(dropdown));
 };
 
 const selectKernelName = async (kernelName: string) => {
-  const user = userEvent.setup();
   const kernelNameDropdown = await getKernelNameOptions();
   await openKernelNameOptions(kernelNameDropdown);
 
@@ -99,7 +95,6 @@ const selectKernelName = async (kernelName: string) => {
 };
 
 const selectCustomKernelName = async (kernelName: string) => {
-  const user = userEvent.setup();
   const kernelNameDropdown = await getKernelNameOptions();
   await waitFor(() => user.type(kernelNameDropdown, kernelName));
 
@@ -108,7 +103,6 @@ const selectCustomKernelName = async (kernelName: string) => {
 };
 
 const clearKernelName = async () => {
-  const user = userEvent.setup();
   const kernelNameClearBtn = await screen.findAllByRole('button', {
     name: /clear input/i,
   });
@@ -116,7 +110,6 @@ const clearKernelName = async () => {
 };
 
 const addKernelAppend = async (kernelArg: string) => {
-  const user = userEvent.setup();
   const kernelAppendInput = await screen.findByPlaceholderText(
     'Add kernel argument'
   );
@@ -130,8 +123,6 @@ const addKernelAppend = async (kernelArg: string) => {
 };
 
 const removeKernelArg = async (kernelArg: string) => {
-  const user = userEvent.setup();
-
   const removeNosmtArgButton = await screen.findByRole('button', {
     name: `Close ${kernelArg}`,
   });
@@ -139,7 +130,6 @@ const removeKernelArg = async (kernelArg: string) => {
 };
 
 const selectProfile = async () => {
-  const user = userEvent.setup();
   const selectProfileDropdown = await screen.findByPlaceholderText(/none/i);
   await waitFor(() => user.click(selectProfileDropdown));
 
@@ -148,7 +138,6 @@ const selectProfile = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('kernel-expandable');
   const revisitButton = await within(expandable).findByTestId('revisit-kernel');
   await waitFor(() => user.click(revisitButton));
@@ -196,7 +185,6 @@ describe('Step Kernel', () => {
   });
 
   test('disable Next with invalid custom kernel name', async () => {
-    const user = userEvent.setup();
     await renderCreateMode();
     await goToKernelStep();
 

--- a/src/test/Components/CreateImageWizard/steps/Locale/Locale.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Locale/Locale.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
@@ -16,13 +15,13 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
 let router: RemixRouter | undefined = undefined;
 
 const goToLocaleStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -51,7 +50,6 @@ const goToReviewStep = async () => {
 };
 
 const clearLanguageSearch = async () => {
-  const user = userEvent.setup();
   const languagesDropdown = await screen.findByPlaceholderText(
     /select a language/i
   );
@@ -59,7 +57,6 @@ const clearLanguageSearch = async () => {
 };
 
 const searchForLanguage = async (search: string) => {
-  const user = userEvent.setup();
   const languagesDropdown = await screen.findByPlaceholderText(
     /select a language/i
   );
@@ -67,7 +64,6 @@ const searchForLanguage = async (search: string) => {
 };
 
 const selectLanguages = async () => {
-  const user = userEvent.setup();
   await searchForLanguage('nl');
   const nlOption = await screen.findByRole('option', {
     name: 'Dutch - Netherlands (nl_NL.UTF-8)',
@@ -82,7 +78,6 @@ const selectLanguages = async () => {
 };
 
 const searchForKeyboard = async (keyboard: string) => {
-  const user = userEvent.setup({ delay: null });
   const keyboardDropdown = await screen.findByPlaceholderText(
     /select a keyboard/i
   );
@@ -90,13 +85,11 @@ const searchForKeyboard = async (keyboard: string) => {
 };
 
 const selectKeyboard = async () => {
-  const user = userEvent.setup({ delay: null });
   const usKeyboard = await screen.findByRole('option', { name: 'us' });
   await waitFor(() => user.click(usKeyboard));
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('locale-expandable');
   const revisitButton = await within(expandable).findByTestId('revisit-locale');
   await waitFor(() => user.click(revisitButton));

--- a/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Compliance.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { CreateBlueprintRequest } from '../../../../../store/imageBuilderApi';
@@ -15,6 +14,7 @@ import {
   renderCreateMode,
   renderEditMode,
   selectRhel9,
+  user,
 } from '../../wizardTestUtils';
 
 // Overwrite
@@ -31,7 +31,6 @@ vi.mock('@unleash/proxy-client-react', () => ({
 }));
 
 const goToComplianceStep = async () => {
-  const user = userEvent.setup();
   await selectRhel9(); // Compliance is not available for RHEL 10 yet
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
@@ -68,8 +67,6 @@ const goToReviewStep = async () => {
 };
 
 const selectPolicy = async () => {
-  const user = userEvent.setup();
-
   const policyMenu = await screen.findByText('None');
   await waitFor(() => user.click(policyMenu));
 
@@ -83,7 +80,6 @@ const selectPolicy = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('compliance-detail-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-compliance'
@@ -144,7 +140,6 @@ describe('Compliance edit mode', () => {
   });
 
   test('fsc and packages get populated on edit', async () => {
-    const user = userEvent.setup();
     const id = mockBlueprintIds['compliance'];
     await renderEditMode(id);
 
@@ -152,6 +147,7 @@ describe('Compliance edit mode', () => {
     const fscBtns = await screen.findAllByRole('button', {
       name: /file system configuration/i,
     });
+    await waitFor(() => expect(fscBtns[0]).toBeEnabled());
     user.click(fscBtns[0]);
     await screen.findByRole('heading', { name: /file system configuration/i });
     await screen.findByText('/tmp');

--- a/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Oscap/Oscap.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { CreateBlueprintRequest } from '../../../../../store/imageBuilderApi';
@@ -25,10 +24,10 @@ import {
   renderEditMode,
   selectGuestImageTarget,
   selectRhel9,
+  user,
 } from '../../wizardTestUtils';
 
 const selectRhel8 = async () => {
-  const user = userEvent.setup();
   await waitFor(async () => user.click(screen.getByTestId('release_select')));
   const rhel8 = await screen.findByRole('option', {
     name: /red hat enterprise linux \(rhel\) 8/i,
@@ -37,7 +36,6 @@ const selectRhel8 = async () => {
 };
 
 const selectImageInstallerTarget = async () => {
-  const user = userEvent.setup();
   const imageInstallerCheckbox = await screen.findByRole('checkbox', {
     name: /Bare metal installer/i,
   });
@@ -45,7 +43,6 @@ const selectImageInstallerTarget = async () => {
 };
 
 const selectWslTarget = async () => {
-  const user = userEvent.setup();
   const wslCheckBox = await screen.findByRole('checkbox', {
     name: /windows subsystem for linux/i,
   });
@@ -53,7 +50,6 @@ const selectWslTarget = async () => {
 };
 
 const selectProfile = async () => {
-  const user = userEvent.setup();
   const selectProfileDropdown = await screen.findByPlaceholderText(/none/i);
   await waitFor(() => user.click(selectProfileDropdown));
 
@@ -64,7 +60,6 @@ const selectProfile = async () => {
 };
 
 const selectDifferentProfile = async () => {
-  const user = userEvent.setup();
   const selectProfileDropdown = await screen.findByPlaceholderText(/none/i);
   await waitFor(() => user.click(selectProfileDropdown));
 
@@ -75,7 +70,6 @@ const selectDifferentProfile = async () => {
 };
 
 const selectNone = async () => {
-  const user = userEvent.setup();
   const selectProfileDropdown = await screen.findByPlaceholderText(/none/i);
   await waitFor(() => user.click(selectProfileDropdown));
 
@@ -101,7 +95,6 @@ const goToReviewStep = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('oscap-detail-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-openscap'
@@ -113,8 +106,6 @@ describe('Step OpenSCAP', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-
-  const user = userEvent.setup();
 
   test('create an image with None OpenSCAP profile', async () => {
     await renderCreateMode();
@@ -313,7 +304,6 @@ describe('OpenSCAP edit mode', () => {
     vi.clearAllMocks();
   });
 
-  const user = userEvent.setup();
   test('edit mode works', async () => {
     const id = mockBlueprintIds['oscap'];
     await renderEditMode(id);
@@ -334,6 +324,7 @@ describe('OpenSCAP edit mode', () => {
     const fscBtns = await screen.findAllByRole('button', {
       name: /file system configuration/i,
     });
+    await waitFor(() => expect(fscBtns[0]).toBeEnabled());
     user.click(fscBtns[0]);
     await screen.findByRole('heading', { name: /file system configuration/i });
     await screen.findByText('/tmp');

--- a/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Packages/Packages.test.tsx
@@ -1,6 +1,5 @@
 import { Router as RemixRouter } from '@remix-run/router/dist/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import {
   CREATE_BLUEPRINT,
@@ -30,13 +29,13 @@ import {
   renderEditMode,
   selectCustomRepo,
   selectRhel9,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
 const router: RemixRouter | undefined = undefined;
 
 const selectGuestImageTarget = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -69,7 +68,6 @@ const goToReviewStep = async () => {
 };
 
 const typeIntoSearchBox = async (searchTerm: string) => {
-  const user = userEvent.setup();
   const searchbox = await screen.findByRole('textbox', {
     name: /search packages/i,
   });
@@ -77,7 +75,6 @@ const typeIntoSearchBox = async (searchTerm: string) => {
 };
 
 const clearSearchInput = async () => {
-  const user = userEvent.setup();
   const pkgSearch = await screen.findByRole('textbox', {
     name: /search packages/i,
   });
@@ -111,7 +108,6 @@ const comparePackageSearchResults = async () => {
 };
 
 const clickFirstPackageCheckbox = async () => {
-  const user = userEvent.setup();
   const row0Checkbox = await screen.findByRole('checkbox', {
     name: /select row 0/i,
   });
@@ -119,7 +115,6 @@ const clickFirstPackageCheckbox = async () => {
 };
 
 const clickSecondPackageCheckbox = async () => {
-  const user = userEvent.setup();
   const row1Checkbox = await screen.findByRole('checkbox', {
     name: /select row 1/i,
   });
@@ -127,7 +122,6 @@ const clickSecondPackageCheckbox = async () => {
 };
 
 const clickThirdPackageCheckbox = async () => {
-  const user = userEvent.setup();
   const row2Checkbox = await screen.findByRole('checkbox', {
     name: /select row 2/i,
   });
@@ -135,13 +129,11 @@ const clickThirdPackageCheckbox = async () => {
 };
 
 const toggleSelected = async () => {
-  const user = userEvent.setup();
   const selected = await screen.findByRole('button', { name: /selected/i });
   await waitFor(() => user.click(selected));
 };
 
 const openIncludedPackagesPopover = async () => {
-  const user = userEvent.setup();
   const popoverBtn = await screen.findByRole('button', {
     name: /About included packages/i,
   });
@@ -157,19 +149,16 @@ const checkRecommendationsEmptyState = async () => {
 };
 
 const addSingleRecommendation = async () => {
-  const user = userEvent.setup();
   const addPackageButtons = await screen.findAllByText(/add package/i);
   await waitFor(() => user.click(addPackageButtons[0]));
 };
 
 const addAllRecommendations = async () => {
-  const user = userEvent.setup();
   const addAllBtn = await screen.findByText(/add all packages/i);
   await waitFor(async () => user.click(addAllBtn));
 };
 
 const deselectRecommendation = async () => {
-  const user = userEvent.setup();
   const row1Checkbox = await screen.findByRole('checkbox', {
     name: /select row 0/i,
   });
@@ -177,7 +166,6 @@ const deselectRecommendation = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('content-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-custom-repositories'
@@ -194,8 +182,6 @@ describe('Step Packages', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-
-  const user = userEvent.setup();
 
   test('clicking Next loads Users', async () => {
     await renderCreateMode();
@@ -512,8 +498,6 @@ describe('Step Packages', () => {
     });
 
     test('only one stream gets selected, other should be disabled', async () => {
-      const user = userEvent.setup();
-
       await renderCreateMode();
       await goToPackagesStep();
       await selectCustomRepo();
@@ -537,7 +521,6 @@ describe('Packages request generated correctly', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-  const user = userEvent.setup();
 
   test('with custom packages', async () => {
     await renderCreateMode();

--- a/src/test/Components/CreateImageWizard/steps/Registration/Registration.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Registration/Registration.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 
 import {
@@ -36,6 +35,7 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
@@ -58,13 +58,11 @@ Object.defineProperty(window, 'localStorage', {
 const router: RemixRouter | undefined = undefined;
 
 const clickShowAdditionalConnectionOptions = async () => {
-  const user = userEvent.setup();
   const link = await screen.findByText('Show additional connection options');
   await waitFor(() => user.click(link));
 };
 
 const deselectEnableRemoteRemediations = async () => {
-  const user = userEvent.setup();
   const checkBox = await screen.findByRole('checkbox', {
     name: 'Enable remote remediations and system management with automation',
   });
@@ -72,7 +70,6 @@ const deselectEnableRemoteRemediations = async () => {
 };
 
 const deselectPredictiveAnalytics = async () => {
-  const user = userEvent.setup();
   const checkBox = await screen.findByRole('checkbox', {
     name: 'Enable predictive analytics and management capabilities',
   });
@@ -80,7 +77,6 @@ const deselectPredictiveAnalytics = async () => {
 };
 
 const openActivationKeyDropdown = async () => {
-  const user = userEvent.setup();
   const activationKeyDropdown = await screen.findByPlaceholderText(
     'Select activation key'
   );
@@ -88,7 +84,6 @@ const openActivationKeyDropdown = async () => {
 };
 
 const selectActivationKey = async (key: string) => {
-  const user = userEvent.setup();
   const activationKey = await screen.findByRole('option', {
     name: key,
   });
@@ -97,7 +92,6 @@ const selectActivationKey = async (key: string) => {
 };
 
 const addSatelliteRegistrationCommandViaKeyDown = async (command: string) => {
-  const user = userEvent.setup({ delay: null });
   const satelliteRegistrationCommand = await screen.findByPlaceholderText(
     /registration command/i
   );
@@ -108,7 +102,6 @@ const addSatelliteRegistrationCommandViaKeyDown = async (command: string) => {
 };
 
 const uploadFile = async (scriptName: string): Promise<void> => {
-  const user = userEvent.setup();
   const fileInput: HTMLElement | null =
     // eslint-disable-next-line testing-library/no-node-access
     document.querySelector('input[type="file"]');
@@ -141,7 +134,6 @@ const goToReviewStep = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('registration-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-registration'

--- a/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Repositories/Repositories.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import {
@@ -25,10 +24,10 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
 } from '../../wizardTestUtils';
 
 const goToRepositoriesStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -57,7 +56,6 @@ const goToReviewStep = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('content-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-custom-repositories'
@@ -76,19 +74,16 @@ const getSecondRepoCheckbox = async () =>
   });
 
 const selectFirstRepository = async () => {
-  const user = userEvent.setup();
   const row0Checkbox = await getFirstRepoCheckbox();
   await waitFor(async () => user.click(row0Checkbox));
 };
 
 const deselectFirstRepository = async () => {
-  const user = userEvent.setup();
   const row0Checkbox = await getFirstRepoCheckbox();
   await waitFor(async () => user.click(row0Checkbox));
 };
 
 const clickBulkSelect = async () => {
-  const user = userEvent.setup();
   const bulkSelectCheckbox = await screen.findByRole('checkbox', {
     name: /select all/i,
   });
@@ -96,7 +91,6 @@ const clickBulkSelect = async () => {
 };
 
 const toggleSelected = async () => {
-  const user = userEvent.setup();
   const selectedButton = await screen.findByRole('button', {
     name: /selected repositories/i,
   });
@@ -104,7 +98,6 @@ const toggleSelected = async () => {
 };
 
 const toggleAll = async () => {
-  const user = userEvent.setup();
   const allButton = await screen.findByRole('button', {
     name: /all repositories/i,
   });
@@ -112,7 +105,6 @@ const toggleAll = async () => {
 };
 
 const searchForRepository = async (searchTerm: string) => {
-  const user = userEvent.setup();
   const searchInput = await screen.findByRole('textbox', {
     name: /filter repositories/i,
   });
@@ -123,8 +115,6 @@ describe('Step Custom repositories', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
-
-  const user = userEvent.setup();
 
   test('selected repositories stored in and retrieved from form state', async () => {
     await renderCreateMode();
@@ -267,7 +257,6 @@ describe('Repositories request generated correctly', () => {
   });
 
   const selectNginxRepository = async () => {
-    const user = userEvent.setup();
     const search = await screen.findByLabelText('Filter repositories');
     await waitFor(() => user.type(search, 'nginx stable repo'));
     await waitFor(
@@ -350,8 +339,6 @@ describe('Repositories edit mode', () => {
     vi.clearAllMocks();
   });
 
-  const user = userEvent.setup();
-
   test('edit mode works', async () => {
     const id = mockBlueprintIds['repositories'];
     await renderEditMode(id);
@@ -372,6 +359,7 @@ describe('Repositories edit mode', () => {
       name: /Custom repositories/,
     });
 
+    await waitFor(() => expect(customRepositories).toBeEnabled());
     user.click(customRepositories);
 
     await screen.findByText(

--- a/src/test/Components/CreateImageWizard/steps/Review/Review.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Review/Review.test.tsx
@@ -1,19 +1,18 @@
 import { Router as RemixRouter } from '@remix-run/router/dist/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import {
   clickBack,
   clickNext,
   clickRegisterLater,
   renderCreateMode,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
 let router: RemixRouter | undefined = undefined;
 
 const selectGuestImage = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -26,7 +25,6 @@ const setupWithRhel = async () => {
 };
 
 const setupWithCentos = async () => {
-  const user = userEvent.setup();
   await renderCreateMode();
   const releaseMenu = screen.getByTestId('release_select');
 

--- a/src/test/Components/CreateImageWizard/steps/Services/Services.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Services/Services.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import {
   CREATE_BLUEPRINT,
@@ -21,13 +20,13 @@ import {
   renderCreateMode,
   renderEditMode,
   selectRhel9,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
 let router: RemixRouter | undefined = undefined;
 
 const goToServicesStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -49,7 +48,6 @@ const goToServicesStep = async () => {
 };
 
 const goToOpenSCAPStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -81,7 +79,6 @@ const goToReviewStep = async () => {
 };
 
 const addDisabledService = async (service: string) => {
-  const user = userEvent.setup();
   const disabledServiceInput = await screen.findByPlaceholderText(
     'Add disabled service'
   );
@@ -89,7 +86,6 @@ const addDisabledService = async (service: string) => {
 };
 
 const addMaskedService = async (service: string) => {
-  const user = userEvent.setup();
   const maskedServiceInput = await screen.findByPlaceholderText(
     'Add masked service'
   );
@@ -97,7 +93,6 @@ const addMaskedService = async (service: string) => {
 };
 
 const addEnabledService = async (service: string) => {
-  const user = userEvent.setup();
   const enabledServiceInput = await screen.findByPlaceholderText(
     'Add enabled service'
   );
@@ -105,7 +100,6 @@ const addEnabledService = async (service: string) => {
 };
 
 const removeService = async (service: string) => {
-  const user = userEvent.setup();
   const removeServiceButton = await screen.findByRole('button', {
     name: `Close ${service}`,
   });
@@ -113,7 +107,6 @@ const removeService = async (service: string) => {
 };
 
 const selectProfile = async () => {
-  const user = userEvent.setup();
   const selectProfileDropdown = await screen.findByPlaceholderText(/none/i);
   await waitFor(() => user.click(selectProfileDropdown));
 
@@ -124,7 +117,6 @@ const selectProfile = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('services-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-services'
@@ -170,7 +162,6 @@ describe('Step Services', () => {
   });
 
   test('validation works', async () => {
-    const user = userEvent.setup();
     await renderCreateMode();
     await goToServicesStep();
     const clearInputButtons = await screen.findAllByRole('button', {

--- a/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Snapshot/Snapshot.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { CreateBlueprintRequest } from '../../../../../store/imageBuilderApi';
@@ -22,10 +21,10 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
 } from '../../wizardTestUtils';
 
 const goToSnapshotStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -53,7 +52,6 @@ const goToReviewStep = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('content-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-custom-repositories'
@@ -62,14 +60,12 @@ const clickRevisitButton = async () => {
 };
 
 const searchForRepository = async (repo: string) => {
-  const user = userEvent.setup();
   const search = await screen.findByLabelText('Filter repositories');
   await waitFor(() => user.type(search, repo));
   await waitFor(() => expect(screen.getByText(repo)).toBeInTheDocument);
 };
 
 const selectFirstRepository = async () => {
-  const user = userEvent.setup();
   const row0Checkbox = await screen.findByRole('checkbox', {
     name: /select row 0/i,
   });
@@ -77,7 +73,6 @@ const selectFirstRepository = async () => {
 };
 
 const clickBulkSelect = async () => {
-  const user = userEvent.setup();
   const bulkSelectCheckbox = await screen.findByRole('checkbox', {
     name: /select all/i,
   });
@@ -85,7 +80,6 @@ const clickBulkSelect = async () => {
 };
 
 const selectUseSnapshot = async () => {
-  const user = userEvent.setup();
   const snapshotRadio = await screen.findByRole('radio', {
     name: /Enable repeatable build/i,
   });
@@ -93,7 +87,6 @@ const selectUseSnapshot = async () => {
 };
 
 const updateDatePickerWithValue = async (date: string) => {
-  const user = userEvent.setup();
   const dateTextbox = await screen.findByRole('textbox', {
     name: /Date picker/i,
   });
@@ -109,7 +102,6 @@ const datePickerValue = async () => {
 };
 
 const clickContentDropdown = async () => {
-  const user = userEvent.setup();
   const contentExpandable = await screen.findByTestId('content-expandable');
   await waitFor(async () => user.click(contentExpandable));
 };
@@ -118,7 +110,6 @@ const getSnapshotMethodElement = async () =>
   await screen.findByRole('button', { name: /Snapshot method/i });
 
 const clickReset = async () => {
-  const user = userEvent.setup();
   const resetButton = await screen.findByRole('button', {
     name: /Reset/i,
   });
@@ -126,7 +117,6 @@ const clickReset = async () => {
 };
 
 const selectUseTemplate = async () => {
-  const user = userEvent.setup();
   const templateRadio = await screen.findByRole('radio', {
     name: /Use a content template/i,
   });
@@ -134,7 +124,6 @@ const selectUseTemplate = async () => {
 };
 
 const selectFirstTemplate = async () => {
-  const user = userEvent.setup();
   const row0Radio = await screen.findByRole('radio', {
     name: /select row 0/i,
   });

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AwsTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AwsTarget.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 
 import {
@@ -27,6 +26,7 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
@@ -56,7 +56,6 @@ const goToReview = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId(
     'target-environments-expandable'
   );
@@ -67,7 +66,6 @@ const clickRevisitButton = async () => {
 };
 
 const selectAwsTarget = async () => {
-  const user = userEvent.setup();
   const awsCard = await screen.findByRole('button', {
     name: /Amazon Web Services/i,
   });
@@ -76,7 +74,6 @@ const selectAwsTarget = async () => {
 };
 
 const deselectAwsAndSelectGuestImage = async () => {
-  const user = userEvent.setup();
   const awsCard = await screen.findAllByRole('button', {
     name: /Amazon Web Services/i,
   });
@@ -88,7 +85,6 @@ const deselectAwsAndSelectGuestImage = async () => {
 };
 
 const chooseManualOption = async () => {
-  const user = userEvent.setup();
   const manualOption = await screen.findByText(
     /manually enter an account id\./i
   );
@@ -96,7 +92,6 @@ const chooseManualOption = async () => {
 };
 
 const enterAccountId = async () => {
-  const user = userEvent.setup();
   const awsAccountIdTextbox = await screen.findByRole('textbox', {
     name: 'aws account id',
   });
@@ -104,7 +99,6 @@ const enterAccountId = async () => {
 };
 
 const chooseSourcesOption = async () => {
-  const user = userEvent.setup();
   const sourceRadio = await screen.findByRole('radio', {
     name: /use an account configured from sources\./i,
   });
@@ -119,7 +113,6 @@ const getSourceDropdown = async () => {
 };
 
 const selectSource = async () => {
-  const user = userEvent.setup();
   const sourceTexbox = await screen.findByPlaceholderText(/select source/i);
   await waitFor(async () => user.click(sourceTexbox));
 
@@ -136,8 +129,6 @@ describe('Step Upload to AWS', () => {
     vi.clearAllMocks();
     router = undefined;
   });
-
-  const user = userEvent.setup();
 
   test('clicking Next loads Registration', async () => {
     await renderCreateMode();
@@ -216,7 +207,7 @@ describe('Step Upload to AWS', () => {
     const createBlueprintBtn = await screen.findByRole('button', {
       name: /Create blueprint/,
     });
-    user.click(createBlueprintBtn);
+    await waitFor(() => user.click(createBlueprintBtn));
   });
 
   test('revisit step button on Review works', async () => {

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT, PROVISIONING_API } from '../../../../../constants';
@@ -23,6 +22,7 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
@@ -55,7 +55,6 @@ const goToReview = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId(
     'target-environments-expandable'
   );
@@ -66,7 +65,6 @@ const clickRevisitButton = async () => {
 };
 
 const selectAzureTarget = async () => {
-  const user = userEvent.setup();
   const azureCard = await screen.findByRole('button', {
     name: /Microsoft Azure/i,
   });
@@ -75,7 +73,6 @@ const selectAzureTarget = async () => {
 };
 
 const deselectAzureAndSelectGuestImage = async () => {
-  const user = userEvent.setup();
   const azureCard = await screen.findByRole('button', {
     name: /Microsoft Azure/i,
   });
@@ -87,7 +84,6 @@ const deselectAzureAndSelectGuestImage = async () => {
 };
 
 const selectSource = async (sourceName: string) => {
-  const user = userEvent.setup();
   const sourceTexbox = await screen.findByPlaceholderText(/select source/i);
   await waitFor(async () => user.click(sourceTexbox));
 
@@ -98,7 +94,6 @@ const selectSource = async (sourceName: string) => {
 };
 
 const selectResourceGroup = async () => {
-  const user = userEvent.setup();
   const resourceGrpTextbox = await screen.findByPlaceholderText(
     /select resource group/i
   );
@@ -111,7 +106,6 @@ const selectResourceGroup = async () => {
 };
 
 const selectManuallyEnterInformation = async () => {
-  const user = userEvent.setup();
   const manualOption = await screen.findByText(
     /manually enter the account information\./i
   );
@@ -119,7 +113,6 @@ const selectManuallyEnterInformation = async () => {
 };
 
 const selectSourcesOption = async () => {
-  const user = userEvent.setup();
   const sourcesOption = await screen.findByRole('radio', {
     name: /use an account configured from sources\./i,
   });
@@ -134,7 +127,6 @@ const getTenantGuidInput = async () => {
 };
 
 const enterTenantGuid = async () => {
-  const user = userEvent.setup();
   const tenantGuid = await getTenantGuidInput();
   await waitFor(() =>
     user.type(tenantGuid, 'b8f86d22-4371-46ce-95e7-65c415f3b1e2')
@@ -149,7 +141,6 @@ const getSubscriptionIdInput = async () => {
 };
 
 const enterSubscriptionId = async () => {
-  const user = userEvent.setup();
   const subscriptionId = await getSubscriptionIdInput();
   await waitFor(() =>
     user.type(subscriptionId, '60631143-a7dc-4d15-988b-ba83f3c99711')
@@ -157,7 +148,6 @@ const enterSubscriptionId = async () => {
 };
 
 const selectV1 = async () => {
-  const user = userEvent.setup();
   const hypervMenu = screen.getByRole('button', { name: /Generation 2/i });
 
   await waitFor(() => user.click(hypervMenu));
@@ -182,7 +172,6 @@ const getResourceGroupSelect = async () => {
 };
 
 const enterResourceGroup = async () => {
-  const user = userEvent.setup();
   const resourceGroup = await getResourceGroupTextInput();
   await waitFor(() => user.type(resourceGroup, 'testResourceGroup'));
 };
@@ -192,8 +181,6 @@ describe('Step Upload to Azure', () => {
     vi.clearAllMocks();
     router = undefined;
   });
-
-  const user = userEvent.setup();
 
   test('clicking Next loads Registration', async () => {
     await renderCreateMode();

--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/GCPTarget.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import {
@@ -24,6 +23,7 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
@@ -51,7 +51,6 @@ const goToReview = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId(
     'target-environments-expandable'
   );
@@ -76,7 +75,6 @@ const createGCPCloudImage = (
 };
 
 const clickGCPTarget = async () => {
-  const user = userEvent.setup();
   const googleOption = await screen.findByRole('button', {
     name: /Google Cloud Platform/i,
   });
@@ -85,7 +83,6 @@ const clickGCPTarget = async () => {
 };
 
 const deselectGcpAndSelectGuestImage = async () => {
-  const user = userEvent.setup();
   const googleCard = await screen.findAllByRole('button', {
     name: /Google Cloud Platform/i,
   });
@@ -97,7 +94,6 @@ const deselectGcpAndSelectGuestImage = async () => {
 };
 
 const selectGoogleAccount = async (optionId: string) => {
-  const user = userEvent.setup();
   const googleAccountOption = await screen.findByRole('radio', {
     name: optionId,
   });
@@ -113,8 +109,6 @@ describe('Step Upload to Google', () => {
     vi.clearAllMocks();
     router = undefined;
   });
-
-  const user = userEvent.setup();
 
   test('clicking Next loads Registration', async () => {
     await renderCreateMode();
@@ -248,7 +242,6 @@ describe('GCP image type request generated correctly', () => {
   });
 
   test('share image with red hat insight only', async () => {
-    const user = userEvent.setup();
     await renderCreateMode();
     await clickGCPTarget();
     const shareWithInsightOption = await screen.findByRole('radio', {

--- a/src/test/Components/CreateImageWizard/steps/Timezone/Timezone.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Timezone/Timezone.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
@@ -16,13 +15,13 @@ import {
   openAndDismissSaveAndBuildModal,
   renderCreateMode,
   renderEditMode,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
 let router: RemixRouter | undefined = undefined;
 
 const goToTimezoneStep = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /virtualization guest image checkbox/i,
   });
@@ -51,7 +50,6 @@ const goToReviewStep = async () => {
 };
 
 const selectTimezone = async () => {
-  const user = userEvent.setup({ delay: null });
   const timezoneDropdown = await screen.findByPlaceholderText(
     /select a timezone/i
   );
@@ -61,7 +59,6 @@ const selectTimezone = async () => {
 };
 
 const searchForUnknownTimezone = async () => {
-  const user = userEvent.setup();
   const timezoneDropdown = await screen.findByPlaceholderText(
     /select a timezone/i
   );
@@ -69,7 +66,6 @@ const searchForUnknownTimezone = async () => {
 };
 
 const addNtpServerViaKeyDown = async (ntpServer: string) => {
-  const user = userEvent.setup();
   const ntpServersInput = await screen.findByPlaceholderText(
     /add ntp servers/i
   );
@@ -77,7 +73,6 @@ const addNtpServerViaKeyDown = async (ntpServer: string) => {
 };
 
 const addNtpServerViaAddButton = async (ntpServer: string) => {
-  const user = userEvent.setup();
   const ntpServersInput = await screen.findByPlaceholderText(
     /add ntp servers/i
   );
@@ -89,7 +84,6 @@ const addNtpServerViaAddButton = async (ntpServer: string) => {
 };
 
 const clearInput = async () => {
-  const user = userEvent.setup();
   const clearInputBtn = await screen.findByRole('button', {
     name: /clear input/i,
   });
@@ -97,7 +91,6 @@ const clearInput = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('timezone-expandable');
   const revisitButton = await within(expandable).findByTestId(
     'revisit-timezone'

--- a/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
@@ -1,6 +1,5 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
-import { userEvent } from '@testing-library/user-event';
 
 import { CREATE_BLUEPRINT, EDIT_BLUEPRINT } from '../../../../../constants';
 import { mockBlueprintIds } from '../../../../fixtures/blueprints';
@@ -18,6 +17,7 @@ import {
   renderCreateMode,
   renderEditMode,
   selectGuestImageTarget,
+  user,
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
@@ -55,7 +55,6 @@ const goToReviewStep = async () => {
 };
 
 const addAzureTarget = async () => {
-  const user = userEvent.setup();
   await waitFor(() =>
     user.click(screen.getByRole('button', { name: /Microsoft Azure/i }))
   );
@@ -80,21 +79,18 @@ const addAzureTarget = async () => {
 };
 
 const clickRevisitButton = async () => {
-  const user = userEvent.setup();
   const expandable = await screen.findByTestId('users-expandable');
   const revisitButton = await within(expandable).findByTestId('revisit-users');
   await waitFor(() => user.click(revisitButton));
 };
 
 const clickAddUser = async () => {
-  const user = userEvent.setup();
   const addUser = await screen.findByRole('button', { name: /add a user/i });
   expect(addUser).toBeEnabled();
   await waitFor(() => user.click(addUser));
 };
 
 const addAnotherUser = async () => {
-  const user = userEvent.setup();
   const addUser = await screen.findByRole('button', { name: /add tab/i });
   expect(addUser).toBeEnabled();
   await waitFor(() => user.click(addUser));
@@ -122,13 +118,11 @@ const addAndFillThreeUsers = async () => {
 };
 
 const switchToNewUser = async () => {
-  const user = userEvent.setup();
   const newUserButton = await screen.findByRole('tab', { name: /user tab/i });
   await waitFor(() => user.click(newUserButton));
 };
 
 const closeNthTab = async (index: number) => {
-  const user = userEvent.setup();
   const tabs = await screen.findAllByRole('presentation');
   const closeTabButton = await within(tabs[index]).findByRole('button');
   await waitFor(() => user.click(closeTabButton));
@@ -136,7 +130,6 @@ const closeNthTab = async (index: number) => {
 };
 
 const clickRemoveUser = async () => {
-  const user = userEvent.setup();
   const removeUserModalButton = await screen.findByRole('button', {
     name: /Remove user/,
   });
@@ -144,7 +137,6 @@ const clickRemoveUser = async () => {
 };
 
 const addSshKey = async (sshKey: string) => {
-  const user = userEvent.setup();
   const enterSshKey = await screen.findByRole('textbox', {
     name: /public SSH key/i,
   });
@@ -153,7 +145,6 @@ const addSshKey = async (sshKey: string) => {
 };
 
 const addUserName = async (userName: string) => {
-  const user = userEvent.setup();
   const enterUserName = screen.getByRole('textbox', {
     name: /blueprint user name/i,
   });
@@ -162,7 +153,6 @@ const addUserName = async (userName: string) => {
 };
 
 const addPasswordByUserIndex = async (value: string, index: number) => {
-  const user = userEvent.setup();
   const passwordInputs = screen.getAllByPlaceholderText(/enter password/i);
   await waitFor(() => user.type(passwordInputs[index], value));
 };
@@ -175,13 +165,11 @@ const getAdminCheckbox = async () => {
 };
 
 const checkAdminCheckbox = async () => {
-  const user = userEvent.setup();
   const adminCheckbox = await getAdminCheckbox();
   await waitFor(() => user.click(adminCheckbox));
 };
 
 const addUserGroupByUserIndex = async (group: string, index: number) => {
-  const user = userEvent.setup();
   const userGroupInputs = await screen.findAllByPlaceholderText(
     'Add user group'
   );
@@ -194,8 +182,6 @@ const addUserGroupByUserIndex = async (group: string, index: number) => {
 };
 
 const removeUserGroup = async (group: string) => {
-  const user = userEvent.setup();
-
   const removeGroupButton = await screen.findByRole('button', {
     name: `Close ${group}`,
   });

--- a/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
+++ b/src/test/Components/CreateImageWizard/wizardTestUtils.tsx
@@ -52,6 +52,8 @@ const routes = [
   },
 ];
 
+export const user = userEvent.setup({ delay: null });
+
 export const imageRequest: ImageRequest = {
   architecture: 'x86_64',
   image_type: 'guest-image',
@@ -101,13 +103,11 @@ export const renderEditMode = async (id: string) => {
 };
 
 export const openReleaseMenu = async () => {
-  const user = userEvent.setup();
   const releaseMenu = screen.getByTestId('release_select');
   await waitFor(() => user.click(releaseMenu));
 };
 
 export const selectRhel9 = async () => {
-  const user = userEvent.setup();
   await openReleaseMenu();
   const rhel9 = await screen.findByRole('option', {
     name: /red hat enterprise linux \(rhel\) 9 full support ends: may 2027 \| maintenance support ends: may 2032/i,
@@ -116,7 +116,6 @@ export const selectRhel9 = async () => {
 };
 
 export const selectGuestImageTarget = async () => {
-  const user = userEvent.setup();
   const guestImageCheckBox = await screen.findByRole('checkbox', {
     name: /Virtualization guest image/i,
   });
@@ -129,7 +128,6 @@ export const goToRegistrationStep = async () => {
 };
 
 export const clickRegisterLater = async () => {
-  const user = userEvent.setup();
   await screen.findByRole('heading', {
     name: /Register systems using this image/,
   });
@@ -140,7 +138,6 @@ export const clickRegisterLater = async () => {
 };
 
 export const clickRegisterSatellite = async () => {
-  const user = userEvent.setup();
   await screen.findByRole('heading', {
     name: /Register systems using this image/,
   });

--- a/src/test/Components/ImagesTable/ImagesTable.test.tsx
+++ b/src/test/Components/ImagesTable/ImagesTable.test.tsx
@@ -1,5 +1,4 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import {
   mockClones,
@@ -7,13 +6,13 @@ import {
   mockComposes,
 } from '../../fixtures/composes';
 import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
+import { user } from '../CreateImageWizard/wizardTestUtils';
 
 describe('Images Table', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  const user = userEvent.setup();
   test('render ImagesTable', async () => {
     renderCustomRoutesWithReduxRouter();
 
@@ -224,7 +223,6 @@ describe('Clones table', () => {
     vi.clearAllMocks();
   });
 
-  const user = userEvent.setup();
   test('renders clones table', async () => {
     await renderCustomRoutesWithReduxRouter();
 

--- a/src/test/Components/ShareImageModal/ShareImageModal.test.tsx
+++ b/src/test/Components/ShareImageModal/ShareImageModal.test.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 
 import { screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 
 import ShareImageModal from '../../../Components/ShareImageModal/ShareImageModal';
 import { renderCustomRoutesWithReduxRouter } from '../../testUtils';
+import { user } from '../CreateImageWizard/wizardTestUtils';
 
 const composeId = '1579d95b-8f1d-4982-8c53-8c2afa4ab04c';
 
@@ -28,7 +28,6 @@ describe('Create Share To Regions Modal', () => {
     vi.clearAllMocks();
   });
 
-  const user = userEvent.setup();
   test('validation', async () => {
     await renderCustomRoutesWithReduxRouter(`share/${composeId}`, {}, routes);
 
@@ -106,7 +105,7 @@ describe('Create Share To Regions Modal', () => {
     expect(usEast1).toBeDisabled();
 
     // close the select again to avoid state update
-    user.click(selectToggle);
+    await waitFor(() => user.click(selectToggle));
   });
 
   // TODO Verify that sharing clones works once msw/data is incorporated.


### PR DESCRIPTION
This moves `user` definition to `wizardTestUtils.tsx` so it can be shared with the test files.

The delay for user methods is also set to `null` by default as we're currently not testing with user typing latency. This should improve async behaviour and can be easily overriden for individual tests when needed.

Some early exits had to be safeguarded.

JIRA: [HMS-8912](https://issues.redhat.com/browse/HMS-8912)