### PR TITLE
Test: Fix race conditions in coverage tests with proper await handling

### DIFF
--- a/src/test/Components/Blueprints/Blueprints.test.tsx
+++ b/src/test/Components/Blueprints/Blueprints.test.tsx
@@ -183,11 +183,13 @@ describe('Blueprints', () => {
     );
 
     await selectBlueprintById(blueprintIdWithComposes);
-    expect(
-      screen.queryByText(
-        /CentOS Stream 8 is no longer supported, building images from this blueprint will fail./,
-      ),
-    ).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.queryByText(
+          /CentOS Stream 8 is no longer supported, building images from this blueprint will fail./,
+        ),
+      ).not.toBeInTheDocument();
+    });
   });
 
   test('blueprint linting and fixing', async () => {

--- a/src/test/Components/CreateImageWizard/steps/Registration/Registration.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Registration/Registration.test.tsx
@@ -84,7 +84,7 @@ const openActivationKeyDropdown = async () => {
   const activationKeyDropdown = await screen.findByPlaceholderText(
     'Select activation key',
   );
-  user.click(activationKeyDropdown);
+  await waitFor(() => user.click(activationKeyDropdown));
 };
 
 const selectActivationKey = async (key: string) => {
@@ -92,7 +92,7 @@ const selectActivationKey = async (key: string) => {
   const activationKey = await screen.findByRole('option', {
     name: key,
   });
-  user.click(activationKey);
+  await waitFor(() => user.click(activationKey));
   await screen.findByDisplayValue(key);
 };
 


### PR DESCRIPTION
Add waitFor() for CentOS Stream 8 warning dismissal check
Add await to activation key dropdown interactions
Fixes test failures that only occurred during coverage runs due to timing delays

The changes address timing issues where UI elements don't update fast enough during coverage test runs, which are slower due to code instrumentation.