### PR TITLE
devDeps: Remove unused @types/uuid dependency (HMS-9431)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "@types/react": "18.3.12",
         "@types/react-dom": "18.3.1",
         "@types/react-redux": "7.1.34",
-        "@types/uuid": "11.0.0",
         "@typescript-eslint/eslint-plugin": "8.44.0",
         "@typescript-eslint/parser": "8.44.0",
         "@vitejs/plugin-react": "5.0.3",
@@ -5719,17 +5718,6 @@
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "deprecated": "This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "uuid": "*"
-      }
     },
     "node_modules/@types/ws": {
       "version": "8.5.13",
@@ -23540,15 +23528,6 @@
     },
     "@types/use-sync-external-store": {
       "version": "0.0.6"
-    },
-    "@types/uuid": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-11.0.0.tgz",
-      "integrity": "sha512-HVyk8nj2m+jcFRNazzqyVKiZezyhDKrGUA3jlEcg/nZ6Ms+qHwocba1Y/AaVaznJTAM9xpdFSh+ptbNrhOGvZA==",
-      "dev": true,
-      "requires": {
-        "uuid": "*"
-      }
     },
     "@types/ws": {
       "version": "8.5.13",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,6 @@
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "@types/react-redux": "7.1.34",
-    "@types/uuid": "11.0.0",
     "@typescript-eslint/eslint-plugin": "8.44.0",
     "@typescript-eslint/parser": "8.44.0",
     "@vitejs/plugin-react": "5.0.3",


### PR DESCRIPTION
This resolves following warning outputted when running `npm i`:

```
npm warn deprecated @types/uuid@11.0.0: This is a stub types definition. uuid provides its own type definitions, so you do not need this installed.
```

JIRA: [HMS-9431](https://issues.redhat.com/browse/HMS-9431)