### PR TITLE
Revert "playwright: Add duration to test account creation request (HMS-8958)"

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -68,7 +68,7 @@ jobs:
           export PLAYWRIGHT_USER=image-builder-playwright-$RANDOM
           export PLAYWRIGHT_PASSWORD=image-builder-playwright-$(uuidgen)
           # Step 1: Create a new empty account
-          curl -k -X POST https://account-manager-stage.app.eng.rdu2.redhat.com/account/new -d "{\"username\": \"$PLAYWRIGHT_USER\", \"password\":\"$PLAYWRIGHT_PASSWORD\", \"duration\":\"1 year\"}"
+          curl -k -X POST https://account-manager-stage.app.eng.rdu2.redhat.com/account/new -d "{\"username\": \"$PLAYWRIGHT_USER\", \"password\":\"$PLAYWRIGHT_PASSWORD\"}"
           # Step 2: Attach subscriptions to the new account
           curl -k -X POST https://account-manager-stage.app.eng.rdu2.redhat.com/account/attach \
             -d "{\"username\": \"$PLAYWRIGHT_USER\", \"password\":\"$PLAYWRIGHT_PASSWORD\", \"sku\":[\"RH00003\"],\"quantity\": 1}"


### PR DESCRIPTION
Reverts osbuild/image-builder-frontend#3485

Ethel API is fixed now, we don't need to specify "duration" anymore.