### PR TITLE
deps: Remove uuid (HMS-11145)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,7 @@
         "react-dom": "18.3.1",
         "react-redux": "9.3.0",
         "react-router-dom": "6.30.4",
-        "smol-toml": "1.7.1",
-        "uuid": "14.0.1"
+        "smol-toml": "1.7.1"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
@@ -21075,19 +21074,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
-      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "license": "MIT",
-      "bin": {
-        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {

--- a/package.json
+++ b/package.json
@@ -29,8 +29,7 @@
     "react-dom": "18.3.1",
     "react-redux": "9.3.0",
     "react-router-dom": "6.30.4",
-    "smol-toml": "1.7.1",
-    "uuid": "14.0.1"
+    "smol-toml": "1.7.1"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",

--- a/playwright/Basic/basic.spec.ts
+++ b/playwright/Basic/basic.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
@@ -18,7 +17,7 @@ import {
 } from '../helpers/wizardHelpers';
 
 test('Basic create/build/delete test', async ({ page, cleanup }) => {
-  const blueprintName = uuidv4();
+  const blueprintName = crypto.randomUUID();
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
@@ -85,7 +84,7 @@ test('Basic create/build/delete test', async ({ page, cleanup }) => {
 });
 
 test('Basic delete BP tests', async ({ page }) => {
-  const blueprintName = uuidv4();
+  const blueprintName = crypto.randomUUID();
 
   await ensureAuthenticated(page);
 

--- a/playwright/Basic/blueprintUrlParam.spec.ts
+++ b/playwright/Basic/blueprintUrlParam.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { getBlueprintIdByName } from '../helpers/apiHelpers';
@@ -24,7 +23,7 @@ test('Navigate with valid blueprint_id URL parameter', async ({
 }) => {
   test.skip(!isHosted(), 'Hosted only');
 
-  const blueprintName = uuidv4();
+  const blueprintName = crypto.randomUUID();
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);

--- a/playwright/Basic/imageMode.spec.ts
+++ b/playwright/Basic/imageMode.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
@@ -22,7 +21,7 @@ test('Image mode blueprint create, edit, export, import', async ({
 }) => {
   test.skip(!isHosted(), 'Image mode on hosted only');
 
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);

--- a/playwright/BootTests/AAP/AAP.boot.ts
+++ b/playwright/BootTests/AAP/AAP.boot.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../../fixtures/customizations';
 import { isHosted } from '../../helpers/helpers';
@@ -66,7 +65,7 @@ test('AAP registration boot integration test', async ({ page, cleanup }) => {
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',
   );
-  const blueprintName = 'aap-test-' + uuidv4();
+  const blueprintName = 'aap-test-' + crypto.randomUUID();
   const filePath = constructFilePath(blueprintName, 'qcow2');
 
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceCIS.boot.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { deleteCompliancePolicy, navigateToCompliance } from './helpers';
 
@@ -34,8 +33,8 @@ test('Compliance step integration test - CIS', async ({ page, cleanup }) => {
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',
   );
-  const blueprintName = 'compliance-cis-test-' + uuidv4();
-  const policyName = 'test-policy-' + uuidv4();
+  const blueprintName = 'compliance-cis-test-' + crypto.randomUUID();
+  const policyName = 'test-policy-' + crypto.randomUUID();
   const policyType =
     'CIS Red Hat Enterprise Linux 10 Benchmark for Level 2 - Workstation';
   const filePath = constructFilePath(blueprintName, 'qcow2');

--- a/playwright/BootTests/Compliance/ComplianceOpenSCAP.boot.ts
+++ b/playwright/BootTests/Compliance/ComplianceOpenSCAP.boot.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../../fixtures/customizations';
 import { isHosted } from '../../helpers/helpers';
@@ -33,7 +32,7 @@ test('Compliance step integration test - OpenSCAP default profile', async ({
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',
   );
-  const blueprintName = 'compliance-oscap-test-' + uuidv4();
+  const blueprintName = 'compliance-oscap-test-' + crypto.randomUUID();
   const filePath = constructFilePath(blueprintName, 'qcow2');
 
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentNonRepeatable.boot.ts
@@ -1,6 +1,5 @@
 /* eslint-disable playwright/no-wait-for-timeout */
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { deleteRepository, navigateToRepositories } from './helpers';
 
@@ -34,9 +33,10 @@ test('Content integration test - Non repeatable build - URL source', async ({
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',
   );
-  const blueprintName = 'content-non-repeatable-test-' + uuidv4();
+  const blueprintName = 'content-non-repeatable-test-' + crypto.randomUUID();
   const filePath = constructFilePath(blueprintName, 'qcow2');
-  const repositoryName = 'content-non-repeatable-test-' + uuidv4().slice(0, 8);
+  const repositoryName =
+    'content-non-repeatable-test-' + crypto.randomUUID().slice(0, 8);
   const repositoryUrl =
     'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata/';
   const packageName = 'cockateel';
@@ -152,9 +152,10 @@ test('Content integration test - Non repeatable build - Upload source', async ({
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',
   );
-  const blueprintName = 'content-non-repeatable-test-' + uuidv4();
+  const blueprintName = 'content-non-repeatable-test-' + crypto.randomUUID();
   const filePath = constructFilePath(blueprintName, 'qcow2');
-  const repositoryName = 'content-non-repeatable-test-' + uuidv4().slice(0, 8);
+  const repositoryName =
+    'content-non-repeatable-test-' + crypto.randomUUID().slice(0, 8);
   const packageName = 'cockateel';
   const dependencyPackageName = 'wolf';
 
@@ -311,7 +312,7 @@ test('Content integration test - Non repeatable build - Community repository', a
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',
   );
-  const blueprintName = 'content-non-repeatable-test-' + uuidv4();
+  const blueprintName = 'content-non-repeatable-test-' + crypto.randomUUID();
   const filePath = constructFilePath(blueprintName, 'qcow2');
   const repositoryName = 'EPEL 10 Everything x86_64';
   const packageName = 'aha';

--- a/playwright/BootTests/Content/ContentRepeatable.boot.ts
+++ b/playwright/BootTests/Content/ContentRepeatable.boot.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { deleteRepository, navigateToRepositories } from './helpers';
 
@@ -33,9 +32,10 @@ test('Content integration test - Repeatable build - URL source', async ({
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',
   );
-  const blueprintName = 'content-repeatable-test-' + uuidv4();
+  const blueprintName = 'content-repeatable-test-' + crypto.randomUUID();
   const filePath = constructFilePath(blueprintName, 'qcow2');
-  const repositoryName = 'content-repeatable-test-' + uuidv4().slice(0, 8);
+  const repositoryName =
+    'content-repeatable-test-' + crypto.randomUUID().slice(0, 8);
   const initialRepositoryUrl =
     'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata-multi/1/';
   const updatedRepositoryUrl =

--- a/playwright/BootTests/Content/ContentTemplate.boot.ts
+++ b/playwright/BootTests/Content/ContentTemplate.boot.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import {
   deleteRepository,
@@ -41,11 +40,13 @@ test('Content integration test - Content Template', async ({
     'Skipping test. Boot tests run only on the hosted service.',
   );
 
-  const blueprintName = 'content-template-test-' + uuidv4();
+  const blueprintName = 'content-template-test-' + crypto.randomUUID();
   const filePath = constructFilePath(blueprintName, 'qcow2');
-  const repositoryName = 'content-template-test-' + uuidv4().slice(0, 8);
-  const templateName = 'content-template-test-' + uuidv4().slice(0, 8);
-  const hostname = 'content-template-test-' + uuidv4().slice(0, 8);
+  const repositoryName =
+    'content-template-test-' + crypto.randomUUID().slice(0, 8);
+  const templateName =
+    'content-template-test-' + crypto.randomUUID().slice(0, 8);
+  const hostname = 'content-template-test-' + crypto.randomUUID().slice(0, 8);
   const repositoryUrl =
     'https://jlsherrill.fedorapeople.org/fake-repos/needed-errata-multi/2/';
   const packageName = 'cockateel';

--- a/playwright/BootTests/ImageMode/ImageMode.boot.ts
+++ b/playwright/BootTests/ImageMode/ImageMode.boot.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../../fixtures/customizations';
 import { isHosted } from '../../helpers/helpers';
@@ -22,7 +21,7 @@ test('Image mode boot integration test', async ({ page, cleanup }) => {
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',
   );
-  const blueprintName = 'image-mode-test-' + uuidv4();
+  const blueprintName = 'image-mode-test-' + crypto.randomUUID();
   const filePath = constructFilePath(blueprintName, 'qcow2');
 
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/BootTests/Satellite/Satellite.boot.ts
+++ b/playwright/BootTests/Satellite/Satellite.boot.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import {
   registrationCurlCommand,
@@ -35,7 +34,7 @@ test('Satellite registration boot integration test', async ({
     !isHosted(),
     'Skipping test. Boot test run only on the hosted service.',
   );
-  const blueprintName = 'satellite-test-' + uuidv4();
+  const blueprintName = 'satellite-test-' + crypto.randomUUID();
   const filePath = constructFilePath(blueprintName, 'qcow2');
 
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/Cockpit/cockpit.spec.ts
+++ b/playwright/Cockpit/cockpit.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
@@ -85,7 +84,7 @@ test('Cockpit AWS cloud upload', async ({ page, cleanup }) => {
     await frame.getByRole('button', { name: 'Cancel' }).click();
   });
 
-  const blueprintName = uuidv4();
+  const blueprintName = crypto.randomUUID();
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await test.step('Cockpit cloud upload', async () => {

--- a/playwright/Customizations/AAP.spec.ts
+++ b/playwright/Customizations/AAP.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
@@ -55,7 +54,7 @@ test('Create a blueprint with AAP registration customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Skip entirely in Cockpit/on-premise where AAP customization is unavailable
   test.skip(!isHosted(), 'AAP customization is not available in the plugin');

--- a/playwright/Customizations/Compliance.spec.ts
+++ b/playwright/Customizations/Compliance.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import {
   createCompliancePolicy,
@@ -44,7 +43,7 @@ test('Create a blueprint with Compliance policy selected', async ({
     );
   });
 
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));
@@ -115,8 +114,8 @@ test('Compliance alerts - lint warnings display', async ({ page, cleanup }) => {
   // TODO: Re-enable once compliance is working again
   test.skip(true, 'Compliance tests are temporarily disabled.');
   test.skip(!isHosted(), 'Compliance alerts are not available in the plugin');
-  const blueprintName = 'test-compliance-' + uuidv4();
-  const policyName = 'test-policy-' + uuidv4();
+  const blueprintName = 'test-compliance-' + crypto.randomUUID();
+  const policyName = 'test-policy-' + crypto.randomUUID();
   const policyType =
     'Centro Criptológico Nacional (CCN) - STIC for Red Hat Enterprise Linux 9 - Intermediate';
 

--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { exportedDiskBP } from '../fixtures/data/exportBlueprintContents';
@@ -28,7 +27,7 @@ test('Create a blueprint with Disk customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/Customizations/Filesystem.spec.ts
+++ b/playwright/Customizations/Filesystem.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { exportedFilesystemBP } from '../fixtures/data/exportBlueprintContents';
@@ -28,7 +27,7 @@ test('Create a blueprint with Filesystem customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));
@@ -252,7 +251,7 @@ test('Filesystem configuration is hidden for ISO target only', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
@@ -290,7 +289,7 @@ test('Filesystem configuration is available for ISO and other target', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);

--- a/playwright/Customizations/FipsMode.spec.ts
+++ b/playwright/Customizations/FipsMode.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isServiceAvailable } from '../helpers/apiHelpers';
@@ -33,7 +32,7 @@ test('FIPS switch toggles and persists through save', async ({
     );
   });
 
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { exportedFirewallBP } from '../fixtures/data/exportBlueprintContents';
@@ -28,7 +27,7 @@ test('Create a blueprint with Firewall customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));
@@ -245,7 +244,7 @@ test('Firewall fields collapse chips with show less / more', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 

--- a/playwright/Customizations/FirstBoot.spec.ts
+++ b/playwright/Customizations/FirstBoot.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
@@ -26,7 +25,7 @@ test('Create a blueprint with First boot customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
   const scriptContent = '#!/bin/bash\necho "Hello, World!"';
   const editedScriptContent = '#!/bin/bash\necho "Edited script"';
 

--- a/playwright/Customizations/Hostname.spec.ts
+++ b/playwright/Customizations/Hostname.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { exportedHostnameBP } from '../fixtures/data/exportBlueprintContents';
@@ -28,7 +27,7 @@ test('Create a blueprint with Hostname customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
   const hostname = 'testsystem';
 
   // Delete the blueprint after the run fixture

--- a/playwright/Customizations/Kernel.spec.ts
+++ b/playwright/Customizations/Kernel.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { exportedKernelBP } from '../fixtures/data/exportBlueprintContents';
@@ -28,7 +27,7 @@ test('Create a blueprint with Kernel customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/Customizations/Locale.spec.ts
+++ b/playwright/Customizations/Locale.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { exportedLocaleBP } from '../fixtures/data/exportBlueprintContents';
@@ -28,7 +27,7 @@ test('Create a blueprint with Locale customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
@@ -28,7 +27,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
 }) => {
   test.skip(!isHosted(), 'OpenSCAP is not available in the plugin');
 
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 

--- a/playwright/Customizations/Packages.spec.ts
+++ b/playwright/Customizations/Packages.spec.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 
 import { expect } from '@playwright/test';
 import { exportedPackagesBP } from 'playwright/fixtures/data/exportBlueprintContents';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { isHosted } from '../helpers/helpers';
@@ -28,7 +27,7 @@ test('Create a blueprint with Packages customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { isRhel } from '../../src/store/slices/wizard';
 import { test } from '../fixtures/customizations';
@@ -158,7 +157,7 @@ registrationModes.forEach(
           );
         }
 
-        const blueprintName = `test-${name}-${uuidv4()}`;
+        const blueprintName = `test-${name}-${crypto.randomUUID()}`;
 
         // Delete the blueprint after the run fixture
         cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/Customizations/RepeatableBuild.spec.ts
+++ b/playwright/Customizations/RepeatableBuild.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { ensureRepositoryExists } from '../helpers/apiHelpers';
@@ -29,7 +28,7 @@ test('Create a blueprint with Repeatable build customization', async ({
 }) => {
   test.skip(!isHosted(), 'Repeatable build is not available in the plugin');
 
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
   const repositoryName = 'image-builder-ci-repeatable-no-snapshot';
   const repositoryUrl =
     'https://jlsherrill.fedorapeople.org/fake-repos/really-empty/';

--- a/playwright/Customizations/Repositories.spec.ts
+++ b/playwright/Customizations/Repositories.spec.ts
@@ -1,5 +1,4 @@
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import {
@@ -34,8 +33,8 @@ test('Create blueprint with repository and test edit mode removal', async ({
     'Repositories require content-sources API (hosted only)',
   );
 
-  const blueprintName = 'repo-test-' + uuidv4();
-  const repositoryName = 'repo-test-' + uuidv4().slice(0, 8);
+  const blueprintName = 'repo-test-' + crypto.randomUUID();
+  const repositoryName = 'repo-test-' + crypto.randomUUID().slice(0, 8);
 
   await ensureAuthenticated(page);
 

--- a/playwright/Customizations/Systemd.spec.ts
+++ b/playwright/Customizations/Systemd.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { exportedSystemdBP } from '../fixtures/data/exportBlueprintContents';
@@ -28,7 +27,7 @@ test('Create a blueprint with Systemd customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/Customizations/TargetEnvironments/Azure.spec.ts
+++ b/playwright/Customizations/TargetEnvironments/Azure.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from '@playwright/test';
 import { selectTarget } from 'playwright/helpers/targetChooser';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../../fixtures/customizations';
 import { isHosted } from '../../helpers/helpers';
@@ -21,7 +20,7 @@ const RESOURCE_GROUP = 'testResourceGroup';
 test('Create a blueprint with Azure target', async ({ page, cleanup }) => {
   test.skip(!isHosted(), 'Azure target is only available on hosted service');
 
-  const blueprintName = 'test-azure-' + uuidv4();
+  const blueprintName = 'test-azure-' + crypto.randomUUID();
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);
@@ -140,7 +139,7 @@ test('Deselecting Azure removes its config from the blueprint', async ({
 }) => {
   test.skip(!isHosted(), 'Azure target is only available on hosted service');
 
-  const blueprintName = 'test-azure-deselect-' + uuidv4();
+  const blueprintName = 'test-azure-deselect-' + crypto.randomUUID();
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 
   await ensureAuthenticated(page);

--- a/playwright/Customizations/Timezone.spec.ts
+++ b/playwright/Customizations/Timezone.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { exportedTimezoneBP } from '../fixtures/data/exportBlueprintContents';
@@ -28,7 +27,7 @@ test('Create a blueprint with Timezone customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/Customizations/UsersAndGroups.spec.ts
+++ b/playwright/Customizations/UsersAndGroups.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import {
@@ -36,7 +35,7 @@ test('Create a blueprint with Users customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));
@@ -564,7 +563,7 @@ test('Create a blueprint with Groups customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   cleanup.add(() => deleteBlueprint(page, blueprintName));
 

--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -2,7 +2,6 @@ import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
 import { expect } from '@playwright/test';
-import { v4 as uuidv4 } from 'uuid';
 
 import { test } from '../fixtures/customizations';
 import { IMPORT_WITH_DUPLICATE_VALUES } from '../fixtures/data/importFileContents';
@@ -21,7 +20,7 @@ test('Import a blueprint with invalid customization', async ({
   page,
   cleanup,
 }) => {
-  const blueprintName = 'test-' + uuidv4();
+  const blueprintName = 'test-' + crypto.randomUUID();
 
   // Delete the blueprint after the run fixture
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/AdvancedPartitioning.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/AdvancedPartitioning.tsx
@@ -13,7 +13,6 @@ import {
   SelectOption,
 } from '@patternfly/react-core';
 import { AddCircleOIcon } from '@patternfly/react-icons';
-import { v4 as uuidv4 } from 'uuid';
 
 import { useFilesystemValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
 import { ValidatedInputAndTextArea } from '@/Components/CreateImageWizard/ValidatedInput';
@@ -46,7 +45,7 @@ const AdvancedPartitioning = () => {
   const stepValidation = useFilesystemValidation();
   const [isOpen, setIsOpen] = useState(false);
   const handleAddPartition = () => {
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const mountpoint = getNextAvailableMountpoint(
       filesystemPartitions,
       diskPartitions,

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemConfiguration.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import { Button, Content } from '@patternfly/react-core';
 import { AddCircleOIcon } from '@patternfly/react-icons';
-import { v4 as uuidv4 } from 'uuid';
 
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
@@ -25,7 +24,7 @@ const FileSystemConfiguration = () => {
   const dispatch = useAppDispatch();
 
   const handleAddPartition = () => {
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const mountpoint = getNextAvailableMountpoint(
       filesystemPartitions,
       diskPartitions,

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/VolumeGroups.tsx
@@ -9,7 +9,6 @@ import {
   FormGroup,
 } from '@patternfly/react-core';
 import { AddCircleOIcon } from '@patternfly/react-icons';
-import { v4 as uuidv4 } from 'uuid';
 
 import { useFilesystemValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
 import { ValidatedInputAndTextArea } from '@/Components/CreateImageWizard/ValidatedInput';
@@ -54,8 +53,8 @@ const VolumeGroups = ({ volumeGroups }: VolumeGroupsType) => {
     setIsExpanded(isExpanded);
 
     if (isExpanded && !vg) {
-      const vgId = uuidv4();
-      const lvId = uuidv4();
+      const vgId = crypto.randomUUID();
+      const lvId = crypto.randomUUID();
       const mountpoint = getNextAvailableMountpoint(
         filesystemPartitions,
         diskPartitions,
@@ -86,7 +85,7 @@ const VolumeGroups = ({ volumeGroups }: VolumeGroupsType) => {
   };
 
   const handleAddLogicalVolume = (vgId: string) => {
-    const id = uuidv4();
+    const id = crypto.randomUUID();
     const mountpoint = getNextAvailableMountpoint(
       filesystemPartitions,
       diskPartitions,

--- a/src/Components/CreateImageWizard/steps/Oscap/components/useSelectorHandlers.tsx
+++ b/src/Components/CreateImageWizard/steps/Oscap/components/useSelectorHandlers.tsx
@@ -1,5 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { FIRST_BOOT_SERVICE } from '@/constants';
 import { Filesystem, Services } from '@/store/api/backend';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
@@ -68,7 +66,7 @@ export const useSelectorHandlers = () => {
         mountpoint: filesystem.mountpoint,
         min_size: size.toString(),
         unit: unit as Units,
-        id: uuidv4(),
+        id: crypto.randomUUID(),
       };
       return partition;
     });

--- a/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/ActivationKeysList.tsx
@@ -20,7 +20,6 @@ import {
 } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
-import { v4 as uuidv4 } from 'uuid';
 
 import ExternalLinkButton from '@/Components/CreateImageWizard/utilities/ExternalLinkButton';
 import { useRegistrationValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
@@ -56,7 +55,7 @@ const ActivationKeysList = ({ onErrorChange }: RegistrationProps) => {
   const forceShowErrors = useAppSelector(selectForceShowErrors);
   const stepValidation = useRegistrationValidation();
 
-  const defaultActivationKeyName = uuidv4();
+  const defaultActivationKeyName = crypto.randomUUID();
 
   const { isProd } = useGetEnvironment();
   const [isOpen, setIsOpen] = useState(false);

--- a/src/Hooks/Utilities/useEffectiveBlueprintId.tsx
+++ b/src/Hooks/Utilities/useEffectiveBlueprintId.tsx
@@ -2,7 +2,6 @@ import { useEffect, useRef } from 'react';
 
 import { useDispatch } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
-import { validate as uuidValidate } from 'uuid';
 
 import { useAppSelector } from '@/store/hooks';
 import {
@@ -16,8 +15,12 @@ export const useEffectiveBlueprintId = (): string | undefined => {
 
   const [searchParams] = useSearchParams();
   const blueprintIdParam = searchParams.get('blueprint_id')?.trim();
+
+  const uuidRegex =
+    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/i;
+
   const validBlueprintIdParam =
-    blueprintIdParam && uuidValidate(blueprintIdParam)
+    blueprintIdParam && uuidRegex.test(blueprintIdParam)
       ? blueprintIdParam
       : undefined;
 

--- a/src/store/api/backend/onprem/composerApi/blueprints.ts
+++ b/src/store/api/backend/onprem/composerApi/blueprints.ts
@@ -2,7 +2,6 @@ import path from 'path';
 
 import cockpit from 'cockpit';
 import { fsinfo } from 'cockpit/fsinfo';
-import { v4 as uuidv4 } from 'uuid';
 
 import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 
@@ -138,7 +137,7 @@ export const blueprintEndpoints = (builder: OnPremBuilder) => ({
   >({
     queryFn: onPremQueryHandler(
       async ({ queryArgs: { createBlueprintRequest: blueprintReq } }) => {
-        const id = uuidv4();
+        const id = crypto.randomUUID();
         const blueprintsDir = await getBlueprintsPath();
         await cockpit.spawn(['mkdir', '-p', path.join(blueprintsDir, id)], {});
         await cockpit

--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -2,22 +2,21 @@ import path from 'path';
 
 import cockpit from 'cockpit';
 import { fsinfo } from 'cockpit/fsinfo';
-import { v4 as uuidv4 } from 'uuid';
 
 import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 
 import {
   byCreatedAtDesc,
   getBlueprintsPath,
+  getHostDistro,
   getUploadArgs,
   imageStatusFallback,
   imageStatusFromBuildlog,
+  mapHostedToOnPrem,
   progressFromFile,
   readComposes,
   safeReadJsonFile,
   uploadStatusFromFile,
-  getHostDistro,
-  mapHostedToOnPrem,
 } from './helpers';
 
 import {
@@ -68,7 +67,7 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
         const bpOnPrem = mapHostedToOnPrem(parsed as CreateBlueprintRequest);
         const hostDistro = await getHostDistro();
         const user = await cockpit.user();
-        const id = uuidv4();
+        const id = crypto.randomUUID();
         const { runArgs, ibArgs } = await getUploadArgs(
           ir.upload_request.type,
           id,

--- a/src/store/slices/wizard/filesystem/slice.ts
+++ b/src/store/slices/wizard/filesystem/slice.ts
@@ -1,5 +1,4 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
-import { v4 as uuidv4 } from 'uuid';
 
 import { LogicalVolume } from '@/store/api/backend';
 
@@ -40,7 +39,7 @@ export const filesystemSlice = createSlice({
           case 'basic':
             state.fileSystem.partitions = [
               {
-                id: uuidv4(),
+                id: crypto.randomUUID(),
                 mountpoint: '/',
                 min_size: '10',
                 unit: 'GiB',
@@ -50,7 +49,7 @@ export const filesystemSlice = createSlice({
           case 'advanced':
             state.disk.partitions = [
               {
-                id: uuidv4(),
+                id: crypto.randomUUID(),
                 mountpoint: '/',
                 fs_type: 'xfs',
                 min_size: '10',
@@ -68,7 +67,7 @@ export const filesystemSlice = createSlice({
       if (currentMode === 'basic') {
         state.fileSystem.partitions = [
           {
-            id: uuidv4(),
+            id: crypto.randomUUID(),
             mountpoint: '/',
             min_size: '10',
             unit: 'GiB',

--- a/src/store/slices/wizard/filesystem/utilities.ts
+++ b/src/store/slices/wizard/filesystem/utilities.ts
@@ -1,6 +1,5 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { UNIT_GIB, UNIT_MIB } from '@/constants';
+
 import {
   BtrfsVolume,
   Filesystem,
@@ -148,7 +147,7 @@ export const getNextAvailableMountpoint = (
 export const convertFilesystemToPartition = (
   filesystem: Filesystem,
 ): FilesystemPartition => {
-  const id = uuidv4();
+  const id = crypto.randomUUID();
   const [size, unit] = parseSizeUnit(filesystem.min_size);
   const partition = {
     mountpoint: filesystem.mountpoint,
@@ -162,7 +161,7 @@ export const convertFilesystemToPartition = (
 export const convertDiskToFscDisk = (
   disk: FilesystemTyped | VolumeGroup | BtrfsVolume,
 ): DiskPartition => {
-  const id = uuidv4();
+  const id = crypto.randomUUID();
   let size;
   let unit;
 
@@ -204,7 +203,7 @@ export const convertDiskToFscDisk = (
 };
 
 export const convertLogicalVolume = (volume: LogicalVolume) => {
-  const id = uuidv4();
+  const id = crypto.randomUUID();
   let size;
   let unit;
 


### PR DESCRIPTION
This replaces `uuid` dependency with crypto.randomUUID() that is available natively. Meaning we can drop another third-party package and don't have to maintain it.

JIRA: [HMS-11145](https://issues.redhat.com/browse/HMS-11145)

[HMS-11145]: https://redhat.atlassian.net/browse/HMS-11145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ