### PR TITLE
Wizard: add error duplicated language (HMS-9281)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -51,8 +51,11 @@ const LanguagesDropDown = () => {
   const dispatch = useAppDispatch();
 
   const stepValidation = useLocaleValidation();
-  const unknownLanguages = stepValidation.errors['languages']
-    ? stepValidation.errors['languages'].split(' ')
+  const unknownLanguages = stepValidation.errors['unknownLanguages']
+    ? stepValidation.errors['unknownLanguages'].split(' ')
+    : [];
+  const duplicateLanguages = stepValidation.errors['duplicateLanguages']
+    ? stepValidation.errors['duplicateLanguages'].split(' ')
     : [];
 
   const [isOpen, setIsOpen] = useState(false);
@@ -194,6 +197,15 @@ const LanguagesDropDown = () => {
           <HelperTextItem
             variant={'error'}
           >{`Unknown languages: ${unknownLanguages.join(
+            ', ',
+          )}`}</HelperTextItem>
+        </HelperText>
+      )}
+      {duplicateLanguages.length > 0 && (
+        <HelperText>
+          <HelperTextItem
+            variant={'error'}
+          >{`Duplicated languages: ${duplicateLanguages.join(
             ', ',
           )}`}</HelperTextItem>
         </HelperText>

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -353,6 +353,8 @@ export function useTimezoneValidation(): StepValidation {
 }
 
 export function useLocaleValidation(): StepValidation {
+  const languagesSet: Set<string> = new Set();
+  const duplicates: string[] = [];
   const languages = useAppSelector(selectLanguages);
   const keyboard = useAppSelector(selectKeyboard);
 
@@ -364,16 +366,26 @@ export function useLocaleValidation(): StepValidation {
       if (!languagesList.includes(lang)) {
         unknownLanguages.push(lang);
       }
+      if (languagesSet.has(lang)) {
+        duplicates.push(lang);
+      } else {
+        languagesSet.add(lang);
+      }
     }
   }
 
   const languagesError =
     unknownLanguages.length > 0 ? unknownLanguages.join(' ') : '';
+  const duplicateLanguages = duplicates.length > 0 ? duplicates.join(' ') : '';
   const keyboardError =
     keyboard && !keyboardsList.includes(keyboard) ? 'Unknown keyboard' : '';
 
   return {
-    errors: { languages: languagesError, keyboard: keyboardError },
+    errors: {
+      unknownLanguages: languagesError,
+      duplicateLanguages: duplicateLanguages,
+      keyboard: keyboardError,
+    },
     disabledNext: unknownLanguages.length > 0 || 'keyboard' in errors,
   };
 }


### PR DESCRIPTION
In the wizard, it is not possible to select one language more times. However, some values like that might come from the API or from the imported blueprint. We should validate that there are no duplicates.
https://issues.redhat.com/browse/HMS-9281
<img width="932" height="441" alt="Screenshot From 2025-09-04 17-12-54" src="https://github.com/user-attachments/assets/431b507d-18f4-4201-b8e8-df08844db447" />
Fix:
<img width="932" height="441" alt="image" src="https://github.com/user-attachments/assets/338d760e-a63a-424e-8be5-4111ce1196aa" />
