### PR TITLE
Wizard/Packages: Sort packages by the newest added (HMS-10767)

### DIFF
--- a/playwright/fixtures/data/exportBlueprintContents.ts
+++ b/playwright/fixtures/data/exportBlueprintContents.ts
@@ -223,7 +223,7 @@ timezone = "${tz}"
 languages = [ "C.UTF-8" ]
 
 [[packages]]
-name = "vim-minimal"
+name = "tmux"
 version = "*"
 
 [[packages]]
@@ -231,6 +231,6 @@ name = "bash"
 version = "*"
 
 [[packages]]
-name = "tmux"
+name = "vim-minimal"
 version = "*"`;
 };

--- a/src/Components/CreateImageWizard/steps/Packages/components/Packages.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/Packages.tsx
@@ -140,7 +140,6 @@ const Packages = () => {
       <PackagesTable
         isSuccessEpelRepo={isSuccessEpelRepo}
         epelRepo={epelRepo}
-        activeStream={activeStream}
       />
     </>
   );

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
@@ -33,14 +33,9 @@ import RetirementDate from './RetirementDate';
 type PackagesTableProps = {
   isSuccessEpelRepo: boolean;
   epelRepo: ApiRepositoryCollectionResponseRead | undefined;
-  activeStream: string;
 };
 
-const PackagesTable = ({
-  isSuccessEpelRepo,
-  epelRepo,
-  activeStream,
-}: PackagesTableProps) => {
+const PackagesTable = ({ isSuccessEpelRepo, epelRepo }: PackagesTableProps) => {
   const dispatch = useAppDispatch();
   const recommendedRepositories = useAppSelector(selectRecommendedRepositories);
   const packages = useAppSelector(selectPackages);
@@ -94,71 +89,11 @@ const PackagesTable = ({
     }
   };
 
-  const sortedPackages = useMemo(() => {
-    if (packages.length < 1 || !Array.isArray(packages)) {
-      return [];
-    }
-
-    return [...packages].sort((a, b) => {
-      // Active stream packages first (if activeStream is set)
-      const aIsActive = activeStream && a.stream === activeStream ? 0 : 1;
-      const bIsActive = activeStream && b.stream === activeStream ? 0 : 1;
-      if (aIsActive !== bIsActive) return aIsActive - bIsActive;
-
-      // Then by name (asc)
-      if (a.name !== b.name) return a.name.localeCompare(b.name);
-
-      // Then by stream version (desc)
-      const aStream = a.stream || '';
-      const bStream = b.stream || '';
-      if (aStream !== bStream) {
-        if (!aStream) return 1;
-        if (!bStream) return -1;
-        const aParts = aStream
-          .split('.')
-          .map((part) => parseInt(part, 10) || 0);
-        const bParts = bStream
-          .split('.')
-          .map((part) => parseInt(part, 10) || 0);
-        const aVersion = aParts
-          .map((p) => p.toString().padStart(10, '0'))
-          .join('.');
-        const bVersion = bParts
-          .map((p) => p.toString().padStart(10, '0'))
-          .join('.');
-        return bVersion.localeCompare(aVersion); // descending
-      }
-
-      // Then by end date (asc, nulls last)
-      const aEndDate = a.end_date || '9999-12-31';
-      const bEndDate = b.end_date || '9999-12-31';
-      if (aEndDate !== bEndDate) return aEndDate.localeCompare(bEndDate);
-
-      // Then by repository (asc)
-      const aRepo = a.repository || '';
-      const bRepo = b.repository || '';
-      if (aRepo !== bRepo) return aRepo.localeCompare(bRepo);
-
-      // Finally by module name (asc)
-      const aModule = a.module_name || '';
-      const bModule = b.module_name || '';
-      return aModule.localeCompare(bModule);
-    });
-  }, [packages, activeStream]);
-
-  const sortedGroups = useMemo(() => {
-    if (groups.length < 1 || !Array.isArray(groups)) {
-      return [];
-    }
-
-    return [...groups].sort((a, b) => a.name.localeCompare(b.name));
-  }, [groups]);
-
   const composePkgTable = () => {
     let rows: ReactElement[] = [];
 
     rows = rows.concat(
-      sortedGroups.map((grp, rowIndex) => (
+      groups.map((grp, rowIndex) => (
         <Tbody
           key={`${grp.name}-${grp.repository || 'default'}`}
           isExpanded={isGroupExpanded(grp.name)}
@@ -221,8 +156,8 @@ const PackagesTable = ({
 
     // Render required (oscap) packages first, then user-added packages
     const orderedPackages = [
-      ...sortedPackages.filter((pkg) => requiredSet.has(pkg.name)),
-      ...sortedPackages.filter((pkg) => !requiredSet.has(pkg.name)),
+      ...packages.filter((pkg) => requiredSet.has(pkg.name)),
+      ...packages.filter((pkg) => !requiredSet.has(pkg.name)),
     ];
 
     rows = rows.concat(
@@ -267,15 +202,7 @@ const PackagesTable = ({
     return composePkgTable();
     // Would need significant rewrite to fix this
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    packages.length,
-    groups.length,
-    recommendedRepositories,
-    expandedGroups,
-    sortedPackages,
-    sortedGroups,
-    requiredSet,
-  ]);
+  }, [packages, groups, recommendedRepositories, expandedGroups, requiredSet]);
 
   return (
     <Table data-testid='packages-table' style={{ tableLayout: 'fixed' }}>

--- a/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
@@ -550,30 +550,27 @@ describe('Packages Component', () => {
       // Verify packages appear in UI
       const rows = await screen.findAllByTestId('package-row');
       expect(rows).toHaveLength(2);
-      expect(rows[0]).toHaveTextContent('another-pkg');
-      expect(rows[1]).toHaveTextContent('preloaded-pkg');
+      expect(rows[0]).toHaveTextContent('preloaded-pkg');
+      expect(rows[1]).toHaveTextContent('another-pkg');
     });
   });
 
   describe('Selected Packages View', () => {
-    test('selected packages are sorted alphabetically', async () => {
+    test('selected packages appear newest first', async () => {
       fetchMock.mockResponse(createFetchHandler({ rpms: mockSearchResults }));
       renderPackagesStep();
       const user = createUser();
 
-      // Search and select all packages (in reverse order to verify sorting)
       await typeIntoSearchBox(user, 'test');
 
       await screen.findByRole('option', { name: /test-lib/ });
 
-      // Select packages in reverse alphabetical order
       await selectPkgOption(user, 'testPkg');
       await clickOnSearchBox(user);
       await selectPkgOption(user, 'test-lib');
       await clickOnSearchBox(user);
       await selectPkgOption(user, 'test');
 
-      // Verify all packages are shown and sorted
       const rows = await screen.findAllByTestId('package-row');
       expect(rows).toHaveLength(3);
       expect(rows[0]).toHaveTextContent('test');
@@ -764,7 +761,7 @@ describe('Packages Component', () => {
       );
 
       expect(dataRows).toHaveLength(4);
-      // Required packages first (alphabetical)
+      // Required packages first
       expect(dataRows[0]).toHaveTextContent('aide');
       expect(dataRows[0]).toHaveAttribute(
         'data-testid',
@@ -775,10 +772,10 @@ describe('Packages Component', () => {
         'data-testid',
         'required-package-row',
       );
-      // User packages after (alphabetical)
-      expect(dataRows[2]).toHaveTextContent('curl');
+      // User packages after
+      expect(dataRows[2]).toHaveTextContent('zsh');
       expect(dataRows[2]).toHaveAttribute('data-testid', 'package-row');
-      expect(dataRows[3]).toHaveTextContent('zsh');
+      expect(dataRows[3]).toHaveTextContent('curl');
       expect(dataRows[3]).toHaveAttribute('data-testid', 'package-row');
     });
 

--- a/src/store/slices/wizard/content/slice.ts
+++ b/src/store/slices/wizard/content/slice.ts
@@ -87,7 +87,7 @@ export const contentSlice = createSlice({
       if (existingPackageIndex !== -1) {
         state.packages[existingPackageIndex] = action.payload;
       } else {
-        state.packages.push(action.payload);
+        state.packages.unshift(action.payload);
       }
     },
     removePackage: (
@@ -136,7 +136,7 @@ export const contentSlice = createSlice({
       if (existingGrpIndex !== -1) {
         state.groups[existingGrpIndex] = action.payload;
       } else {
-        state.groups.push(action.payload);
+        state.groups.unshift(action.payload);
       }
     },
     removePackageGroup: (

--- a/src/store/slices/wizard/content/tests/content.test.ts
+++ b/src/store/slices/wizard/content/tests/content.test.ts
@@ -63,9 +63,9 @@ describe('content reducers', () => {
 
         expect(state.content.packages).toHaveLength(3);
         expect(state.content.packages.map((p) => p.name)).toEqual([
-          'vim',
-          'git',
           'curl',
+          'git',
+          'vim',
         ]);
       });
 
@@ -253,6 +253,25 @@ describe('content reducers', () => {
 
         expect(result.content.groups).toHaveLength(1);
         expect(result.content.groups[0].name).toBe('Development Tools');
+      });
+
+      it('should insert new groups at the beginning', () => {
+        let state = wizardReducer(
+          initialState,
+          addPackageGroup(createGroup('Development Tools')),
+        );
+        state = wizardReducer(state, addPackageGroup(createGroup('Server')));
+        state = wizardReducer(
+          state,
+          addPackageGroup(createGroup('Networking')),
+        );
+
+        expect(state.content.groups).toHaveLength(3);
+        expect(state.content.groups.map((g) => g.name)).toEqual([
+          'Networking',
+          'Server',
+          'Development Tools',
+        ]);
       });
 
       it('should update existing group if same name', () => {


### PR DESCRIPTION
This replaces original sorting logic, that was mostly leftover from the pre-revamp table focused workflow, with a simple sort by recency.

This will not touch sorting within the search, so all functionality as sorting active app stream to the top within the list of available options is still in place.