### PR TITLE
Wizard: Increase limit for Compliance policies in selector to 50

### DIFF
--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -96,6 +96,7 @@ const PolicySelector = () => {
     isSuccess: isSuccessPolicies,
   } = usePoliciesQuery({
     filter: `os_major_version=${majorVersion}`,
+    limit: 50,
   });
 
   const { data: currentProfileData } = useGetComplianceCustomizationsQuery(

--- a/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/PolicySelector.tsx
@@ -97,6 +97,7 @@ const PolicySelector = () => {
   } = usePoliciesQuery({
     filter: `os_major_version=${majorVersion}`,
     limit: 50,
+    sortBy: ['title:asc'],
   });
 
   const { data: currentProfileData } = useGetComplianceCustomizationsQuery(


### PR DESCRIPTION
This was previously set to 10 and there is no other way how to see other policies than the first 10 returned by Compliance API.