### PR TITLE
ci: skip CI on stacked pull requests

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -3,6 +3,12 @@ name: Hosted playwright tests
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+    # Too expensive to run once per PR in a stack: only run for PRs
+    # targeting main. Stacked PRs (base = another in-flight branch) run
+    # the full suite once they are retargeted after the PR below them
+    # merges, so every merge into main is still fully gated.
+    branches:
+      - main
   workflow_dispatch:
   merge_group:
 

--- a/packit.yaml
+++ b/packit.yaml
@@ -19,6 +19,9 @@ jobs:
   - job: tests
     identifier: self
     trigger: pull_request
+    # Only for PRs targeting main - stacked PRs run these once they are
+    # retargeted after the PR below them merges.
+    branch: "^main$"
     tmt_plan: /plans/all/main
     targets:
       - centos-stream-10
@@ -27,6 +30,7 @@ jobs:
 
   - job: copr_build
     trigger: pull_request
+    branch: "^main$"
     targets: &build_targets
       - centos-stream-9
       - centos-stream-9-aarch64


### PR DESCRIPTION
Disable the packit and playwright jobs for now for stacked pull requests
(basically anything that isn't targeting main).

I expect we will need to tweak this in the future but for now, I just
want to establish a convention where we don't run the full CI while
using stacked pull requests - should save us time waiting for CI runs
that will just have to run again on a rebase anyway and maybe even a bit
of money.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>