### PR TITLE
Wizard: Resolve row reordering issue on selection and expansion (HMS-8924)

### DIFF
--- a/src/test/fixtures/packages.ts
+++ b/src/test/fixtures/packages.ts
@@ -75,6 +75,64 @@ export const mockSourcesPackagesResults = (
       },
     ];
   }
+  if (search === 'sortingTest') {
+    return [
+      {
+        package_name: 'alphaModule',
+        summary: 'Alpha module for sorting tests',
+        package_sources: [
+          {
+            name: 'alphaModule',
+            type: 'module',
+            stream: '2.0',
+            end_date: '2025-12-01',
+          },
+          {
+            name: 'alphaModule',
+            type: 'module',
+            stream: '3.0',
+            end_date: '2027-12-01',
+          },
+        ],
+      },
+      {
+        package_name: 'betaModule',
+        summary: 'Beta module for sorting tests',
+        package_sources: [
+          {
+            name: 'betaModule',
+            type: 'module',
+            stream: '2.0',
+            end_date: '2025-06-01',
+          },
+          {
+            name: 'betaModule',
+            type: 'module',
+            stream: '4.0',
+            end_date: '2028-06-01',
+          },
+        ],
+      },
+      {
+        package_name: 'gammaModule',
+        summary: 'Gamma module for sorting tests',
+        package_sources: [
+          {
+            name: 'gammaModule',
+            type: 'module',
+            stream: '2.0',
+            end_date: '2025-08-01',
+          },
+          {
+            name: 'gammaModule',
+            type: 'module',
+            stream: '1.5',
+            end_date: '2026-08-01',
+          },
+        ],
+      },
+    ];
+  }
   if (search === 'mock') {
     return [
       {


### PR DESCRIPTION
**Summary**
- Fix issue when clicking the expandable arrow or selecting a package checkbox in the Packages step it caused unexpected row reordering.
- Updated sorting logic to ensure that selecting a package with a specific stream groups all related module streams together at the top.
- Ensured that rows expand in place and selection does not affect row position.

**Jira**
Fixes [HMS-8924](https://issues.redhat.com/browse/HMS-8924)

**How to Test**
1) Navigate to Image Builder wizard → Packages step
2) Search for packages to populate the table
3) Click on the expandable arrow (▶) next to any package row
OR Click on the checkbox to select a package

🤖 Generated with AI