### PR TITLE
Update on-prem known images for RHEL 10.3

### DIFF
--- a/src/store/api/backend/onprem/constants.ts
+++ b/src/store/api/backend/onprem/constants.ts
@@ -4,10 +4,16 @@ export type KnownImage = Omit<BootcDistributionItem, 'arch'>;
 
 export const KNOWN_IMAGES: KnownImage[] = [
   {
-    reference: 'registry.redhat.io/rhel10/rhel-bootc:latest',
+    reference: 'registry.redhat.io/rhel10/rhel-kvm:latest',
     distro: 'rhel-10.3',
     name: 'Red Hat Enterprise Linux (RHEL) 10.3',
     type: 'guest-image',
+  },
+  {
+    reference: 'registry.redhat.io/rhel10/rhel-aws:latest',
+    distro: 'rhel-10.3',
+    name: 'Red Hat Enterprise Linux (RHEL) 10.3',
+    type: 'aws',
   },
 ];
 


### PR DESCRIPTION
## Summary

Update the on-prem known images list to include RHEL 10.3 variants and fix the existing RHEL 10 reference.

## Changes

- Rename `rhel-bootc` reference to `rhel-kvm` for the existing RHEL 10 image
- Add `rhel-aws` as a new known image for RHEL 10.3

Fixes #4712
Fixes #4715