### PR TITLE
Wizard: restrict `SingleTargetAlert` banner visibility (HMS-11066)

### DIFF
--- a/src/Components/LandingPage/SingleTargetAlert.tsx
+++ b/src/Components/LandingPage/SingleTargetAlert.tsx
@@ -9,24 +9,25 @@ import {
   FlexItem,
 } from '@patternfly/react-core';
 
+import useHasMultiTargetBlueprints from './useHasMultiTargetBlueprints';
+
 const TITLE =
   'Blueprints are transitioning to single image target environments.';
 const BODY =
   'Existing multi-target blueprints will be migrated to single-target configurations.';
 
-const SingleTargetAlert = () => {
-  const localStorageKey = 'imageBuilder.singleTargetMigration.dismissed';
-  const isAlertDismissed = window.localStorage.getItem(localStorageKey);
+const localStorageKey = 'imageBuilder.singleTargetMigration.dismissed';
 
-  const [displayAlert, setDisplayAlert] = useState(!isAlertDismissed);
+const SingleTargetAlert = () => {
+  const { hasMultiTarget } = useHasMultiTargetBlueprints();
   const [isTemporarilyHidden, setIsTemporarilyHidden] = useState(false);
 
   const dismissAlert = () => {
-    setDisplayAlert(false);
+    setIsTemporarilyHidden(true);
     window.localStorage.setItem(localStorageKey, 'true');
   };
 
-  if (!displayAlert || isTemporarilyHidden) {
+  if (!hasMultiTarget || isTemporarilyHidden) {
     return null;
   }
 
@@ -66,4 +67,10 @@ const SingleTargetAlert = () => {
   );
 };
 
-export default SingleTargetAlert;
+const SingleTargetAlertWrapper = () => {
+  const isAlertDismissed = window.localStorage.getItem(localStorageKey);
+  if (isAlertDismissed) return null;
+  return <SingleTargetAlert />;
+};
+
+export default SingleTargetAlertWrapper;

--- a/src/Components/LandingPage/tests/SingleTargetAlert.test.tsx
+++ b/src/Components/LandingPage/tests/SingleTargetAlert.test.tsx
@@ -6,12 +6,21 @@ import { createUser } from '@/test/testUtils';
 import { clickWithWait } from '@/test/testUtils/userEvents';
 
 import SingleTargetAlert from '../SingleTargetAlert';
+import useHasMultiTargetBlueprints from '../useHasMultiTargetBlueprints';
 
 const STORAGE_KEY = 'imageBuilder.singleTargetMigration.dismissed';
+
+vi.mock('../useHasMultiTargetBlueprints', () => ({
+  default: vi.fn(() => ({ hasMultiTarget: true, isLoading: false })),
+}));
 
 describe('Single Target Alert', () => {
   beforeEach(() => {
     window.localStorage.clear();
+    vi.mocked(useHasMultiTargetBlueprints).mockReturnValue({
+      hasMultiTarget: true,
+      isLoading: false,
+    });
   });
 
   test('renders with title and body', async () => {
@@ -74,6 +83,32 @@ describe('Single Target Alert', () => {
 
   test('does not render when previously dismissed via localStorage', () => {
     window.localStorage.setItem(STORAGE_KEY, 'true');
+
+    render(<SingleTargetAlert />);
+
+    expect(
+      screen.queryByTestId('single-target-migration-banner'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not render when no multi-target blueprints exist', () => {
+    vi.mocked(useHasMultiTargetBlueprints).mockReturnValue({
+      hasMultiTarget: false,
+      isLoading: false,
+    });
+
+    render(<SingleTargetAlert />);
+
+    expect(
+      screen.queryByTestId('single-target-migration-banner'),
+    ).not.toBeInTheDocument();
+  });
+
+  test('does not render while loading', () => {
+    vi.mocked(useHasMultiTargetBlueprints).mockReturnValue({
+      hasMultiTarget: false,
+      isLoading: true,
+    });
 
     render(<SingleTargetAlert />);
 

--- a/src/Components/LandingPage/useHasMultiTargetBlueprints.ts
+++ b/src/Components/LandingPage/useHasMultiTargetBlueprints.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react';
+
+import {
+  useGetBlueprintsQuery,
+  useLazyGetBlueprintQuery,
+} from '@/store/api/backend';
+
+const useHasMultiTargetBlueprints = () => {
+  const { data: blueprintsData, isLoading: isListLoading } =
+    useGetBlueprintsQuery({ limit: 100, offset: 0 });
+  const [triggerGetBlueprint] = useLazyGetBlueprintQuery();
+
+  const [hasMultiTarget, setHasMultiTarget] = useState(false);
+  const [isCheckingDetails, setIsCheckingDetails] = useState(true);
+
+  useEffect(() => {
+    if (isListLoading || !blueprintsData?.data) return;
+
+    if (blueprintsData.data.length === 0) {
+      setIsCheckingDetails(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    const check = async () => {
+      try {
+        for (const bp of blueprintsData.data) {
+          if (cancelled) return;
+          const result = await triggerGetBlueprint(
+            { id: bp.id },
+            true,
+          ).unwrap();
+          if (result.image_requests.length > 1) {
+            setHasMultiTarget(true);
+            return;
+          }
+        }
+      } catch {
+        // fail closed — hide the banner if we can't fetch blueprints
+      } finally {
+        if (!cancelled) {
+          setIsCheckingDetails(false);
+        }
+      }
+    };
+
+    check();
+    return () => {
+      cancelled = true;
+    };
+  }, [blueprintsData, isListLoading, triggerGetBlueprint]);
+
+  return { hasMultiTarget, isLoading: isListLoading || isCheckingDetails };
+};
+
+export default useHasMultiTargetBlueprints;

--- a/src/Utilities/useGetEnvironment.ts
+++ b/src/Utilities/useGetEnvironment.ts
@@ -39,8 +39,6 @@ export const useFlagWithEphemDefault = (
 
 const onPremFlag = (flag: string): boolean => {
   switch (flag) {
-    case 'image-builder.single-target-migration':
-      return true;
     case 'image-builder.images-table-revamp.enabled':
     default:
       return false;

--- a/src/store/api/backend/index.ts
+++ b/src/store/api/backend/index.ts
@@ -31,6 +31,10 @@ export const useGetBlueprintsQuery = process.env.IS_ON_PREMISE
   ? composerQueries.useGetBlueprintsQuery
   : serviceQueries.useGetBlueprintsQuery;
 
+export const useLazyGetBlueprintQuery = process.env.IS_ON_PREMISE
+  ? composerQueries.useLazyGetBlueprintQuery
+  : serviceQueries.useLazyGetBlueprintQuery;
+
 export const useLazyGetBlueprintsQuery = process.env.IS_ON_PREMISE
   ? composerQueries.useLazyGetBlueprintsQuery
   : serviceQueries.useLazyGetBlueprintsQuery;

--- a/src/store/api/backend/onprem/composerApi/index.ts
+++ b/src/store/api/backend/onprem/composerApi/index.ts
@@ -29,6 +29,7 @@ export const {
   useGetDistributionsQuery,
   useGetBlueprintQuery,
   useGetBlueprintsQuery,
+  useLazyGetBlueprintQuery,
   useLazyGetBlueprintsQuery,
   useCreateBlueprintMutation,
   useUpdateBlueprintMutation,


### PR DESCRIPTION
Shows the banner with the single target migration announcement only to users who have created a blueprint with multiple targets.
<img width="1520" height="794" alt="mt" src="https://github.com/user-attachments/assets/437d33b4-ae47-4f71-8a2f-a05ccb7c0992" />

