### PR TITLE
Wizard: Update wording for package search input (HMS-11172)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -1003,7 +1003,7 @@ const PackageSearch = ({
           icon={<SearchIcon />}
           aria-label={`Search ${packageTypeLabel}`}
           data-testid='packages-search-input'
-          placeholder='Add packages'
+          placeholder='Search and add packages'
         />
         <TextInputGroupUtilities>
           <Button
@@ -1018,7 +1018,7 @@ const PackageSearch = ({
   );
 
   return (
-    <FormGroup label='Packages' style={{ width: '100%' }}>
+    <FormGroup label='Add packages' style={{ width: '100%' }}>
       <Select
         isScrollable
         isOpen={isOpen}


### PR DESCRIPTION
This updates label and placeholder of the package search input as per UX guidance.

<img width="985" height="571" alt="image" src="https://github.com/user-attachments/assets/99892dc7-e274-4e84-9b61-0248d00b2596" />


JIRA: [HMS-11172](https://issues.redhat.com/browse/HMS-11172)

[HMS-11172]: https://redhat.atlassian.net/browse/HMS-11172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ