### PR TITLE
Wizard: always enable Create/Save buttons on Review step (HMS-10658)

### DIFF
--- a/playwright/Customizations/UsersAndGroups.spec.ts
+++ b/playwright/Customizations/UsersAndGroups.spec.ts
@@ -681,6 +681,12 @@ test('Create a blueprint with Groups customization', async ({
     await expect(frame.getByText('ops')).toBeVisible();
   });
 
+  await test.step('Verify Create button is enabled', async () => {
+    await expect(
+      frame.getByRole('button', { name: 'Create blueprint' }),
+    ).toBeEnabled();
+  });
+
   await test.step('Create and save blueprint', async () => {
     await createBlueprint(frame, blueprintName);
   });

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -113,6 +113,7 @@ import {
   useTimezoneValidation,
   useUserGroupsValidation,
   useUsersValidation,
+  WIZARD_STEP_IDS,
 } from '../CreateImageWizard/utilities/useValidation';
 
 const CreateImageWizard = () => {
@@ -366,7 +367,9 @@ const CreateImageWizard = () => {
   useEffect(() => {
     if (!isOnPremise && showWizardModal && !hasTrackedInitialStepRef.current) {
       const initialStepId =
-        mode === 'edit' ? 'review-step' : 'base-settings-step';
+        mode === 'edit'
+          ? WIZARD_STEP_IDS.REVIEW
+          : WIZARD_STEP_IDS.BASE_SETTINGS;
       const accountId = userData?.identity.internal?.account_id;
 
       analytics.track(`${AMPLITUDE_MODULE_NAME} - Step Viewed`, {
@@ -423,9 +426,9 @@ const CreateImageWizard = () => {
   ) => {
     const status = (step.id !== activeStep.id && step.status) || 'default';
 
-    const isBaseSettingsStep = step.id === 'base-settings-step';
+    const isBaseSettingsStep = step.id === WIZARD_STEP_IDS.BASE_SETTINGS;
     const hasVisitedBaseSettings = _steps.find(
-      (s) => s.id === 'base-settings-step',
+      (s) => s.id === WIZARD_STEP_IDS.BASE_SETTINGS,
     )?.isVisited;
     const canNavigate =
       (isBaseSettingsStep || !localImageSourceSelected) &&
@@ -493,7 +496,7 @@ const CreateImageWizard = () => {
       >
         <WizardStep
           name='Base settings'
-          id='base-settings-step'
+          id={WIZARD_STEP_IDS.BASE_SETTINGS}
           navItem={CustomStatusNavItem}
           status={baseSettingsHasErrors ? 'error' : 'default'}
           footer={
@@ -546,7 +549,7 @@ const CreateImageWizard = () => {
         </WizardStep>
         <WizardStep
           name='Repositories and packages'
-          id='content-step'
+          id={WIZARD_STEP_IDS.CONTENT}
           navItem={CustomStatusNavItem}
           status='default'
           isHidden={
@@ -577,7 +580,7 @@ const CreateImageWizard = () => {
         </WizardStep>
         <WizardStep
           name='Advanced settings'
-          id='advanced-settings-step'
+          id={WIZARD_STEP_IDS.ADVANCED_SETTINGS}
           navItem={CustomStatusNavItem}
           status={advancedSettingsHasErrors ? 'error' : 'default'}
           isHidden={
@@ -651,7 +654,7 @@ const CreateImageWizard = () => {
         </WizardStep>
         <WizardStep
           name='Review'
-          id='review-step'
+          id={WIZARD_STEP_IDS.REVIEW}
           navItem={CustomStatusNavItem}
           status='default'
           footer={<ReviewWizardFooter />}

--- a/src/Components/CreateImageWizard/components/CustomWizardFooter.tsx
+++ b/src/Components/CreateImageWizard/components/CustomWizardFooter.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/store/slices/wizard';
 
 import { scrollToFirstError } from '../utilities/scrollToFirstError';
+import { WIZARD_STEP_IDS } from '../utilities/useValidation';
 
 type CustomWizardFooterPropType = {
   disableBack?: boolean;
@@ -80,7 +81,7 @@ export const CustomWizardFooter = ({
         });
       }
       dispatch(resetForceShowErrors());
-      goToStepById('review-step');
+      goToStepById(WIZARD_STEP_IDS.REVIEW);
     }
   };
 

--- a/src/Components/CreateImageWizard/components/ReviewWizardFooter.tsx
+++ b/src/Components/CreateImageWizard/components/ReviewWizardFooter.tsx
@@ -17,7 +17,11 @@ import {
   useCreateBPWithNotification as useCreateBlueprintMutation,
   useUpdateBPWithNotification as useUpdateBlueprintMutation,
 } from '../../../Hooks';
-import { useAppSelector } from '../../../store/hooks';
+import { useAppDispatch, useAppSelector } from '../../../store/hooks';
+import {
+  resetForceShowErrors,
+  setForceShowErrors,
+} from '../../../store/slices/wizard';
 import {
   CreateSaveAndBuildBtn,
   CreateSaveButton,
@@ -26,10 +30,12 @@ import {
   EditSaveAndBuildBtn,
   EditSaveButton,
 } from '../steps/Review/Footer/EditDropdown';
-import { useIsBlueprintValid } from '../utilities/useValidation';
+import { scrollToFirstError } from '../utilities/scrollToFirstError';
+import { useBlueprintValidation } from '../utilities/useValidation';
 
 const ReviewWizardFooter = () => {
-  const { goToPrevStep, close } = useWizardContext();
+  const { goToPrevStep, goToStepById, close } = useWizardContext();
+  const dispatch = useAppDispatch();
   const { isSuccess: isCreateSuccess, reset: resetCreate } =
     useCreateBlueprintMutation({ fixedCacheKey: 'createBlueprintKey' });
 
@@ -38,10 +44,24 @@ const ReviewWizardFooter = () => {
   const mode = useAppSelector(selectWizardModalMode);
   const blueprintId = useAppSelector(selectSelectedBlueprintId);
   const [isOpen, setIsOpen] = useState(false);
+  const { isValid, firstErrorStepId } = useBlueprintValidation();
+
+  const handleValidationFail = () => {
+    if (!firstErrorStepId) return;
+    dispatch(setForceShowErrors());
+    goToStepById(firstErrorStepId);
+    requestAnimationFrame(() => {
+      scrollToFirstError();
+    });
+  };
+
   const onToggleClick = () => {
+    if (!isValid) {
+      handleValidationFail();
+      return;
+    }
     setIsOpen(!isOpen);
   };
-  const isValid = useIsBlueprintValid();
 
   useEffect(() => {
     if (isUpdateSuccess || isCreateSuccess) {
@@ -51,6 +71,14 @@ const ReviewWizardFooter = () => {
     }
   }, [isUpdateSuccess, isCreateSuccess, resetCreate, resetUpdate, close]);
 
+  const validateBeforeAction = (): boolean => {
+    if (!isValid) {
+      handleValidationFail();
+      return false;
+    }
+    return true;
+  };
+
   const isEditMode = mode === 'edit';
 
   return (
@@ -59,7 +87,13 @@ const ReviewWizardFooter = () => {
         columnGap={{ default: 'columnGapSm' }}
         justifyContent={{ default: 'justifyContentFlexEnd' }}
       >
-        <Button variant='secondary' onClick={goToPrevStep}>
+        <Button
+          variant='secondary'
+          onClick={() => {
+            dispatch(resetForceShowErrors());
+            goToPrevStep();
+          }}
+        >
           Back
         </Button>
         <Dropdown
@@ -71,7 +105,6 @@ const ReviewWizardFooter = () => {
               ref={toggleRef}
               onClick={onToggleClick}
               isExpanded={isOpen}
-              isDisabled={!isValid}
               splitButtonItems={
                 isEditMode
                   ? [
@@ -79,14 +112,14 @@ const ReviewWizardFooter = () => {
                         key='wizard-edit-save-btn'
                         setIsOpen={setIsOpen}
                         blueprintId={blueprintId || ''}
-                        isDisabled={!isValid}
+                        validateBeforeAction={validateBeforeAction}
                       />,
                     ]
                   : [
                       <CreateSaveButton
                         key='wizard-create-save-btn'
                         setIsOpen={setIsOpen}
-                        isDisabled={!isValid}
+                        validateBeforeAction={validateBeforeAction}
                       />,
                     ]
               }
@@ -98,12 +131,12 @@ const ReviewWizardFooter = () => {
             <EditSaveAndBuildBtn
               blueprintId={blueprintId || ''}
               setIsOpen={setIsOpen}
-              isDisabled={!isValid}
+              validateBeforeAction={validateBeforeAction}
             />
           ) : (
             <CreateSaveAndBuildBtn
               setIsOpen={setIsOpen}
-              isDisabled={!isValid}
+              validateBeforeAction={validateBeforeAction}
             />
           )}
         </Dropdown>

--- a/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/CreateDropdown.tsx
@@ -40,12 +40,12 @@ import { createAnalytics } from '../../../../../Utilities/analytics';
 
 type CreateDropdownProps = {
   setIsOpen: (isOpen: boolean) => void;
-  isDisabled: boolean;
+  validateBeforeAction: () => boolean;
 };
 
 export const CreateSaveAndBuildBtn = ({
   setIsOpen,
-  isDisabled,
+  validateBeforeAction,
 }: CreateDropdownProps) => {
   const { analytics, auth, isBeta } = useChrome();
   const { userData } = useGetUser(auth);
@@ -59,7 +59,9 @@ export const CreateSaveAndBuildBtn = ({
     fixedCacheKey: 'createBlueprintKey',
   });
   const dispatch = useAppDispatch();
+
   const onSaveAndBuild = async () => {
+    if (!validateBeforeAction()) return;
     const requestBody = mapStateToRequest(store.getState());
     setIsOpen(false);
 
@@ -92,7 +94,7 @@ export const CreateSaveAndBuildBtn = ({
 
   return (
     <DropdownList>
-      <DropdownItem onClick={onSaveAndBuild} isDisabled={isDisabled}>
+      <DropdownItem onClick={onSaveAndBuild}>
         Create blueprint and build image(s)
       </DropdownItem>
     </DropdownList>
@@ -132,7 +134,7 @@ const SaveAndBuildImagesModal = ({
 
 export const CreateSaveButton = ({
   setIsOpen,
-  isDisabled,
+  validateBeforeAction,
 }: CreateDropdownProps) => {
   const { analytics, auth, isBeta } = useChrome();
   const { userData } = useGetUser(auth);
@@ -155,6 +157,7 @@ export const CreateSaveButton = ({
   };
 
   const onClick = () => {
+    if (!validateBeforeAction()) return;
     if (!wasModalSeen) {
       setShowModal(true);
       window.localStorage.setItem('imageBuilder.saveAndBuildModalSeen', 'true');
@@ -191,11 +194,7 @@ export const CreateSaveButton = ({
         showModal={showModal}
         handleClose={handleClose}
       />
-      <MenuToggleAction
-        onClick={onClick}
-        id='wizard-create-save-btn'
-        isDisabled={isDisabled}
-      >
+      <MenuToggleAction onClick={onClick} id='wizard-create-save-btn'>
         <Flex display={{ default: 'inlineFlex' }}>
           {isLoading && (
             <FlexItem>

--- a/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/Footer/EditDropdown.tsx
@@ -31,13 +31,13 @@ import { createAnalytics } from '../../../../../Utilities/analytics';
 type EditDropdownProps = {
   setIsOpen: (isOpen: boolean) => void;
   blueprintId: string;
-  isDisabled: boolean;
+  validateBeforeAction: () => boolean;
 };
 
 export const EditSaveAndBuildBtn = ({
   setIsOpen,
   blueprintId,
-  isDisabled,
+  validateBeforeAction,
 }: EditDropdownProps) => {
   const { analytics, auth, isBeta } = useChrome();
   const { userData } = useGetUser(auth);
@@ -52,6 +52,7 @@ export const EditSaveAndBuildBtn = ({
   });
 
   const onSaveAndBuild = async () => {
+    if (!validateBeforeAction()) return;
     const requestBody = mapStateToRequest(store.getState());
 
     if (!isOnPremise) {
@@ -83,7 +84,7 @@ export const EditSaveAndBuildBtn = ({
 
   return (
     <DropdownList>
-      <DropdownItem onClick={onSaveAndBuild} isDisabled={isDisabled}>
+      <DropdownItem onClick={onSaveAndBuild}>
         Save changes and build image(s)
       </DropdownItem>
     </DropdownList>
@@ -93,7 +94,7 @@ export const EditSaveAndBuildBtn = ({
 export const EditSaveButton = ({
   setIsOpen,
   blueprintId,
-  isDisabled,
+  validateBeforeAction,
 }: EditDropdownProps) => {
   const { analytics, auth, isBeta } = useChrome();
   const { userData } = useGetUser(auth);
@@ -106,6 +107,7 @@ export const EditSaveButton = ({
     fixedCacheKey: 'updateBlueprintKey',
   });
   const onSave = async () => {
+    if (!validateBeforeAction()) return;
     const requestBody = mapStateToRequest(store.getState());
 
     if (!isOnPremise) {
@@ -127,11 +129,7 @@ export const EditSaveButton = ({
     });
   };
   return (
-    <MenuToggleAction
-      onClick={onSave}
-      id='wizard-edit-save-btn'
-      isDisabled={isDisabled}
-    >
+    <MenuToggleAction onClick={onSave} id='wizard-edit-save-btn'>
       <Flex display={{ default: 'inlineFlex' }}>
         {isLoading && (
           <FlexItem>

--- a/src/Components/CreateImageWizard/tests/CreateMode.test.tsx
+++ b/src/Components/CreateImageWizard/tests/CreateMode.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor, within } from '@testing-library/react';
+import { screen, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 
 import { composeHandlers, createArchitecturesHandler } from '@/test/testUtils';
@@ -32,31 +32,6 @@ describe('Create Image Wizard', () => {
     await screen.findByRole('button', { name: 'Repositories and packages' });
     await screen.findByRole('button', { name: 'Advanced settings' });
     await screen.findByRole('button', { name: 'Review' });
-  });
-
-  test('should only enable first navigation item in create mode', async () => {
-    await renderCreateMode();
-
-    const navigation = await screen.findByRole('navigation', {
-      name: /wizard steps/i,
-    });
-    const baseNavItem = within(navigation).getByRole('button', {
-      name: /base settings/i,
-    });
-    const contentNavItem = within(navigation).getByRole('button', {
-      name: /repositories and packages/i,
-    });
-    const advancedNavItem = within(navigation).getByRole('button', {
-      name: /advanced settings/i,
-    });
-    const reviewNavItem = within(navigation).getByRole('button', {
-      name: /review/i,
-    });
-
-    expect(baseNavItem).toBeEnabled();
-    expect(contentNavItem).toBeDisabled();
-    expect(advancedNavItem).toBeDisabled();
-    expect(reviewNavItem).toBeDisabled();
   });
 });
 

--- a/src/Components/CreateImageWizard/utilities/scrollToFirstError.ts
+++ b/src/Components/CreateImageWizard/utilities/scrollToFirstError.ts
@@ -1,5 +1,7 @@
 export const scrollToFirstError = (): boolean => {
-  const errorEl = document.querySelector('.pf-m-error');
+  const scope =
+    document.querySelector('.pf-v6-c-wizard__main-body') ?? document;
+  const errorEl = scope.querySelector('.pf-m-error');
   if (errorEl) {
     errorEl.scrollIntoView({ behavior: 'smooth', block: 'center' });
     const parent = errorEl.closest('.pf-v6-c-form-group, [role="group"]');

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -51,6 +51,7 @@ import {
   selectHostname,
   selectImageSource,
   selectImageTypes,
+  selectIsImageMode,
   selectIsOfficialImage,
   selectIsoPayloadReference,
   selectKernel,
@@ -127,7 +128,22 @@ export type UsersStepValidation = {
   disabledNext: boolean;
 };
 
-export function useIsBlueprintValid(): boolean {
+export const WIZARD_STEP_IDS = {
+  BASE_SETTINGS: 'base-settings-step',
+  CONTENT: 'content-step',
+  ADVANCED_SETTINGS: 'advanced-settings-step',
+  REVIEW: 'review-step',
+} as const;
+
+export type WizardStepId =
+  (typeof WIZARD_STEP_IDS)[keyof typeof WIZARD_STEP_IDS];
+
+type BlueprintValidation = {
+  isValid: boolean;
+  firstErrorStepId: WizardStepId | null;
+};
+
+export function useBlueprintValidation(): BlueprintValidation {
   const aap = useAAPValidation();
   const registration = useRegistrationValidation();
   const filesystem = useFilesystemValidation();
@@ -143,30 +159,56 @@ export function useIsBlueprintValid(): boolean {
   const azureTarget = useAzureValidation();
   const gcpTarget = useGcpValidation();
   const awsTarget = useAwsValidation();
-
+  const imagePull = useImagePullValidation();
+  const targetEnvironments = useAppSelector(selectImageTypes);
+  const isOnPremise = useAppSelector(selectIsOnPremise);
+  const isImageMode = useAppSelector(selectIsImageMode);
+  const imageSource = useAppSelector(selectImageSource);
   const hostnameErrors = validateHostname(useAppSelector(selectHostname));
   const kernelErrors = validateKernel(useAppSelector(selectKernel));
 
-  return (
-    !aap.disabledNext &&
-    !registration.disabledNext &&
-    !filesystem.disabledNext &&
-    !snapshot.disabledNext &&
-    !timezone.disabledNext &&
-    !locale.disabledNext &&
-    hostnameErrors.length === 0 &&
-    kernelErrors.length === 0 &&
-    !firewall.disabledNext &&
-    !services.disabledNext &&
-    !firstBoot.disabledNext &&
-    !details.disabledNext &&
-    !details.isPending &&
-    !users.disabledNext &&
-    !userGroups.disabledNext &&
-    !azureTarget.disabledNext &&
-    !gcpTarget.disabledNext &&
-    !awsTarget.disabledNext
-  );
+  const usersAreStandalone = isImageMode && isOnPremise;
+  const usersHaveErrors = users.disabledNext || userGroups.disabledNext;
+
+  const baseSettingsInvalid =
+    targetEnvironments.length === 0 ||
+    (isImageMode && !imageSource) ||
+    aap.disabledNext ||
+    details.disabledNext ||
+    details.isPending ||
+    registration.disabledNext ||
+    snapshot.disabledNext ||
+    awsTarget.disabledNext ||
+    gcpTarget.disabledNext ||
+    azureTarget.disabledNext ||
+    imagePull.disabledNext ||
+    (usersAreStandalone && usersHaveErrors);
+
+  const advancedSettingsInvalid =
+    filesystem.disabledNext ||
+    timezone.disabledNext ||
+    locale.disabledNext ||
+    hostnameErrors.length > 0 ||
+    kernelErrors.length > 0 ||
+    firewall.disabledNext ||
+    services.disabledNext ||
+    firstBoot.disabledNext ||
+    (!usersAreStandalone && usersHaveErrors);
+
+  const isValid = !baseSettingsInvalid && !advancedSettingsInvalid;
+
+  return {
+    isValid,
+    firstErrorStepId: !isValid
+      ? baseSettingsInvalid
+        ? WIZARD_STEP_IDS.BASE_SETTINGS
+        : WIZARD_STEP_IDS.ADVANCED_SETTINGS
+      : null,
+  };
+}
+
+export function useIsBlueprintValid(): boolean {
+  return useBlueprintValidation().isValid;
 }
 
 type PasswordValidationResult = {


### PR DESCRIPTION
Keep Create and Save buttons enabled on the Review step instead of disabling them when validation errors exist. On click, navigate back to the step with errors instead of blocking.

- Refactor useIsBlueprintValid into useBlueprintValidation to expose
  firstErrorStepId
- Fix edit mode save being blocked while the async name uniqueness
  check is still in flight
- Remove shouldDisableAction helper — buttons are always enabled,
  validation runs on click via validateBeforeAction
- Replace flushSync with direct dispatch in handleValidationFail

Follows up on the "always enable Next/Review buttons" commit — same
pattern applied to the Review step.

Note: Depends on the activation key loading fix in #4622.

  JIRA: HMS-10658