### PR TITLE
Image mode subs

### DIFF
--- a/schutzbot/playwright_tests.sh
+++ b/schutzbot/playwright_tests.sh
@@ -72,15 +72,17 @@ fi
 # download all of the repository metadata, which takes longer than playwright's
 # action timeout. this has to run after the repository override above so that
 # the cache is populated from the nightly repositories.
+#
+# --distro is intentionally not passed, matching the plugin: image-builder
+# falls back to the host distro including the minor version. the cache is
+# keyed by distro, so warming it for anything else would be useless.
 admin_home="$(getent passwd admin | cut -d: -f6)"
-distro="${ID}-${VERSION_ID%%.*}"
 
 if ! sudo -u admin -H image-builder pkgsearch \
         --rpmmd-cache "${admin_home}/.cache/image-builder" \
-        --distro "${distro}" \
         --arch "$(uname -m)" \
         bash >/dev/null; then
-    echo "WARNING: could not warm the rpm metadata cache for ${distro}," \
+    echo "WARNING: could not warm the rpm metadata cache," \
          "package search tests are likely to time out"
 fi
 

--- a/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/components/Registration.tsx
@@ -6,6 +6,7 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
 import {
   changeRegistrationType,
+  selectIsImageMode,
   selectRegistrationType,
 } from '@/store/slices/wizard';
 
@@ -19,6 +20,7 @@ const Registration = ({ onErrorChange }: RegistrationProps) => {
   const dispatch = useAppDispatch();
   const registrationType = useAppSelector(selectRegistrationType);
   const isOnPremise = useAppSelector(selectIsOnPremise);
+  const isImageMode = useAppSelector(selectIsImageMode);
 
   return (
     <FormGroup label='Registration method'>
@@ -88,23 +90,26 @@ const Registration = ({ onErrorChange }: RegistrationProps) => {
           }
         />
       </Content>
-      <Content className='pf-v6-u-pb-sm'>
-        <Radio
-          label='Register for a Satellite or Capsule server'
-          isChecked={registrationType === 'register-satellite'}
-          onChange={() => {
-            dispatch(changeRegistrationType('register-satellite'));
-            onErrorChange(false);
-          }}
-          id='register-satellite'
-          name='registration-type'
-          body={
-            registrationType === 'register-satellite' && (
-              <SatelliteRegistration />
-            )
-          }
-        />
-      </Content>
+      {/* Satellite registration is not supported for image mode yet */}
+      {!isImageMode && (
+        <Content className='pf-v6-u-pb-sm'>
+          <Radio
+            label='Register for a Satellite or Capsule server'
+            isChecked={registrationType === 'register-satellite'}
+            onChange={() => {
+              dispatch(changeRegistrationType('register-satellite'));
+              onErrorChange(false);
+            }}
+            id='register-satellite'
+            name='registration-type'
+            body={
+              registrationType === 'register-satellite' && (
+                <SatelliteRegistration />
+              )
+            }
+          />
+        </Content>
+      )}
       <Content className='pf-v6-u-pb-sm'>
         <Radio
           label='Register later'

--- a/src/Components/CreateImageWizard/steps/Registration/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/index.tsx
@@ -5,9 +5,10 @@ import useChrome from '@redhat-cloud-services/frontend-components/useChrome';
 
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import { useGetUser } from '@/Hooks';
+import { useCustomizationRestrictions } from '@/store/api/distributions';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
-import { changeOrgId } from '@/store/slices/wizard';
+import { changeOrgId, selectImageTypes } from '@/store/slices/wizard';
 
 import AnsibleAutomationPlatform from './components/AnsibleAutomationPlatform';
 import Registration from './components/Registration';
@@ -17,7 +18,12 @@ const RegistrationStep = () => {
   const { auth } = useChrome();
   const { orgId } = useGetUser(auth);
   const isOnPremise = useAppSelector(selectIsOnPremise);
+  const imageTypes = useAppSelector(selectImageTypes);
   const [showAlert, setShowAlert] = useState(false);
+
+  const { restrictions } = useCustomizationRestrictions({
+    selectedImageTypes: imageTypes,
+  });
 
   useEffect(() => {
     if (!isOnPremise && orgId) {
@@ -37,7 +43,7 @@ const RegistrationStep = () => {
         </Content>
       </Content>
       <Registration onErrorChange={setShowAlert} />
-      <AnsibleAutomationPlatform />
+      {!restrictions.aap.shouldHide && <AnsibleAutomationPlatform />}
       {showAlert && (
         <Alert title='Activation keys unavailable' variant='danger' isInline>
           Activation keys cannot be reached, try again later.

--- a/src/Components/CreateImageWizard/steps/Registration/tests/Registration.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Registration/tests/Registration.test.tsx
@@ -306,4 +306,55 @@ describe('Registration Component', () => {
       ).not.toBeInTheDocument();
     });
   });
+
+  describe('Image mode', () => {
+    const renderImageModeStep = () =>
+      renderRegistrationStep(
+        {
+          details: {
+            ...initialState.details,
+            blueprint: { ...initialState.details.blueprint, mode: 'image' },
+          },
+          output: {
+            ...initialState.output,
+            imageTypes: ['guest-image'],
+          },
+        },
+        { preloadedState: { env: { isOnPremise: true } } },
+      );
+
+    test('displays the subscription options', async () => {
+      renderImageModeStep();
+
+      expect(
+        await screen.findByRole('radio', {
+          name: /automatically register to red hat/i,
+        }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('textbox', { name: /activation key/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('textbox', { name: /organization id/i }),
+      ).toBeInTheDocument();
+    });
+
+    test('hides satellite and AAP registration', async () => {
+      renderImageModeStep();
+
+      expect(
+        await screen.findByRole('radio', { name: /register later/i }),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('radio', {
+          name: /register for a satellite or capsule server/i,
+        }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('checkbox', {
+          name: /register to ansible automation platform/i,
+        }),
+      ).not.toBeInTheDocument();
+    });
+  });
 });

--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -8,7 +8,6 @@ import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 import {
   byCreatedAtDesc,
   getBlueprintsPath,
-  getHostDistro,
   getRegistrationArgs,
   getUploadArgs,
   imageStatusFallback,
@@ -66,7 +65,6 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
         }
 
         const bpOnPrem = mapHostedToOnPrem(parsed as CreateBlueprintRequest);
-        const hostDistro = await getHostDistro();
         const user = await cockpit.user();
         const id = crypto.randomUUID();
         const { runArgs, ibArgs } = await getUploadArgs(
@@ -86,6 +84,10 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
           id,
         );
 
+        // The distro is intentionally not passed: image-builder falls back to
+        // the host distro, including the minor version for distros that have
+        // one (e.g. rhel-10.3). Generic aliases like `rhel-10` are not
+        // supported by the CLI.
         await cockpit.spawn(
           [
             'systemd-run',
@@ -101,8 +103,6 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
             'image-builder',
             'build',
             ir.image_type,
-            '--distro',
-            bpOnPrem.distro || hostDistro,
             '--blueprint',
             bpPath,
             '--with-buildlog',

--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -269,6 +269,9 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
               reason:
                 'image-builder process is not running and no result was found',
             };
+            // Return before the upload result check overwrites this error
+            // with the less specific "no upload result found" one.
+            return status;
           }
         }
 

--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -81,12 +81,15 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
           .file(bpPath, { superuser: 'require' })
           .replace(JSON.stringify(bpOnPrem));
 
-        const registrationArgs = await getRegistrationArgs(
-          blueprint.customizations.subscription,
-          id,
-        );
+        const { args: registrationArgs, path: regsPath } =
+          await getRegistrationArgs(blueprint.customizations.subscription, id);
 
         const bootcArgs = getBootcArgs(blueprint.bootc);
+
+        // The blueprint and registrations files are only needed while the
+        // build runs, and the latter contains the activation key, so have
+        // the unit remove them when it stops (on success or failure).
+        const cacheFiles = [bpPath, ...(regsPath ? [regsPath] : [])];
 
         // The distro is intentionally not passed: image-builder falls back to
         // the host distro, including the minor version for distros that have
@@ -103,6 +106,8 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
             '--service-type=oneshot',
             '--no-block',
             '--collect',
+            '-p',
+            `ExecStopPost=/usr/bin/rm -f ${cacheFiles.join(' ')}`,
             '--',
             'image-builder',
             'build',

--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -9,6 +9,7 @@ import {
   byCreatedAtDesc,
   getBlueprintsPath,
   getHostDistro,
+  getRegistrationArgs,
   getUploadArgs,
   imageStatusFallback,
   imageStatusFromBuildlog,
@@ -79,6 +80,12 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
         await cockpit
           .file(bpPath, { superuser: 'require' })
           .replace(JSON.stringify(bpOnPrem));
+
+        const registrationArgs = await getRegistrationArgs(
+          blueprint.customizations.subscription,
+          id,
+        );
+
         await cockpit.spawn(
           [
             'systemd-run',
@@ -107,6 +114,7 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
             'json',
             '--output-dir',
             path.join(dataDir, id),
+            ...registrationArgs,
             ...ibArgs,
           ],
           {

--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -8,6 +8,7 @@ import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 import {
   byCreatedAtDesc,
   getBlueprintsPath,
+  getBootcArgs,
   getRegistrationArgs,
   getUploadArgs,
   imageStatusFallback,
@@ -16,6 +17,7 @@ import {
   progressFromFile,
   readComposes,
   safeReadJsonFile,
+  toBackendImageType,
   uploadStatusFromFile,
 } from './helpers';
 
@@ -84,6 +86,8 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
           id,
         );
 
+        const bootcArgs = getBootcArgs(blueprint.bootc);
+
         // The distro is intentionally not passed: image-builder falls back to
         // the host distro, including the minor version for distros that have
         // one (e.g. rhel-10.3). Generic aliases like `rhel-10` are not
@@ -102,7 +106,9 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
             '--',
             'image-builder',
             'build',
-            ir.image_type,
+            // The CLI's native names (e.g. qcow2) differ from the frontend
+            // aliases, so translate them back before invoking it.
+            toBackendImageType(ir.image_type),
             '--blueprint',
             bpPath,
             '--with-buildlog',
@@ -115,6 +121,7 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
             '--output-dir',
             path.join(dataDir, id),
             ...registrationArgs,
+            ...bootcArgs,
             ...ibArgs,
           ],
           {

--- a/src/store/api/backend/onprem/composerApi/helpers/getBootcArgs.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/getBootcArgs.ts
@@ -1,0 +1,18 @@
+import type { Bootc } from '@/store/api/backend/onprem';
+
+// Image mode: the bootc container provides the OS content. The
+// CLI resolves the reference from root's local container storage,
+// where the wizard has already pulled it.
+export const getBootcArgs = (bootc: Bootc | undefined): string[] => {
+  if (!bootc) {
+    return [];
+  }
+  const args = ['--bootc-ref', bootc.reference];
+  if (bootc.build_reference) {
+    args.push('--bootc-build-ref', bootc.build_reference);
+  }
+  if (bootc.iso_payload_reference) {
+    args.push('--bootc-installer-payload-ref', bootc.iso_payload_reference);
+  }
+  return args;
+};

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -11,6 +11,7 @@ export {
   filterBootcImages,
   listPodmanImages,
   normalizeArch,
+  toBackendImageType,
   toBootcDistro,
 } from './podman';
 export { readComposes } from './readComposes';
@@ -36,3 +37,4 @@ export { progressFromFile } from './progressFromFile';
 export { uploadStatusFromFile } from './uploadStatusFromFile';
 export { imageStatusFallback } from './imageStatusFallback';
 export { getUploadArgs } from './getUploadArgs';
+export { getBootcArgs } from './getBootcArgs';

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -27,6 +27,10 @@ export type {
   SshKeyOnPrem,
   UserOnPrem,
 } from './blueprintMapper';
+export {
+  getRegistrationArgs,
+  mapSubscriptionToRegistrations,
+} from './registrations';
 export { imageStatusFromBuildlog } from './imageStatusFromBuildlog';
 export { progressFromFile } from './progressFromFile';
 export { uploadStatusFromFile } from './uploadStatusFromFile';

--- a/src/store/api/backend/onprem/composerApi/helpers/podman/filters.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podman/filters.ts
@@ -9,13 +9,24 @@ import { inferDistro } from './inferDistro';
 // The backend (osbuild-composer) uses different names for some image
 // types than the frontend. Normalize at the boundary so downstream
 // code only deals with frontend types.
-const backendToFrontendType: Record<string, string> = {
+export const backendToFrontendType: Record<string, string> = {
   qcow2: 'guest-image',
   ami: 'aws',
 };
 
 const normalizeImageType = (type: string): string =>
   backendToFrontendType[type] ?? type;
+
+// The CLI's native type names (e.g. qcow2) are the backend ones, so the
+// normalization has to be undone when invoking it. A unit test ensures
+// this stays the exact inverse of backendToFrontendType above.
+export const frontendToBackendType: Record<string, string> = {
+  'guest-image': 'qcow2',
+  aws: 'ami',
+};
+
+export const toBackendImageType = (type: string): string =>
+  frontendToBackendType[type] ?? type;
 
 // Extract numeric version from a distro string like "rhel-10" or
 // "rhel-10.3". Returns NaN for non-RHEL distros so they sort after RHEL.

--- a/src/store/api/backend/onprem/composerApi/helpers/podman/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podman/index.ts
@@ -1,6 +1,7 @@
 export {
   byDistroDescending,
   filterBootcImages,
+  toBackendImageType,
   toBootcDistro,
 } from './filters';
 export { normalizeArch } from './normalizeArch';

--- a/src/store/api/backend/onprem/composerApi/helpers/registrations.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/registrations.ts
@@ -25,12 +25,14 @@ export const mapSubscriptionToRegistrations = (
 
 // The on-prem blueprint has no subscription customization, so the
 // registration details are passed separately via `--registrations`.
+// The path is returned so the caller can clean the file up once the
+// build is done — it contains the activation key.
 export const getRegistrationArgs = async (
   subscription: Subscription | undefined,
   id: string,
-): Promise<string[]> => {
+): Promise<{ args: string[]; path: string | undefined }> => {
   if (!subscription) {
-    return [];
+    return { args: [], path: undefined };
   }
   const regsPath = path.join(
     '/var/cache/cockpit-image-builder',
@@ -39,5 +41,5 @@ export const getRegistrationArgs = async (
   await cockpit
     .file(regsPath, { superuser: 'require' })
     .replace(JSON.stringify(mapSubscriptionToRegistrations(subscription)));
-  return ['--registrations', regsPath];
+  return { args: ['--registrations', regsPath], path: regsPath };
 };

--- a/src/store/api/backend/onprem/composerApi/helpers/registrations.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/registrations.ts
@@ -1,0 +1,43 @@
+import path from 'path';
+
+import cockpit from 'cockpit';
+
+import type { Subscription } from '@/store/api/backend/hosted/imageBuilderApi';
+import type { Registrations } from '@/store/api/backend/onprem';
+
+export const mapSubscriptionToRegistrations = (
+  subscription: Subscription,
+): Registrations => ({
+  redhat: {
+    subscription: {
+      organization: String(subscription.organization),
+      activation_key: subscription['activation-key'],
+      server_url: subscription['server-url'],
+      base_url: subscription['base-url'],
+      insights: subscription.insights,
+      rhc: subscription.rhc ?? false,
+      ...(subscription.insights_client_proxy && {
+        proxy: subscription.insights_client_proxy,
+      }),
+    },
+  },
+});
+
+// The on-prem blueprint has no subscription customization, so the
+// registration details are passed separately via `--registrations`.
+export const getRegistrationArgs = async (
+  subscription: Subscription | undefined,
+  id: string,
+): Promise<string[]> => {
+  if (!subscription) {
+    return [];
+  }
+  const regsPath = path.join(
+    '/var/cache/cockpit-image-builder',
+    `cockpit-image-builder-${id}-registrations.json`,
+  );
+  await cockpit
+    .file(regsPath, { superuser: 'require' })
+    .replace(JSON.stringify(mapSubscriptionToRegistrations(subscription)));
+  return ['--registrations', regsPath];
+};

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/getBootcArgs.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/getBootcArgs.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBootcArgs } from '../getBootcArgs';
+
+describe('getBootcArgs', () => {
+  it('returns no args without a bootc section', () => {
+    expect(getBootcArgs(undefined)).toEqual([]);
+  });
+
+  it('returns the container reference arg', () => {
+    expect(getBootcArgs({ reference: 'quay.io/example/image:latest' })).toEqual(
+      ['--bootc-ref', 'quay.io/example/image:latest'],
+    );
+  });
+
+  it('includes the optional build and installer payload references', () => {
+    expect(
+      getBootcArgs({
+        reference: 'quay.io/example/image:latest',
+        build_reference: 'quay.io/example/build:latest',
+        iso_payload_reference: 'quay.io/example/payload:latest',
+      }),
+    ).toEqual([
+      '--bootc-ref',
+      'quay.io/example/image:latest',
+      '--bootc-build-ref',
+      'quay.io/example/build:latest',
+      '--bootc-installer-payload-ref',
+      'quay.io/example/payload:latest',
+    ]);
+  });
+});

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/registrations.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/registrations.test.ts
@@ -42,7 +42,10 @@ describe('mapSubscriptionToRegistrations', () => {
 
 describe('getRegistrationArgs', () => {
   it('returns no args without a subscription', async () => {
-    expect(await getRegistrationArgs(undefined, 'compose-id')).toEqual([]);
+    expect(await getRegistrationArgs(undefined, 'compose-id')).toEqual({
+      args: [],
+      path: undefined,
+    });
     expect(cockpit.file).not.toHaveBeenCalled();
   });
 
@@ -52,10 +55,10 @@ describe('getRegistrationArgs', () => {
 
     const regsPath =
       '/var/cache/cockpit-image-builder/cockpit-image-builder-compose-id-registrations.json';
-    expect(await getRegistrationArgs(subscription, 'compose-id')).toEqual([
-      '--registrations',
-      regsPath,
-    ]);
+    expect(await getRegistrationArgs(subscription, 'compose-id')).toEqual({
+      args: ['--registrations', regsPath],
+      path: regsPath,
+    });
     expect(cockpit.file).toHaveBeenCalledWith(regsPath, {
       superuser: 'require',
     });

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/registrations.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/registrations.test.ts
@@ -1,0 +1,66 @@
+import cockpit from 'cockpit';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Subscription } from '@/store/api/backend/hosted/imageBuilderApi';
+
+import {
+  getRegistrationArgs,
+  mapSubscriptionToRegistrations,
+} from '../registrations';
+
+vi.mock('cockpit', () => ({
+  default: {
+    file: vi.fn(),
+  },
+}));
+
+const subscription: Subscription = {
+  organization: 12345,
+  'activation-key': 'my-key',
+  'server-url': 'subscription.rhsm.redhat.com',
+  'base-url': 'https://cdn.redhat.com/',
+  insights: true,
+  rhc: true,
+};
+
+describe('mapSubscriptionToRegistrations', () => {
+  it('maps the subscription customization to the registrations file format', () => {
+    expect(mapSubscriptionToRegistrations(subscription)).toEqual({
+      redhat: {
+        subscription: {
+          organization: '12345',
+          activation_key: 'my-key',
+          server_url: 'subscription.rhsm.redhat.com',
+          base_url: 'https://cdn.redhat.com/',
+          insights: true,
+          rhc: true,
+        },
+      },
+    });
+  });
+});
+
+describe('getRegistrationArgs', () => {
+  it('returns no args without a subscription', async () => {
+    expect(await getRegistrationArgs(undefined, 'compose-id')).toEqual([]);
+    expect(cockpit.file).not.toHaveBeenCalled();
+  });
+
+  it('writes the registrations file and returns the CLI args', async () => {
+    const replace = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(cockpit.file).mockReturnValue({ replace } as never);
+
+    const regsPath =
+      '/var/cache/cockpit-image-builder/cockpit-image-builder-compose-id-registrations.json';
+    expect(await getRegistrationArgs(subscription, 'compose-id')).toEqual([
+      '--registrations',
+      regsPath,
+    ]);
+    expect(cockpit.file).toHaveBeenCalledWith(regsPath, {
+      superuser: 'require',
+    });
+    expect(replace).toHaveBeenCalledWith(
+      JSON.stringify(mapSubscriptionToRegistrations(subscription)),
+    );
+  });
+});

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/toBackendImageType.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/toBackendImageType.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+
+import { toBackendImageType } from '../podman';
+import {
+  backendToFrontendType,
+  frontendToBackendType,
+} from '../podman/filters';
+
+describe('toBackendImageType', () => {
+  it('maps frontend aliases back to backend type names', () => {
+    expect(toBackendImageType('guest-image')).toBe('qcow2');
+    expect(toBackendImageType('aws')).toBe('ami');
+  });
+
+  it('passes through types without an alias', () => {
+    expect(toBackendImageType('qcow2')).toBe('qcow2');
+    expect(toBackendImageType('image-installer')).toBe('image-installer');
+  });
+
+  it('keeps the two maps exact inverses of each other', () => {
+    const inverted = Object.fromEntries(
+      Object.entries(backendToFrontendType).map(([backend, frontend]) => [
+        frontend,
+        backend,
+      ]),
+    );
+
+    expect(frontendToBackendType).toEqual(inverted);
+  });
+});

--- a/src/store/api/backend/onprem/types/custom.ts
+++ b/src/store/api/backend/onprem/types/custom.ts
@@ -88,6 +88,22 @@ export type ComposerComposesResponseItem = Omit<
   };
 };
 
+// Shape of the file consumed by `image-builder build --registrations`.
+// Unlike the hosted API, the CLI expects the organization as a string.
+export type Registrations = {
+  redhat: {
+    subscription: {
+      organization: string;
+      activation_key: string;
+      server_url: string;
+      base_url: string;
+      insights: boolean;
+      rhc: boolean;
+      proxy?: string;
+    };
+  };
+};
+
 type PodmanLabels = Record<string, string | undefined> & {
   version?: string | undefined;
   name?: string | undefined;

--- a/src/store/api/contentSources/onprem/contentSourcesApi.ts
+++ b/src/store/api/contentSources/onprem/contentSourcesApi.ts
@@ -23,7 +23,6 @@ export const contentSourcesApi = emptyContentSourcesApi.injectEndpoints({
         }
 
         const result = await listPackages({
-          distribution,
           architecture,
           packages,
         });

--- a/src/store/api/contentSources/onprem/helpers.ts
+++ b/src/store/api/contentSources/onprem/helpers.ts
@@ -86,12 +86,13 @@ const cacheDir = async () => {
   return path.join(cacheDir, 'image-builder');
 };
 
+// The distro is intentionally not passed: image-builder falls back to the
+// host distro, including the minor version for distros that have one (e.g.
+// rhel-10.3). Generic aliases like `rhel-10` are not supported by the CLI.
 export const listPackages = async ({
-  distribution,
   architecture,
   packages,
 }: {
-  distribution: string;
   architecture: string;
   packages: string[];
 }) => {
@@ -102,8 +103,6 @@ export const listPackages = async ({
       'pkgsearch',
       '--rpmmd-cache',
       rpmmdCache,
-      '--distro',
-      distribution,
       '--arch',
       architecture,
       ...packages,

--- a/src/store/api/distributions/hooks.tsx
+++ b/src/store/api/distributions/hooks.tsx
@@ -111,14 +111,25 @@ export const isCustomizationSupported = (
 
   let supportedOptions = imageType?.supported_blueprint_options;
   if (ctx.isImageMode) {
-    // Image mode at most supports filesystem and users, and might not support any customization.
-    supportedOptions = supportedOptions?.filter((c) =>
-      ['filesystem', 'users'].includes(c),
-    ) ?? ['filesystem', 'users'];
+    // Image mode at most supports filesystem, users and registration, and
+    // might not support any customization. Registration is passed to
+    // image-builder via `--registrations`, which is only wired up
+    // on-premises so far — the hosted service (Lightspeed) can be enabled
+    // here later.
+    const imageModeOptions = ['filesystem', 'users'];
+    if (ctx.isOnPremise) {
+      imageModeOptions.push('registration');
+    }
+    supportedOptions =
+      supportedOptions?.filter((c) => imageModeOptions.includes(c)) ??
+      imageModeOptions;
   }
 
-  // only rhel distros support registration
+  // only rhel distros support registration; in image mode the OS comes from
+  // the selected container image (official RHEL or custom), not the
+  // distribution, so the check doesn't apply
   if (
+    !ctx.isImageMode &&
     !ctx.isRhel &&
     (customization === 'registration' || customization === 'aap')
   ) {

--- a/src/store/api/distributions/tests/hooks.test.tsx
+++ b/src/store/api/distributions/tests/hooks.test.tsx
@@ -4,6 +4,7 @@ import {
   computeImageTypeCustomizationSupport,
   computeRestrictions,
   CustomizationType,
+  DISTRO_DETAILS,
   isCustomizationSupported,
   RestrictionStrategy,
   SupportContext,
@@ -80,6 +81,44 @@ describe('useCustomizationRestrictions hook logic', () => {
       for (const customization of nonUserTypes) {
         expect(result[customization].isStandalone).toBe(false);
       }
+    });
+  });
+
+  describe('image mode registration (on-premise)', () => {
+    const onPremImageMode: SupportContext = {
+      isImageMode: true,
+      isOnPremise: true,
+      isRhel: true,
+    };
+
+    it('should show registration', () => {
+      const result = computeRestrictions({
+        imageTypes: {
+          'guest-image': DISTRO_DETAILS['guest-image'],
+          aws: DISTRO_DETAILS['aws'],
+        },
+        context: onPremImageMode,
+      });
+
+      expect(result.registration.shouldHide).toBe(false);
+    });
+
+    it('should show registration for non-RHEL custom images', () => {
+      const result = computeRestrictions({
+        imageTypes: { 'guest-image': DISTRO_DETAILS['guest-image'] },
+        context: { ...onPremImageMode, isRhel: false },
+      });
+
+      expect(result.registration.shouldHide).toBe(false);
+    });
+
+    it('should keep registration hidden in hosted image mode', () => {
+      const result = computeRestrictions({
+        imageTypes: { 'guest-image': DISTRO_DETAILS['guest-image'] },
+        context: { ...onPremImageMode, isOnPremise: false },
+      });
+
+      expect(result.registration.shouldHide).toBe(true);
     });
   });
 

--- a/src/store/middleware/listeners.ts
+++ b/src/store/middleware/listeners.ts
@@ -2,10 +2,18 @@ import { createListenerMiddleware } from '@reduxjs/toolkit';
 
 import { WizardStartListening } from './types';
 
-import { changeArchitecture, changeDistribution } from '../slices/wizard';
+import {
+  changeArchitecture,
+  changeBlueprintMode,
+  changeDistribution,
+} from '../slices/wizard';
 // export from slices/wizard/listeners rather than slices/wizard
 // this is needed to avoid circular dependencies
-import { filterImageTypes, registerLater } from '../slices/wizard/listeners';
+import {
+  clearUnsupportedRegistration,
+  filterImageTypes,
+  registerLater,
+} from '../slices/wizard/listeners';
 
 export const listenerMiddleware = createListenerMiddleware();
 
@@ -25,4 +33,9 @@ startListening({
 startListening({
   actionCreator: changeDistribution,
   effect: registerLater,
+});
+
+startListening({
+  actionCreator: changeBlueprintMode,
+  effect: clearUnsupportedRegistration,
 });

--- a/src/store/slices/wizard/listeners.ts
+++ b/src/store/slices/wizard/listeners.ts
@@ -51,6 +51,13 @@ export const registerLater: WizardListenerEffect = (_action, listenerApi) => {
   const state = listenerApi.getState();
   const distribution = selectDistribution(state);
 
+  // In image mode the distribution doesn't determine whether registration
+  // is available — selecting a custom image dispatches changeDistribution
+  // with a possibly non-RHEL distro and must not reset the registration.
+  if (selectIsImageMode(state)) {
+    return;
+  }
+
   if (process.env.IS_ON_PREMISE && !isRhel(distribution)) {
     listenerApi.dispatch(changeRegistrationType('register-later'));
   }

--- a/src/store/slices/wizard/listeners.ts
+++ b/src/store/slices/wizard/listeners.ts
@@ -9,7 +9,13 @@ import {
   selectDistribution,
   selectImageTypes,
 } from './output';
-import { changeRegistrationType } from './registration';
+import {
+  changeAapEnabled,
+  changeRegistrationType,
+  registrationState,
+  selectAapEnabled,
+  selectRegistrationType,
+} from './registration';
 
 export const filterImageTypes: WizardListenerEffect = (
   _action,
@@ -60,5 +66,27 @@ export const registerLater: WizardListenerEffect = (_action, listenerApi) => {
 
   if (process.env.IS_ON_PREMISE && !isRhel(distribution)) {
     listenerApi.dispatch(changeRegistrationType('register-later'));
+  }
+};
+
+// Satellite and Ansible Automation Platform registration are not supported
+// for image mode yet, so a selection made in package mode must not carry
+// over into the blueprint when the user switches modes.
+export const clearUnsupportedRegistration: WizardListenerEffect = (
+  _action,
+  listenerApi,
+) => {
+  const state = listenerApi.getState();
+
+  if (!selectIsImageMode(state)) {
+    return;
+  }
+
+  if (selectRegistrationType(state) === 'register-satellite') {
+    listenerApi.dispatch(changeRegistrationType(registrationState.type));
+  }
+
+  if (selectAapEnabled(state)) {
+    listenerApi.dispatch(changeAapEnabled(false));
   }
 };

--- a/src/store/slices/wizard/tests/clearUnsupportedRegistration.test.ts
+++ b/src/store/slices/wizard/tests/clearUnsupportedRegistration.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  changeAapEnabled,
+  changeRegistrationType,
+  initialState,
+  type WizardState,
+} from '@/store/slices/wizard';
+import {
+  createListenerApi,
+  createMockState,
+} from '@/store/slices/wizard/tests/mockWizardState';
+
+import { clearUnsupportedRegistration } from '../listeners';
+
+const createState = (
+  mode: 'image' | 'package',
+  registration: Partial<WizardState['registration']> = {},
+) =>
+  createMockState({
+    details: {
+      ...initialState.details,
+      blueprint: { ...initialState.details.blueprint, mode },
+    },
+    registration: { ...initialState.registration, ...registration },
+  });
+
+describe('clearUnsupportedRegistration', () => {
+  it('resets satellite registration when switching to image mode', () => {
+    const listenerApi = createListenerApi(
+      createState('image', { type: 'register-satellite' }),
+    );
+
+    clearUnsupportedRegistration({} as never, listenerApi as never);
+
+    expect(listenerApi.dispatch).toHaveBeenCalledWith(
+      changeRegistrationType(initialState.registration.type),
+    );
+  });
+
+  it('disables AAP registration when switching to image mode', () => {
+    const listenerApi = createListenerApi(
+      createState('image', {
+        aap: { ...initialState.registration.aap, enabled: true },
+      }),
+    );
+
+    clearUnsupportedRegistration({} as never, listenerApi as never);
+
+    expect(listenerApi.dispatch).toHaveBeenCalledWith(changeAapEnabled(false));
+  });
+
+  it('leaves the registration untouched in package mode', () => {
+    const listenerApi = createListenerApi(
+      createState('package', {
+        type: 'register-satellite',
+        aap: { ...initialState.registration.aap, enabled: true },
+      }),
+    );
+
+    clearUnsupportedRegistration({} as never, listenerApi as never);
+
+    expect(listenerApi.dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not reset a supported registration in image mode', () => {
+    const listenerApi = createListenerApi(
+      createState('image', { type: 'register-now-rhc' }),
+    );
+
+    clearUnsupportedRegistration({} as never, listenerApi as never);
+
+    expect(listenerApi.dispatch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
While wiring up subscription support for Image Mode, I found a few bugs that were preventing Image Mode from building on RHEL and fixed them. Image Mode builds are now working on RHEL. Note that subscription support requires image-builder > v77.

The biggest change is that --distro is no longer passed to the CLI at all. This means that you can only build images equal to whatever the host is… but that’s always been the case for Cockpit.