### PR TITLE
playwright: reduce worker count on schutzbot

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ if (process.env.CURRENTS_PROJECT_ID && process.env.CURRENTS_RECORD_KEY) {
 export default defineConfig({
   testDir: 'playwright',
   fullyParallel: true,
-  workers: 4,
+  workers: Number.parseInt(process.env.PLAYWRIGHT_WORKERS) || 4,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   reporter: reporters,

--- a/schutzbot/playwright_tests.sh
+++ b/schutzbot/playwright_tests.sh
@@ -79,6 +79,7 @@ sudo podman run \
      -e "CI=true" \
      -e "PLAYWRIGHT_USER=admin" \
      -e "PLAYWRIGHT_PASSWORD=foobar" \
+     -e "PLAYWRIGHT_WORKERS=2" \
      --net=host \
      -v "$PWD:/tests" \
      -v '/etc:/etc' \


### PR DESCRIPTION
The CI machines we have only have 2 cpus and between 4 and 8 GB of memory. A worker count of 4 makes the tests more flaky, especially on RHEL 10.