### PR TITLE
Wizard: Add spinner to compliance dropdown (HMS-9312)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -6,6 +6,7 @@ import {
   MenuToggleElement,
   Select,
   SelectOption,
+  Spinner,
 } from '@patternfly/react-core';
 
 import { useSelectorHandlers } from './useSelectorHandlers';
@@ -197,6 +198,14 @@ const PolicySelector = () => {
   const complianceOptions = () => {
     if (!policies || policies.data === undefined) {
       return [];
+    }
+
+    if (isFetchingPolicies) {
+      return [
+        <SelectOption key='compliance-loader' value='loader'>
+          <Spinner size='lg' />
+        </SelectOption>,
+      ];
     }
 
     const res = [


### PR DESCRIPTION
This renders a spinner in the compliance dropdown when policies are getting fetched.

<img width="504" height="149" alt="image" src="https://github.com/user-attachments/assets/f33d4240-bede-4c7e-8d00-49bae137a633" />


JIRA: [HMS-9312](https://issues.redhat.com/browse/HMS-9312)