### PR TITLE
cockpit: attach the journal as error details when appropriate (HMS-11184)

### DIFF
--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -9,6 +9,7 @@ import {
   byCreatedAtDesc,
   getBlueprintsPath,
   getBootcArgs,
+  getJournal,
   getRegistrationArgs,
   getUploadArgs,
   imageStatusFallback,
@@ -272,6 +273,7 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
           if (buildlogEntry !== undefined) {
             status.image_status = await imageStatusFromBuildlog(
               path.join(composeDir, buildlogEntry),
+              queryArgs.composeId,
             );
             if (status.image_status.status === 'failure') {
               return status;
@@ -282,6 +284,7 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
               id: 10,
               reason:
                 'image-builder process is not running and no result was found',
+              details: await getJournal(queryArgs.composeId),
             };
             // Return before the upload result check overwrites this error
             // with the less specific "no upload result found" one.
@@ -320,6 +323,7 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
             status.image_status.error = {
               id: 28,
               reason: 'image build succeeded but upload failed',
+              details: await getJournal(queryArgs.composeId),
             };
           }
         } else if (!unitActive) {
@@ -328,6 +332,7 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
             id: 28,
             reason:
               'image-builder process is not running and no upload result found',
+            details: await getJournal(queryArgs.composeId),
           };
         }
 

--- a/src/store/api/backend/onprem/composerApi/composes.ts
+++ b/src/store/api/backend/onprem/composerApi/composes.ts
@@ -197,10 +197,12 @@ export const composeEndpoints = (builder: OnPremBuilder) => ({
   >({
     queryFn: onPremQueryHandler(async ({ queryArgs }) => {
       const blueprintsDir = await getBlueprintsPath();
-      const bpinfo = await fsinfo(blueprintsDir, ['entries'], {
+      const bpinfo = await fsinfo(blueprintsDir, ['entries', 'type'], {
         superuser: 'try',
       });
-      const entries = Object.entries(bpinfo.entries || {});
+      const entries = Object.entries(bpinfo.entries || {}).filter(
+        (entry) => entry[1].type === 'dir',
+      );
       const dataDir = path.join('/var/lib/cockpit-image-builder');
 
       for (const bpEntry of entries) {

--- a/src/store/api/backend/onprem/composerApi/helpers/getJournal.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/getJournal.ts
@@ -1,0 +1,15 @@
+import cockpit from 'cockpit';
+
+export const getJournal = async (composeId: string): Promise<string | null> => {
+  try {
+    return (await cockpit.spawn([
+      'journalctl',
+      '-o',
+      'cat',
+      '-u',
+      `cockpit-image-builder-${composeId}.service`,
+    ])) as string;
+  } catch {
+    return null;
+  }
+};

--- a/src/store/api/backend/onprem/composerApi/helpers/imageStatusFromBuildlog.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/imageStatusFromBuildlog.ts
@@ -1,3 +1,4 @@
+import { getJournal } from './getJournal';
 import { safeReadJsonFile } from './safeReadJsonFile';
 
 import type { ImageStatus } from '../../../hosted';
@@ -15,6 +16,7 @@ export type OSBuildResult = {
 
 export const imageStatusFromBuildlog = async (
   buildlog: string,
+  composeId: string,
 ): Promise<ImageStatus> => {
   const result = await safeReadJsonFile<OSBuildResult>(buildlog);
 
@@ -26,6 +28,7 @@ export const imageStatusFromBuildlog = async (
       error: {
         id: 10,
         reason: 'image-builder process is not running and no result was found',
+        details: await getJournal(composeId),
       },
     };
   }
@@ -41,6 +44,9 @@ export const imageStatusFromBuildlog = async (
   // "error" contains build failures, and "errors" contains validation failures.
   if (result.error || result.errors) {
     details = JSON.stringify(result.error || result.errors);
+  }
+  if (!details) {
+    details = await getJournal(composeId);
   }
 
   // osbuild failures are always id: 10

--- a/src/store/api/backend/onprem/composerApi/helpers/index.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/index.ts
@@ -38,3 +38,4 @@ export { uploadStatusFromFile } from './uploadStatusFromFile';
 export { imageStatusFallback } from './imageStatusFallback';
 export { getUploadArgs } from './getUploadArgs';
 export { getBootcArgs } from './getBootcArgs';
+export { getJournal } from './getJournal';

--- a/src/store/api/backend/onprem/composerApi/helpers/tests/imageStatusFromBuildlog.test.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/tests/imageStatusFromBuildlog.test.ts
@@ -9,6 +9,7 @@ import {
 vi.mock('cockpit', () => ({
   default: {
     file: vi.fn(),
+    spawn: vi.fn(),
   },
 }));
 
@@ -22,7 +23,7 @@ describe('imageStatusFromBuildlog', () => {
     vi.mocked(cockpit.file).mockReturnValue({
       read: vi.fn().mockResolvedValue(JSON.stringify(mockData)),
     } as never);
-    const status = await imageStatusFromBuildlog('/path/to/buildlog');
+    const status = await imageStatusFromBuildlog('/path/to/buildlog', '');
     expect(status).toEqual({
       status: 'success',
     });
@@ -39,7 +40,7 @@ describe('imageStatusFromBuildlog', () => {
     vi.mocked(cockpit.file).mockReturnValue({
       read: vi.fn().mockResolvedValue(JSON.stringify(mockData)),
     } as never);
-    const status = await imageStatusFromBuildlog('/path/to/buildlog');
+    const status = await imageStatusFromBuildlog('/path/to/buildlog', '');
     expect(status).toEqual({
       status: 'failure',
       error: {
@@ -57,12 +58,14 @@ describe('imageStatusFromBuildlog', () => {
     vi.mocked(cockpit.file).mockReturnValue({
       read: vi.fn().mockResolvedValue(''),
     } as never);
-    const status = await imageStatusFromBuildlog('/path/to/buildlog');
+    vi.mocked(cockpit.spawn).mockResolvedValue('journal-log');
+    const status = await imageStatusFromBuildlog('/path/to/buildlog', '');
     expect(status).toEqual({
       status: 'failure',
       error: {
         id: 10,
         reason: 'image-builder process is not running and no result was found',
+        details: 'journal-log',
       },
     });
     expect(cockpit.file).toHaveBeenCalledWith('/path/to/buildlog', {


### PR DESCRIPTION
    cockpit: attach the journal as error details when appropriate
    
    If no specific error details are found in the buildlog, just attach the
    journal. This is useful in cases where the unit itself failed to
    start. Or in cases where something went wrong during the upload itself,
    as there are no upload results saved in case of upload failure.
