### PR TITLE
Makefile: init cache dir for cockpit/devel-install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,12 @@ cockpit/devel-install:
 	PREFIX="~/.local"
 	mkdir -p $(PREFIX)$(INSTALL_DIR_BASE)
 	ln -s $(shell pwd)/cockpit/public $(PREFIX)$(INSTALL_DIR)
+	if [ ! -d "/var/cache/cockpit-image-builder" ]; then \
+		echo "Creating cache directory /var/cache/cockpit-image-builder"; \
+		echo "This requires root privileges"; \
+		sudo mkdir -p /var/cache/cockpit-image-builder; \
+		sudo chmod 700 /var/cache/cockpit-image-builder; \
+	fi
 
 .PHONY: cockpit/download
 cockpit/download: Makefile


### PR DESCRIPTION
The cockpit-image-builder RPM now creates /var/cache/cockpit-image-builder via a systemd-tmpfiles snippet. However, when you want to hack on cockpit-image-builder using cockpit/devel-install and you don't have the RPM installed, the directory is not created, leading to very confusing errors.

This commit adds a simple check to the cockpit/devel-install target that creates the dir if needed.