### PR TITLE
playwright/CI: Fix slack notification condition in nightly action

### DIFF
--- a/.github/workflows/boot-tests-nightly.yml
+++ b/.github/workflows/boot-tests-nightly.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Notify Slack on success
         uses: slackapi/slack-github-action@v2.1.1
-        if: github.event_name != 'workflow_dispatch' && steps.playwright-tests.result == 'success'
+        if: ${{ success() && github.event_name != 'workflow_dispatch' }}
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
@@ -123,7 +123,7 @@ jobs:
 
       - name: Notify Slack on failure
         uses: slackapi/slack-github-action@v2.1.1
-        if: github.event_name != 'workflow_dispatch' && steps.playwright-tests.result != 'success'
+        if: ${{ failure() && github.event_name != 'workflow_dispatch' }}
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook


### PR DESCRIPTION
The conditions previously were dependent on the playwright step only and fetched invalid `result` steps property. This also caused that when the `playwright-tests` step failed, the _on failure_ notification got skipped as this is standard Github Action behaviour. Changed it to on `success()` and on `failure()`, since they are simpler and fit this use case better, because they are directly controlled by the outcome of previous jobs.