### PR TITLE
Wizard: Replace deprecated innerRef with ref in RegionsSelect MenuToggle

### DIFF
--- a/src/Components/ShareImageModal/RegionsSelect.tsx
+++ b/src/Components/ShareImageModal/RegionsSelect.tsx
@@ -156,7 +156,7 @@ const RegionsSelect = ({ composeId, handleClose }: RegionsSelectPropTypes) => {
     <MenuToggle
       variant='typeahead'
       onClick={handleToggle}
-      innerRef={toggleRef}
+      ref={toggleRef}
       isExpanded={isOpen}
     >
       <TextInputGroup isPlain>


### PR DESCRIPTION
Replace `innerRef` prop with standard React `ref` prop in MenuToggle component
PatternFly's Select component requires a ref to the toggle element for proper dropdown positioning
