### PR TITLE
npm: check for vulnerable packages on each PR

### DIFF
--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,0 +1,48 @@
+# Configuration for dependency-review-action
+# Documentation: https://github.com/actions/dependency-review-action
+
+# Fail the action if vulnerabilities are found with these severities
+fail-on-severity: high
+
+# Allow or deny specific licenses (optional)
+# For the full list of licenses: https://docs.github.com/en/rest/licenses
+# allow-licenses:
+#   - MIT
+#   - Apache-2.0
+#   - BSD-3-Clause
+#   - ISC
+
+# Deny packages with these licenses
+# deny-licenses:
+#   - GPL-3.0
+#   - LGPL-2.0
+
+# List of packages that should never be allowed
+# These are packages from the npm supply chain attack (Sept 2025)
+# Source: https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack
+deny-packages:
+  - pkg:npm/backslash@0.2.1
+  - pkg:npm/chalk@5.6.1
+  - pkg:npm/chalk-template@1.1.1
+  - pkg:npm/color-convert@3.1.1
+  - pkg:npm/color-name@2.0.1
+  - pkg:npm/color-string@2.1.1
+  - pkg:npm/wrap-ansi@9.0.1
+  - pkg:npm/supports-hyperlinks@4.1.1
+  - pkg:npm/strip-ansi@7.1.1
+  - pkg:npm/slice-ansi@7.1.1
+  - pkg:npm/simple-swizzle@0.2.3
+  - pkg:npm/is-arrayish@0.3.3
+  - pkg:npm/error-ex@1.3.3
+  - pkg:npm/has-ansi@6.0.1
+  - pkg:npm/ansi-regex@6.2.1
+  - pkg:npm/ansi-styles@6.2.2
+  - pkg:npm/supports-color@10.2.1
+  - pkg:npm/proto-tinker-wc@1.8.7
+  - pkg:npm/debug@4.4.2
+
+# Create a comment on the PR with the review summary
+comment-summary-in-pr: always
+
+# Additional settings for more strict checking
+warn-only: false

--- a/.github/dependency-review-config.yml
+++ b/.github/dependency-review-config.yml
@@ -1,22 +1,6 @@
 # Configuration for dependency-review-action
 # Documentation: https://github.com/actions/dependency-review-action
 
-# Fail the action if vulnerabilities are found with these severities
-fail-on-severity: high
-
-# Allow or deny specific licenses (optional)
-# For the full list of licenses: https://docs.github.com/en/rest/licenses
-# allow-licenses:
-#   - MIT
-#   - Apache-2.0
-#   - BSD-3-Clause
-#   - ISC
-
-# Deny packages with these licenses
-# deny-licenses:
-#   - GPL-3.0
-#   - LGPL-2.0
-
 # List of packages that should never be allowed
 # These are packages from the npm supply chain attack (Sept 2025)
 # Source: https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack
@@ -40,9 +24,6 @@ deny-packages:
   - pkg:npm/supports-color@10.2.1
   - pkg:npm/proto-tinker-wc@1.8.7
   - pkg:npm/debug@4.4.2
-
-# Create a comment on the PR with the review summary
-comment-summary-in-pr: always
 
 # Additional settings for more strict checking
 warn-only: false

--- a/.github/workflows/README_SECURITY.md
+++ b/.github/workflows/README_SECURITY.md
@@ -1,0 +1,37 @@
+# Security Vulnerability Scanning
+
+This repository has automated security scanning to prevent compromised packages from being merged.
+
+## Overview
+
+We use two security checks to protect against supply chain attacks:
+
+1. **GitHub Dependency Review Action** - Checks for known vulnerabilities in the GHSA database
+2. **Custom Blocked Package Check** - Blocks specific compromised packages from known supply chain attacks
+
+## Configuration
+
+All compromised packages are listed in `.github/dependency-review-config.yml` under the `deny-packages` section.
+
+This configuration is used by:
+- GitHub's dependency-review-action (in CI)
+- Our local security check script
+
+## How to Use
+
+### Check for compromised packages locally:
+```bash
+npm run security:check
+```
+
+### Add new blocked packages:
+Edit `.github/dependency-review-config.yml` and add to the `deny-packages` list:
+```yaml
+deny-packages:
+  - package-name:version
+```
+
+## References
+
+- [Supply Chain Attack (Sept 2025)](https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack)
+- [GitHub Dependency Review Action](https://github.com/actions/dependency-review-action)

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,63 @@
+name: Dependency Review
+
+on:
+  pull_request:
+    branches: [ "main" ]
+  merge_group:
+
+# Cancel in-progress jobs for the same workflow and ref
+concurrency:
+  group: ${{github.workflow}}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  # Required for dependency-review-action to post comments
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # GitHub's dependency-review-action checks for:
+      # - Known vulnerabilities in the GHSA database
+      # - License compliance issues
+      # - Introduces new dependencies
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          # Fail on vulnerabilities with severity critical or high
+          fail-on-severity: high
+          # Also check for vulnerable transitive dependencies
+          vulnerability-check: true
+          # Warn about licenses that might be problematic
+          license-check: true
+          # Deny specific licenses if needed (uncomment and modify as needed)
+          # deny-licenses: GPL-3.0, LGPL-2.0, BSD-2-Clause
+          # Comment on PR with results
+          comment-summary-in-pr: always
+          # Set a custom configuration file path
+          config-file: .github/dependency-review-config.yml
+
+  check-blocked-packages:
+    name: Check for Blocked Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 22
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Check for compromised packages
+        run: npm run security:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "moment": "2.30.1",
         "msw": "2.11.2",
         "npm-run-all": "4.1.5",
+        "packageurl-js": "^2.0.1",
         "path-browserify": "1.0.1",
         "postcss-scss": "4.0.9",
         "react-chartjs-2": "5.3.0",
@@ -14804,6 +14805,13 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/packageurl-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-2.0.1.tgz",
+      "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "dev": true,
@@ -29355,6 +29363,12 @@
     },
     "package-json-from-dist": {
       "version": "1.0.1",
+      "dev": true
+    },
+    "packageurl-js": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-2.0.1.tgz",
+      "integrity": "sha512-N5ixXjzTy4QDQH0Q9YFjqIWd6zH6936Djpl2m9QNFmDv5Fum8q8BjkpAcHNMzOFE0IwQrFhJWex3AN6kS0OSwg==",
       "dev": true
     },
     "pako": {

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "moment": "2.30.1",
     "msw": "2.11.2",
     "npm-run-all": "4.1.5",
-    "packageurl-js": "^2.0.1",
+    "packageurl-js": "2.0.1",
     "path-browserify": "1.0.1",
     "postcss-scss": "4.0.9",
     "react-chartjs-2": "5.3.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "moment": "2.30.1",
     "msw": "2.11.2",
     "npm-run-all": "4.1.5",
+    "packageurl-js": "^2.0.1",
     "path-browserify": "1.0.1",
     "postcss-scss": "4.0.9",
     "react-chartjs-2": "5.3.0",
@@ -120,7 +121,8 @@
     "verify": "npm-run-all build lint test",
     "postinstall": "ts-patch install",
     "circular": "madge --circular ./src --extensions js,ts,tsx",
-    "circular:graph": "madge --circular ./src --extensions js,ts,tsx -i deps.png"
+    "circular:graph": "madge --circular ./src --extensions js,ts,tsx -i deps.png",
+    "security:check": "node scripts/check-vulnerable-packages.js"
   },
   "insights": {
     "appname": "image-builder"

--- a/scripts/check-vulnerable-packages.js
+++ b/scripts/check-vulnerable-packages.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+
+/**
+ * Check for compromised packages from .github/dependency-review-config.yml
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { PackageURL } = require('packageurl-js');
+
+// Parse deny-packages from config
+function loadDeniedPackages() {
+  const configPath = path.join(process.cwd(), '.github', 'dependency-review-config.yml');
+  
+  if (!fs.existsSync(configPath)) {
+    console.error('Error: .github/dependency-review-config.yml not found');
+    process.exit(1);
+  }
+
+  const deniedPackages = {};
+  const lines = fs.readFileSync(configPath, 'utf8').split('\n');
+  let inDenyPackages = false;
+  
+  for (const line of lines) {
+    if (line.trim() === 'deny-packages:') {
+      inDenyPackages = true;
+      continue;
+    }
+    if (inDenyPackages && line[0] !== ' ' && line[0] !== '-' && line.trim() !== '') {
+      break;
+    }
+    if (inDenyPackages && line.trim().startsWith('- ')) {
+      const purlString = line.trim().substring(2).trim();
+      
+      try {
+        // Parse the purl using the official library
+        const purl = PackageURL.fromString(purlString);
+        
+        // Only process npm packages
+        if (purl.type === 'npm') {
+          // Build the full package name with namespace if present
+          const packageName = purl.namespace 
+            ? `${decodeURIComponent(purl.namespace)}/${purl.name}`
+            : purl.name;
+          
+          if (packageName && purl.version) {
+            deniedPackages[`${packageName}@${purl.version}`] = true;
+          }
+        }
+      } catch (error) {
+        console.warn(`Warning: Invalid purl format: ${purlString}`);
+      }
+    }
+  }
+  
+  return deniedPackages;
+}
+
+// Check package-lock.json
+function checkPackages() {
+  const packageLockPath = path.join(process.cwd(), 'package-lock.json');
+  
+  if (!fs.existsSync(packageLockPath)) {
+    console.error('Error: package-lock.json not found');
+    process.exit(1);
+  }
+
+  const deniedPackages = loadDeniedPackages();
+  const packageLock = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
+  const found = [];
+  
+  // Scan all packages
+  function scan(packages) {
+    for (const [path, info] of Object.entries(packages)) {
+      if (path === '') continue;
+      const key = `${path.split('/').pop()}@${info.version}`;
+      if (deniedPackages[key]) {
+        found.push(key);
+      }
+    }
+  }
+  
+  if (packageLock.packages) scan(packageLock.packages);
+  
+  // Report results
+  if (found.length > 0) {
+    console.error(`\n❌ Found ${found.length} compromised package(s):`);
+    found.forEach(pkg => console.error(`  - ${pkg}`));
+    console.error('\nThese packages are from a supply chain attack. DO NOT MERGE!');
+    console.error('See: https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack\n');
+    process.exit(1);
+  } else {
+    console.log(`✅ No compromised packages detected (checked ${Object.keys(deniedPackages).length} packages)`);
+  }
+}
+
+checkPackages();

--- a/scripts/check-vulnerable-packages.js
+++ b/scripts/check-vulnerable-packages.js
@@ -11,16 +11,16 @@ const { PackageURL } = require('packageurl-js');
 // Parse deny-packages from config
 function loadDeniedPackages() {
   const configPath = path.join(process.cwd(), '.github', 'dependency-review-config.yml');
-  
+
   if (!fs.existsSync(configPath)) {
     console.error('Error: .github/dependency-review-config.yml not found');
     process.exit(1);
   }
 
-  const deniedPackages = {};
+  const deniedPackages = new Set();
   const lines = fs.readFileSync(configPath, 'utf8').split('\n');
   let inDenyPackages = false;
-  
+
   for (const line of lines) {
     if (line.trim() === 'deny-packages:') {
       inDenyPackages = true;
@@ -31,35 +31,29 @@ function loadDeniedPackages() {
     }
     if (inDenyPackages && line.trim().startsWith('- ')) {
       const purlString = line.trim().substring(2).trim();
-      
+
       try {
         // Parse the purl using the official library
         const purl = PackageURL.fromString(purlString);
-        
+
         // Only process npm packages
         if (purl.type === 'npm') {
-          // Build the full package name with namespace if present
-          const packageName = purl.namespace 
-            ? `${decodeURIComponent(purl.namespace)}/${purl.name}`
-            : purl.name;
-          
-          if (packageName && purl.version) {
-            deniedPackages[`${packageName}@${purl.version}`] = true;
-          }
+          // Store the normalized purl string
+          deniedPackages.add(purl.toString());
         }
       } catch (error) {
         console.warn(`Warning: Invalid purl format: ${purlString}`);
       }
     }
   }
-  
+
   return deniedPackages;
 }
 
 // Check package-lock.json
 function checkPackages() {
   const packageLockPath = path.join(process.cwd(), 'package-lock.json');
-  
+
   if (!fs.existsSync(packageLockPath)) {
     console.error('Error: package-lock.json not found');
     process.exit(1);
@@ -68,29 +62,66 @@ function checkPackages() {
   const deniedPackages = loadDeniedPackages();
   const packageLock = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
   const found = [];
-  
+
   // Scan all packages
   function scan(packages) {
-    for (const [path, info] of Object.entries(packages)) {
-      if (path === '') continue;
-      const key = `${path.split('/').pop()}@${info.version}`;
-      if (deniedPackages[key]) {
-        found.push(key);
+    for (const [pkgPath, info] of Object.entries(packages)) {
+      if (pkgPath === '' || !info.version) continue;
+
+      // Extract package name from the path
+      // e.g., "node_modules/@scope/package" -> "@scope/package"
+      // e.g., "node_modules/package" -> "package"
+      const pathParts = pkgPath.split('node_modules/').pop();
+
+      // Parse the package name to extract namespace and name
+      let namespace = null;
+      let name = pathParts;
+
+      if (pathParts.startsWith('@')) {
+        const scopeParts = pathParts.split('/');
+        if (scopeParts.length >= 2) {
+          namespace = scopeParts[0];
+          name = scopeParts.slice(1).join('/');
+        }
+      }
+
+      try {
+        // Create a PackageURL object for this package
+        const purl = new PackageURL(
+          'npm',
+          namespace,
+          name,
+          info.version,
+          null,
+          null
+        );
+
+        // Convert to string and check if it's in the denied list
+        const purlString = purl.toString();
+        if (deniedPackages.has(purlString)) {
+          found.push({
+            purl: purlString,
+            displayName: `${namespace ? namespace + '/' : ''}${name}@${info.version}`
+          });
+        }
+      } catch (error) {
+        // Skip packages that can't be parsed as purl
+        continue;
       }
     }
   }
-  
+
   if (packageLock.packages) scan(packageLock.packages);
   
   // Report results
   if (found.length > 0) {
     console.error(`\n❌ Found ${found.length} compromised package(s):`);
-    found.forEach(pkg => console.error(`  - ${pkg}`));
+    found.forEach(pkg => console.error(`  - ${pkg.displayName}`));
     console.error('\nThese packages are from a supply chain attack. DO NOT MERGE!');
     console.error('See: https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack\n');
     process.exit(1);
   } else {
-    console.log(`✅ No compromised packages detected (checked ${Object.keys(deniedPackages).length} packages)`);
+    console.log(`✅ No compromised packages detected (checked ${deniedPackages.size} packages)`);
   }
 }
 


### PR DESCRIPTION
Implements checks to avoid https://socket.dev/blog/npm-author-qix-compromised-in-major-supply-chain-attack
as transitive dependency.

The upstream check only seems to check changes and not dependencies already in.
So there is a small script for this. To cover _only_ the specific packages, we could remove `dependency-review-action` but this might give some other benefits 🤷

@regexowl please check.
btw. all the affected packages seem to be removed from npm database already, so we can as well cancel this PR 🤔