### PR TITLE
ci/playwright: Use large RHOS runners instead of AWS m5.large runners for Cockpit 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -30,9 +30,9 @@ test:
   parallel:
     matrix:
       - RUNNER:
-          - aws/fedora-41-x86_64
-          - aws/fedora-42-x86_64
-          - aws/rhel-10.1-nightly-x86_64
+          - rhos-01/fedora-41-x86_64-large
+          - rhos-01/fedora-42-x86_64-large
+          - rhos-01/rhel-10.1-nightly-x86_64-large
         INTERNAL_NETWORK: ["true"]
 
 finish:


### PR DESCRIPTION
Swap AWS m5.large instances for RHOS large runners. This mainly raises the amount of avaiable vCPUs to 4, because m5.large only had 2 and that caused the flakiness in Cockpit plugin PW tests .