### PR TITLE
playwright/CI: Remove Currents reporter from Gitlab runs (HMS-9314)

### DIFF
--- a/schutzbot/playwright_tests.sh
+++ b/schutzbot/playwright_tests.sh
@@ -79,8 +79,6 @@ sudo podman run \
      -e "CI=true" \
      -e "PLAYWRIGHT_USER=admin" \
      -e "PLAYWRIGHT_PASSWORD=foobar" \
-     -e "CURRENTS_PROJECT_ID=${CURRENTS_PROJECT_ID:-}" \
-     -e "CURRENTS_RECORD_KEY=${CURRENTS_RECORD_KEY:-}" \
      --net=host \
      -v "$PWD:/tests" \
      -v '/etc:/etc' \


### PR DESCRIPTION
Remove Currents from CI runs for Cockpit plugin in Gitlab, because we use four runners per run and each one generates a report, which leads to increased spending for Currents that can be avoided since we can track test results using the results from hosted tests that are mostly the same.