### PR TITLE
Wizard: fix overflowing bp name (HMS-9061)

### DIFF
--- a/src/Components/Blueprints/BlueprintCard.tsx
+++ b/src/Components/Blueprints/BlueprintCard.tsx
@@ -8,6 +8,7 @@ import {
   CardHeader,
   CardTitle,
   Spinner,
+  Truncate,
 } from '@patternfly/react-core';
 
 import { useDeleteBPWithNotification as useDeleteBlueprintMutation } from '../../Hooks';
@@ -54,7 +55,7 @@ const BlueprintCard = ({ blueprint }: blueprintProps) => {
             {isLoading && blueprint.id === selectedBlueprintId && (
               <Spinner size='md' />
             )}
-            {blueprint.name}
+            <Truncate content={blueprint.name} position='end' />
           </CardTitle>
         </CardHeader>
         <CardBody>{blueprint.description}</CardBody>


### PR DESCRIPTION
Truncate the name of a bp if it's too long and does not fit the Blueprint card on landing page. Not sure truncating is what we want tho. What do you think @regexowl @supakeen ?

<img width="1827" height="607" alt="Screenshot From 2025-08-14 14-47-57" src="https://github.com/user-attachments/assets/e114914e-5074-458f-a9f1-1ab7b90b3fd2" />

Fixes #3034

JIRA: [HMS-9061](https://issues.redhat.com/browse/HMS-9061)