### PR TITLE
Wizard: Tracking links leading outside Wizard (HMS-9218)

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -113,8 +113,6 @@ export const CustomWizardFooter = ({
   const { goToNextStep, goToPrevStep, goToStepById, close, activeStep } =
     useWizardContext();
   const { analytics } = useChrome();
-  const nextBtnID = 'wizard-next-btn';
-  const backBtnID = 'wizard-back-btn';
   const reviewAndFinishBtnID = 'wizard-review-and-finish-btn';
   const cancelBtnID = 'wizard-cancel-btn';
   return (
@@ -123,13 +121,6 @@ export const CustomWizardFooter = ({
         <Button
           variant='primary'
           onClick={() => {
-            if (!process.env.IS_ON_PREMISE) {
-              analytics.track(`${AMPLITUDE_MODULE_NAME} - Button Clicked`, {
-                module: AMPLITUDE_MODULE_NAME,
-                button_id: nextBtnID,
-                active_step_id: activeStep.id,
-              });
-            }
             if (!beforeNext || beforeNext()) goToNextStep();
           }}
           isDisabled={disableNext}
@@ -139,13 +130,6 @@ export const CustomWizardFooter = ({
         <Button
           variant='secondary'
           onClick={() => {
-            if (!process.env.IS_ON_PREMISE) {
-              analytics.track(`${AMPLITUDE_MODULE_NAME} - Button Clicked`, {
-                module: AMPLITUDE_MODULE_NAME,
-                button_id: backBtnID,
-                active_step_id: activeStep.id,
-              });
-            }
             goToPrevStep();
           }}
           isDisabled={disableBack || false}
@@ -354,23 +338,22 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
 
     const status = (step.id !== activeStep.id && step.status) || 'default';
 
-    // Track step view when this step becomes active
     useEffect(() => {
       const currentStepId = activeStep.id as string | undefined;
       if (
         !process.env.IS_ON_PREMISE &&
         currentStepId &&
-        step.id === currentStepId &&
         lastTrackedStepIdRef.current !== currentStepId
       ) {
         analytics.track(`${AMPLITUDE_MODULE_NAME} - Step Viewed`, {
           module: AMPLITUDE_MODULE_NAME,
           step_id: currentStepId,
           account_id: userData?.identity.internal?.account_id || 'Not found',
+          from_step_id: lastTrackedStepIdRef.current,
         });
         lastTrackedStepIdRef.current = currentStepId;
       }
-    }, [activeStep.id, step.id]);
+    }, [activeStep.id]);
 
     return (
       <WizardNavItem
@@ -387,15 +370,6 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
         isVisited={step.isVisited || false}
         stepIndex={step.index}
         onClick={() => {
-          if (!process.env.IS_ON_PREMISE) {
-            analytics.track(`${AMPLITUDE_MODULE_NAME} - Wizard Nav Clicked`, {
-              module: AMPLITUDE_MODULE_NAME,
-              from_step_id: activeStep.id,
-              to_step_id: step.id,
-              account_id:
-                userData?.identity.internal?.account_id || 'Not found',
-            });
-          }
           goToStepByIndex(step.index);
           if (isEdit && step.id === 'wizard-additional-packages') {
             analytics.track(

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 
 import {
   Button,
@@ -70,6 +70,7 @@ import {
   RHEL_8,
   RHEL_9,
 } from '../../constants';
+import { useGetUser } from '../../Hooks';
 import { useAppDispatch, useAppSelector } from '../../store/hooks';
 import './CreateImageWizard.scss';
 import {
@@ -194,7 +195,8 @@ type CreateImageWizardProps = {
 };
 
 const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
-  const { analytics, isBeta } = useChrome();
+  const { analytics, auth, isBeta } = useChrome();
+  const { userData } = useGetUser(auth);
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
   const [searchParams] = useSearchParams();
@@ -308,6 +310,7 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
   }
 
   const [wasRegisterVisited, setWasRegisterVisited] = useState(false);
+  const lastTrackedStepIdRef = useRef<string | undefined>();
 
   useEffect(() => {
     if (isEdit) {
@@ -349,8 +352,25 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
       (s) => s.index > step.index && s.isVisited,
     );
 
-    // Only this code is different from the original
     const status = (step.id !== activeStep.id && step.status) || 'default';
+
+    // Track step view when this step becomes active
+    useEffect(() => {
+      const currentStepId = activeStep.id as string | undefined;
+      if (
+        !process.env.IS_ON_PREMISE &&
+        currentStepId &&
+        step.id === currentStepId &&
+        lastTrackedStepIdRef.current !== currentStepId
+      ) {
+        analytics.track(`${AMPLITUDE_MODULE_NAME} - Step Viewed`, {
+          module: AMPLITUDE_MODULE_NAME,
+          step_id: currentStepId,
+          account_id: userData?.identity.internal?.account_id || 'Not found',
+        });
+        lastTrackedStepIdRef.current = currentStepId;
+      }
+    }, [activeStep.id, step.id]);
 
     return (
       <WizardNavItem
@@ -367,6 +387,15 @@ const CreateImageWizard = ({ isEdit }: CreateImageWizardProps) => {
         isVisited={step.isVisited || false}
         stepIndex={step.index}
         onClick={() => {
+          if (!process.env.IS_ON_PREMISE) {
+            analytics.track(`${AMPLITUDE_MODULE_NAME} - Wizard Nav Clicked`, {
+              module: AMPLITUDE_MODULE_NAME,
+              from_step_id: activeStep.id,
+              to_step_id: step.id,
+              account_id:
+                userData?.identity.internal?.account_id || 'Not found',
+            });
+          }
           goToStepByIndex(step.index);
           if (isEdit && step.id === 'wizard-additional-packages') {
             analytics.track(

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemAutomaticPartitionInformation.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemAutomaticPartitionInformation.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 
 import { Button, Content, ContentVariants } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import { FILE_SYSTEM_CUSTOMIZATION_URL } from '../../../../../constants';
+import {
+  AMPLITUDE_MODULE_NAME,
+  FILE_SYSTEM_CUSTOMIZATION_URL,
+} from '../../../../../constants';
+import { useGetUser } from '../../../../../Hooks';
 
 const FileSystemAutomaticPartition = () => {
+  const { analytics, auth } = useChrome();
+  const { userData } = useGetUser(auth);
   return (
     <Content>
       <Content component={ContentVariants.h3}>Automatic partitioning</Content>
@@ -23,6 +30,18 @@ const FileSystemAutomaticPartition = () => {
           iconPosition='right'
           href={FILE_SYSTEM_CUSTOMIZATION_URL}
           className='pf-v6-u-pl-0'
+          onClick={() => {
+            if (!process.env.IS_ON_PREMISE) {
+              analytics.track(
+                `${AMPLITUDE_MODULE_NAME} - Outside link clicked`,
+                {
+                  account_id:
+                    userData?.identity.internal?.account_id || 'Not found',
+                  step_id: 'step-file-system',
+                },
+              );
+            }
+          }}
         >
           Customizing file systems during the image creation
         </Button>

--- a/src/Components/CreateImageWizard/steps/Registration/components/ManageKeysButton.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ManageKeysButton.tsx
@@ -2,10 +2,17 @@ import React from 'react';
 
 import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import { ACTIVATION_KEYS_URL } from '../../../../../constants';
+import {
+  ACTIVATION_KEYS_URL,
+  AMPLITUDE_MODULE_NAME,
+} from '../../../../../constants';
+import { useGetUser } from '../../../../../Hooks';
 
 const ManageKeysButton = () => {
+  const { analytics, auth } = useChrome();
+  const { userData } = useGetUser(auth);
   return (
     <Button
       component='a'
@@ -14,6 +21,14 @@ const ManageKeysButton = () => {
       icon={<ExternalLinkAltIcon />}
       iconPosition='right'
       isInline
+      onClick={() => {
+        if (!process.env.IS_ON_PREMISE) {
+          analytics.track(`${AMPLITUDE_MODULE_NAME} - Outside link clicked`, {
+            step_id: 'step-registration',
+            account_id: userData?.identity.internal?.account_id || 'Not found',
+          });
+        }
+      }}
       href={ACTIVATION_KEYS_URL}
     >
       Manage Activation keys

--- a/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/Repositories.tsx
@@ -21,6 +21,7 @@ import {
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 import { BulkSelect } from './components/BulkSelect';
 import CommunityRepositoryLabel from './components/CommunityRepositoryLabel';
@@ -36,10 +37,12 @@ import RepositoriesStatus from './RepositoriesStatus';
 import RepositoryUnavailable from './RepositoryUnavailable';
 
 import {
+  AMPLITUDE_MODULE_NAME,
   ContentOrigin,
   PAGINATION_COUNT,
   TEMPLATES_URL,
 } from '../../../../constants';
+import { useGetUser } from '../../../../Hooks';
 import {
   ApiRepositoryResponseRead,
   useGetTemplateQuery,
@@ -67,6 +70,8 @@ import useDebounce from '../../../../Utilities/useDebounce';
 import { useFlag } from '../../../../Utilities/useGetEnvironment';
 
 const Repositories = () => {
+  const { analytics, auth } = useChrome();
+  const { userData } = useGetUser(auth);
   const dispatch = useAppDispatch();
   const wizardMode = useAppSelector(selectWizardMode);
   const arch = useAppSelector(selectArchitecture);
@@ -687,6 +692,19 @@ const Repositories = () => {
                                 icon={<ExternalLinkAltIcon />}
                                 iconPosition='right'
                                 isInline
+                                onClick={() => {
+                                  if (!process.env.IS_ON_PREMISE) {
+                                    analytics.track(
+                                      `${AMPLITUDE_MODULE_NAME} - Outside link clicked`,
+                                      {
+                                        step_id: 'step-repositories',
+                                        account_id:
+                                          userData?.identity.internal
+                                            ?.account_id || 'Not found',
+                                      },
+                                    );
+                                  }
+                                }}
                                 href={url}
                               >
                                 {url}

--- a/src/Components/CreateImageWizard/steps/Repositories/components/ManageRepositoriesButton.tsx
+++ b/src/Components/CreateImageWizard/steps/Repositories/components/ManageRepositoriesButton.tsx
@@ -2,10 +2,14 @@ import React from 'react';
 
 import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import { CONTENT_URL } from '../../../../../constants';
+import { AMPLITUDE_MODULE_NAME, CONTENT_URL } from '../../../../../constants';
+import { useGetUser } from '../../../../../Hooks';
 
 const ManageRepositoriesButton = () => {
+  const { analytics, auth } = useChrome();
+  const { userData } = useGetUser(auth);
   return (
     <Button
       component='a'
@@ -14,6 +18,14 @@ const ManageRepositoriesButton = () => {
       iconPosition='right'
       isInline
       icon={<ExternalLinkAltIcon />}
+      onClick={() => {
+        if (!process.env.IS_ON_PREMISE) {
+          analytics.track(`${AMPLITUDE_MODULE_NAME} - Outside link clicked`, {
+            step_id: 'step-repositories',
+            account_id: userData?.identity.internal?.account_id || 'Not found',
+          });
+        }
+      }}
       href={CONTENT_URL}
     >
       Create and manage repositories here

--- a/src/Components/sharedComponents/DocumentationButton.tsx
+++ b/src/Components/sharedComponents/DocumentationButton.tsx
@@ -2,11 +2,15 @@ import React from 'react';
 
 import { Button } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
+import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
-import { DOCUMENTATION_URL } from '../../constants';
+import { AMPLITUDE_MODULE_NAME, DOCUMENTATION_URL } from '../../constants';
+import { useGetUser } from '../../Hooks';
 
 const DocumentationButton = () => {
   const documentationURL = DOCUMENTATION_URL;
+  const { analytics, auth } = useChrome();
+  const { userData } = useGetUser(auth);
 
   return (
     <Button
@@ -16,6 +20,14 @@ const DocumentationButton = () => {
       icon={<ExternalLinkAltIcon />}
       iconPosition='right'
       isInline
+      onClick={() => {
+        if (!process.env.IS_ON_PREMISE) {
+          analytics.track(`${AMPLITUDE_MODULE_NAME} - Outside link clicked`, {
+            account_id: userData?.identity.internal?.account_id || 'Not found',
+            step_id: 'step-image-output',
+          });
+        }
+      }}
       href={documentationURL}
     >
       Documentation


### PR DESCRIPTION
This PR:

- adds tracking "Step Viewed" for when user visits a step. This way, we don't have to set up tracking for each step individually, and newly created steps will also be logged
(@regexowl @lucasgarfield  this makes me think that maybe our tracking via footer buttons is redundant - if we are tracking each step that a user visits and views, maybe current footer buttons tracking is not needed, but I am afraid to just delete them, idk how many people are looking at those statistics. It could also mean that the first bullet point of this pr might be redundant as well, unless we care about if users are using the nav bar)
- adds tracking of links that are leading outside of the wizard
