### PR TITLE
playwright: Fix missing expect import in imageBuilding.ts

### DIFF
--- a/playwright/BootTests/helpers/imageBuilding.ts
+++ b/playwright/BootTests/helpers/imageBuilding.ts
@@ -1,4 +1,4 @@
-import { Page } from '@playwright/test';
+import { expect, Page } from '@playwright/test';
 
 export const buildImage = async (page: Page) => {
   /**


### PR DESCRIPTION
Static analysis failed to notice the expect import was missing here, because vitest imports expect globally.