### PR TITLE
Clean up redux deps (HMS-11143)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "react-dom": "18.3.1",
         "react-redux": "9.3.0",
         "react-router-dom": "6.30.4",
-        "redux": "5.0.1",
         "redux-promise-middleware": "6.2.0",
         "smol-toml": "1.7.1",
         "uuid": "14.0.1"
@@ -56,7 +55,6 @@
         "@types/node": "25.9.2",
         "@types/react": "18.3.27",
         "@types/react-dom": "18.3.7",
-        "@types/react-redux": "7.1.34",
         "@vitejs/plugin-react": "6.0.4",
         "@vitest/coverage-istanbul": "4.1.10",
         "babel-loader": "10.1.1",
@@ -6462,19 +6460,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/html-minifier-terser": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -6581,29 +6566,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
-      }
-    },
-    "node_modules/@types/react-redux": {
-      "version": "7.1.34",
-      "resolved": "https://registry.npmjs.org/@types/react-redux/-/react-redux-7.1.34.tgz",
-      "integrity": "sha512-GdFaVjEbYv4Fthm2ZLvj1VSCedV7TqE5y1kNwnjSdBOTXuRSgowux6J8TAct15T3CKBr63UMk+2CO7ilRhyrAQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "^3.3.0",
-        "@types/react": "*",
-        "hoist-non-react-statics": "^3.3.0",
-        "redux": "^4.0.0"
-      }
-    },
-    "node_modules/@types/react-redux/node_modules/redux": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
-      "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.9.2"
       }
     },
     "node_modules/@types/retry": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,6 @@
         "react-dom": "18.3.1",
         "react-redux": "9.3.0",
         "react-router-dom": "6.30.4",
-        "redux-promise-middleware": "6.2.0",
         "smol-toml": "1.7.1",
         "uuid": "14.0.1"
       },
@@ -17875,15 +17874,6 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
-    },
-    "node_modules/redux-promise-middleware": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.2.0.tgz",
-      "integrity": "sha512-TEzfMeLX63gju2WqkdFQlQMvUGYzFvJNePIJJsBlbPHs3Txsbc/5Rjhmtha1XdMU6lkeiIlp1Qx7AR3Zo9he9g==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
-      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "react-dom": "18.3.1",
     "react-redux": "9.3.0",
     "react-router-dom": "6.30.4",
-    "redux": "5.0.1",
     "redux-promise-middleware": "6.2.0",
     "smol-toml": "1.7.1",
     "uuid": "14.0.1"
@@ -54,7 +53,6 @@
     "@types/node": "25.9.2",
     "@types/react": "18.3.27",
     "@types/react-dom": "18.3.7",
-    "@types/react-redux": "7.1.34",
     "@vitejs/plugin-react": "6.0.4",
     "@vitest/coverage-istanbul": "4.1.10",
     "babel-loader": "10.1.1",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "react-dom": "18.3.1",
     "react-redux": "9.3.0",
     "react-router-dom": "6.30.4",
-    "redux-promise-middleware": "6.2.0",
     "smol-toml": "1.7.1",
     "uuid": "14.0.1"
   },

--- a/src/Components/CreateImageWizard/LabelInput.tsx
+++ b/src/Components/CreateImageWizard/LabelInput.tsx
@@ -13,7 +13,7 @@ import {
   Truncate,
 } from '@patternfly/react-core/dist/esm';
 import { PlusCircleIcon } from '@patternfly/react-icons';
-import { UnknownAction } from 'redux';
+import { UnknownAction } from '@reduxjs/toolkit';
 
 import { StepValidation } from './utilities/useValidation';
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,5 +1,4 @@
 import { combineReducers, configureStore } from '@reduxjs/toolkit';
-import promiseMiddleware from 'redux-promise-middleware';
 
 import {
   complianceApi,
@@ -51,7 +50,6 @@ export const serviceMiddleware = (getDefaultMiddleware: Function) =>
   getDefaultMiddleware()
     .prepend(listenerMiddleware.middleware)
     .concat(
-      promiseMiddleware,
       contentSourcesApi.middleware,
       imageBuilderApi.middleware,
       rhsmApi.middleware,
@@ -63,7 +61,6 @@ export const serviceMiddleware = (getDefaultMiddleware: Function) =>
 // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
 export const onPremMiddleware = (getDefaultMiddleware: Function) =>
   getDefaultMiddleware().prepend(listenerMiddleware.middleware).concat(
-    promiseMiddleware,
     // TODO: add other endpoints so we can remove this.
     // It's still needed to get things to work.
     contentSourcesApi.middleware,


### PR DESCRIPTION
`@reduxjs/toolkit` has redux in its required deps, so `redux` stays in node_modules as a transitive dep, but we don't need it as a direct dependency.

`@types/react-redux` is redundant since `react-redux` v8 which started shipping its own types. Could also conflict with the `react-redux` types so might be better to remove it.

`redux-promise-middleware` is probably a leftover from before the migration to RTK query. Nothing in the code base dispatches promise-based actions. RTK query completely replaced the pattern.

JIRA: [HMS-11143](https://issues.redhat.com/browse/HMS-11143)

[HMS-11143]: https://redhat.atlassian.net/browse/HMS-11143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ