### PR TITLE
Wizard: Tighten row spacing and hide idle password hints (HMS-10793)

### DIFF
--- a/src/Components/CreateImageWizard/steps/UserGroups/components/GroupRow.tsx
+++ b/src/Components/CreateImageWizard/steps/UserGroups/components/GroupRow.tsx
@@ -76,7 +76,7 @@ const GroupRow = ({ index, groupCount, group }: GroupRowProps) => {
   };
 
   return (
-    <Tr>
+    <Tr resetOffset>
       <Td>
         <ValidatedInputAndTextArea
           ariaLabel='Group name'

--- a/src/Components/CreateImageWizard/steps/Users/components/UserRow.tsx
+++ b/src/Components/CreateImageWizard/steps/Users/components/UserRow.tsx
@@ -100,7 +100,7 @@ const UserRow = ({ user, index, userCount }: UserRowProps) => {
 
   return (
     <>
-      <Tr>
+      <Tr resetOffset>
         <Td>
           <ValidatedInputAndTextArea
             ariaLabel='blueprint user name'


### PR DESCRIPTION
Reset table row offset in Users and Groups for neater input spacing.
Only show password validation helper text when the input is focused
or has errors.
Before: 
<img width="1299" height="584" alt="Screenshot 2026-07-22 at 18 42 19" src="https://github.com/user-attachments/assets/8505f3b4-ffcb-4e6f-88bb-2a4edf955d3b" />
After:
<img width="1293" height="663" alt="Screenshot 2026-07-22 at 18 41 26" src="https://github.com/user-attachments/assets/ac50129c-8080-4188-8557-7d2d3d091f43" />
  



  JIRA: HMS-10793