### PR TITLE
Wizard: Add fetch and error state for target environments (HMS-8941)

### DIFF
--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/TargetEnvironment.tsx
@@ -1,16 +1,19 @@
 import React, { MouseEventHandler, useEffect } from 'react';
 
 import {
+  Alert,
   Button,
   Card,
   CardHeader,
   Checkbox,
   Content,
+  EmptyState,
   Flex,
   FlexItem,
   FormGroup,
   Gallery,
   Popover,
+  Spinner,
   Title,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon, HelpIcon } from '@patternfly/react-icons';
@@ -92,11 +95,9 @@ const TargetEnvironment = () => {
   const environments = useAppSelector(selectImageTypes);
   const distribution = useAppSelector(selectDistribution);
 
-  const { data } = useGetArchitecturesQuery({
+  const { data, isFetching, isError } = useGetArchitecturesQuery({
     distribution: distribution,
   });
-  // TODO: Handle isFetching state (add skeletons)
-  // TODO: Handle isError state (very unlikely...)
 
   const dispatch = useAppDispatch();
   const prefetchSources = provisioningApi.usePrefetch('getSourceList');
@@ -104,6 +105,9 @@ const TargetEnvironment = () => {
 
   useEffect(() => {
     prefetchActivationKeys();
+    // This useEffect hook should run *only* on mount and therefore has an empty
+    // dependency array. eslint's exhaustive-deps rule does not support this use.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const supportedEnvironments = data?.find(
@@ -135,6 +139,22 @@ const TargetEnvironment = () => {
       supportedEnvironments?.includes('azure') ||
       supportedEnvironments?.includes('oci')
     );
+  };
+
+  if (isFetching) {
+    return <EmptyState titleText="Loading target environments" headingLevel="h6" icon={Spinner} />
+  };
+
+  if (isError) {
+    return (
+      <Alert
+        title="Couldn't fetch target environments"
+        variant="danger"
+        isInline
+      >
+        Target environments couldn&apos;t be loaded, please refresh the page or try again later.
+      </Alert>
+    )
   };
 
   return (
@@ -200,7 +220,7 @@ const TargetEnvironment = () => {
           label={<small>Private cloud</small>}
           className="pf-v6-u-mt-sm"
         >
-          {supportedEnvironments?.includes('vsphere-ova') && (
+          {supportedEnvironments.includes('vsphere-ova') && (
             <Checkbox
               name="vsphere-checkbox-ova"
               aria-label="VMware vSphere checkbox OVA"
@@ -239,7 +259,7 @@ const TargetEnvironment = () => {
               isChecked={environments.includes('vsphere-ova')}
             />
           )}
-          {supportedEnvironments?.includes('vsphere') && (
+          {supportedEnvironments.includes('vsphere') && (
             <Checkbox
               className="pf-v6-u-mt-sm"
               name="vsphere-checkbox-vmdk"

--- a/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/ImageOutput/ImageOutput.test.tsx
@@ -1,12 +1,14 @@
 import type { Router as RemixRouter } from '@remix-run/router';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
 
 import {
   AARCH64,
   CENTOS_9,
   CREATE_BLUEPRINT,
   EDIT_BLUEPRINT,
+  IMAGE_BUILDER_API,
   RHEL_10,
   RHEL_8,
   RHEL_9,
@@ -25,6 +27,7 @@ import {
   rhel9CreateBlueprintRequest,
   x86_64CreateBlueprintRequest,
 } from '../../../../fixtures/editMode';
+import { server } from '../../../../mocks/server';
 import {
   blueprintRequest,
   clickNext,
@@ -309,6 +312,17 @@ describe('Step Image output', () => {
     await goToDetailsStep();
     await clickNext(); // Review
     await verifyNameInReviewStep('Red Velvet');
+  });
+
+  test('alert gets rendered when fetching target environments fails', async () => {
+    server.use(
+      http.get(`${IMAGE_BUILDER_API}/architectures/${RHEL_10}`, () => {
+        return new HttpResponse(null, { status: 404 });
+      })
+    );
+
+    await renderCreateMode();
+    await screen.findByText(/Couldn't fetch target environments/);
   });
 });
 

--- a/src/test/Components/CreateImageWizard/steps/Services/Services.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Services/Services.test.tsx
@@ -360,5 +360,3 @@ describe('Services edit mode', () => {
     expect(receivedRequest).toEqual(expectedRequest);
   });
 });
-
-// TO DO 'Services step' -> 'revisit step button on Review works'


### PR DESCRIPTION
This renders an empty state with a spinner when fetching target environments and alert when there's an issue.

JIRA: [HMS-8941](https://issues.redhat.com/browse/HMS-8941)