### PR TITLE
Wizard: Add FIPS state management infrastructure (HMS-8992)

### DIFF
--- a/src/Components/CreateImageWizard/utilities/requestMapper.ts
+++ b/src/Components/CreateImageWizard/utilities/requestMapper.ts
@@ -70,6 +70,7 @@ import {
   selectCustomRepositories,
   selectDistribution,
   selectFileSystemConfigurationType,
+  selectFips,
   selectFirewall,
   selectFirstBootScript,
   selectGcpAccountType,
@@ -364,6 +365,9 @@ function commonRequestToState(
         disabled: request.customizations.firewall?.services?.disabled || [],
       },
     },
+    fips: {
+      enabled: request.customizations.fips?.enabled || false,
+    },
   };
 }
 
@@ -631,7 +635,7 @@ const getCustomizations = (state: RootState, orgID: string): Customizations => {
     fdo: undefined,
     ignition: undefined,
     partitioning_mode: undefined,
-    fips: undefined,
+    fips: getFips(state),
     cacerts:
       satCert && selectRegistrationType(state) === 'register-satellite'
         ? {
@@ -867,6 +871,18 @@ const getPayloadRepositories = (state: RootState) => {
     return undefined;
   }
   return payloadAndRecommendedRepositories;
+};
+
+const getFips = (state: RootState) => {
+  const fips = selectFips(state);
+
+  if (!fips.enabled) {
+    return undefined;
+  }
+
+  return {
+    enabled: fips.enabled,
+  };
 };
 
 const getKernel = (state: RootState) => {

--- a/src/store/wizardSlice.ts
+++ b/src/store/wizardSlice.ts
@@ -170,6 +170,9 @@ export type wizardState = {
       disabled: string[];
     };
   };
+  fips: {
+    enabled: boolean;
+  };
   metadata?: {
     parent_id: string | null;
     exported_at: string;
@@ -269,6 +272,9 @@ export const initialState: wizardState = {
       enabled: [],
       disabled: [],
     },
+  },
+  fips: {
+    enabled: false,
   },
   firstBoot: { script: '' },
   users: [],
@@ -492,6 +498,10 @@ export const selectHostname = (state: RootState) => {
 
 export const selectFirewall = (state: RootState) => {
   return state.wizard.firewall;
+};
+
+export const selectFips = (state: RootState) => {
+  return state.wizard.fips;
 };
 
 export const wizardSlice = createSlice({
@@ -1131,6 +1141,9 @@ export const wizardSlice = createSlice({
         state.users[action.payload.index].groups.splice(groupIndex, 1);
       }
     },
+    changeFips: (state, action: PayloadAction<boolean>) => {
+      state.fips.enabled = action.payload;
+    },
   },
 });
 
@@ -1231,5 +1244,6 @@ export const {
   addUserGroupByIndex,
   removeUserGroupByIndex,
   changeRedHatRepositories,
+  changeFips,
 } = wizardSlice.actions;
 export default wizardSlice.reducer;


### PR DESCRIPTION
- Add fips field to wizardState type with enabled boolean property
- Add fips configuration to initialState with default value false
- Add selectFips selector to access FIPS state from store
- Add changeFips reducer action to update FIPS enabled state

**JIRA:**
[HMS-8992](https://issues.redhat.com/browse/HMS-8992)
FIPS (Federal Information Processing Standards) is a security standard required by organizations that handle sensitive data. 
When enabled, it enforces cryptographic requirements and security policies on the generated image. 
This change adds the Redux state management foundation to support FIPS mode configuration in the image
builder wizard.
the next step of enabling fips if Compliance policy or SCAP profile indicates FIPS needs to be enabled, will be done after UX meeting