### PR TITLE
test: Clean up mocked flags

### DIFF
--- a/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/TargetEnvironment/AzureTarget.test.tsx
@@ -29,18 +29,6 @@ import {
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
-vi.mock('@unleash/proxy-client-react', () => ({
-  useUnleashContext: () => vi.fn(),
-  useFlag: vi.fn((flag) => {
-    switch (flag) {
-      case 'image-builder.launcheof':
-        return false;
-      default:
-        return false;
-    }
-  }),
-}));
-
 // The router is just initiliazed here, it's assigned a value in the tests
 let router: RemixRouter | undefined = undefined;
 

--- a/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
+++ b/src/test/Components/CreateImageWizard/steps/Users/Users.test.tsx
@@ -25,18 +25,6 @@ import {
   verifyCancelButton,
 } from '../../wizardTestUtils';
 
-vi.mock('@unleash/proxy-client-react', () => ({
-  useUnleashContext: () => vi.fn(),
-  useFlag: vi.fn((flag) => {
-    switch (flag) {
-      case 'image-builder.launcheof':
-        return false;
-      default:
-        return false;
-    }
-  }),
-}));
-
 let router: RemixRouter | undefined = undefined;
 
 const validUserName = 'best';


### PR DESCRIPTION
`image-builder.launcheof` was already removed from the code base, these mocks can be cleaned up and flags can be removed after release.