### PR TITLE
cockpit: support a development container registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,12 @@ cockpit/download: Makefile
 
 .PHONY: cockpit/build
 cockpit/build: cockpit/download
-	npm run build:cockpit
+	DEV_REGISTRY="$(DEV_REGISTRY)" npm run build:cockpit
 
+# Set DEV_REGISTRY to redirect podman and image-builder invocations to a
+# registry holding unpublished containers, e.g.
+#   make cockpit/devel DEV_REGISTRY=registry.stage.redhat.io/rhel10
+# Everything (UI, blueprints, podman) uses the development references.
 .PHONY: cockpit/devel
 cockpit/devel: cockpit/devel-uninstall cockpit/build cockpit/devel-install
 

--- a/cockpit/webpack.config.ts
+++ b/cockpit/webpack.config.ts
@@ -20,6 +20,9 @@ const plugins = [
   }),
   new webpack.DefinePlugin({
     'process.env.IS_ON_PREMISE': JSON.stringify(true),
+    // Development-only registry override for unpublished containers;
+    // see IMAGE_REGISTRY in src/store/api/backend/onprem/constants.ts
+    'process.env.DEV_REGISTRY': JSON.stringify(process.env.DEV_REGISTRY || ''),
   }),
 ];
 

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/RegistryAuth.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/RegistryAuth.tsx
@@ -28,6 +28,7 @@ import {
   useRegistryLoginMutation,
   useRegistryLogoutMutation,
 } from '@/store/api/backend';
+import { IMAGE_REGISTRY_HOST } from '@/store/api/backend/onprem/constants';
 import { OnPremError } from '@/store/api/shared';
 
 const EmptyCard = ({ openForm }: { openForm: (arg0: boolean) => void }) => {
@@ -35,7 +36,7 @@ const EmptyCard = ({ openForm }: { openForm: (arg0: boolean) => void }) => {
     <Card variant='secondary' className='pf-v6-u-mt-md pf-v6-u-py-md'>
       <EmptyState titleText='Login to select an image' headingLevel='h4'>
         <EmptyStateBody>
-          <Content>Registry images come from registry.redhat.io.</Content>
+          <Content>Registry images come from {IMAGE_REGISTRY_HOST}.</Content>
           <Content>
             Sign in to browse available images for this release.
           </Content>
@@ -92,7 +93,7 @@ const LoginCard = ({ closeForm }: { closeForm: (arg0: boolean) => void }) => {
   return (
     <Card variant='secondary' className='pf-v6-u-mt-md'>
       <CardHeader>
-        <CardTitle>Log in to registry.redhat.io</CardTitle>
+        <CardTitle>Log in to {IMAGE_REGISTRY_HOST}</CardTitle>
       </CardHeader>
       <CardBody>
         <Content component={ContentVariants.p}>
@@ -194,7 +195,7 @@ const RegistryStatus = ({ username }: { username: string }) => {
     <Flex gap={{ default: 'gapSm' }}>
       <FlexItem>
         <Content className='pf-v6-u-mt-md pf-v6-u-text-color-subtle'>
-          Connected to registry.redhat.io &middot; {username}
+          Connected to {IMAGE_REGISTRY_HOST} &middot; {username}
         </Content>
       </FlexItem>
       <FlexItem>

--- a/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/index.tsx
+++ b/src/Components/CreateImageWizard/steps/ImageOutput/components/ImageSourceSelect/OnPrem/index.tsx
@@ -10,6 +10,7 @@ import {
   Label,
 } from '@patternfly/react-core';
 
+import { IMAGE_REGISTRY_HOST } from '@/store/api/backend/onprem/constants';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   changeImageSourceType,
@@ -49,7 +50,7 @@ const OnPremImageSourceSelect = () => {
               Official Red Hat images <Label isCompact>Login required</Label>
             </CardTitle>
           </CardHeader>
-          <CardBody>Remote images from registry.redhat.io</CardBody>
+          <CardBody>Remote images from {IMAGE_REGISTRY_HOST}</CardBody>
         </Card>
         <Card
           id='custom-card'

--- a/src/store/api/backend/onprem/composerApi/helpers/podman/registryAuth.ts
+++ b/src/store/api/backend/onprem/composerApi/helpers/podman/registryAuth.ts
@@ -1,11 +1,15 @@
 import cockpit from 'cockpit';
 
+import {
+  IMAGE_REGISTRY,
+  IMAGE_REGISTRY_HOST,
+} from '@/store/api/backend/onprem/constants';
 import type { RegistryAuthStatus } from '@/store/api/backend/onprem/types';
 
 const getRegistryLogin = async (): Promise<string | null> => {
   try {
     const result = await cockpit.spawn(
-      ['podman', 'login', '--get-login', 'registry.redhat.io'],
+      ['podman', 'login', '--get-login', IMAGE_REGISTRY_HOST],
       { superuser: 'require' },
     );
     return (result as string).trim() || null;
@@ -16,10 +20,9 @@ const getRegistryLogin = async (): Promise<string | null> => {
 
 const verifyRegistryAccess = async (): Promise<boolean> => {
   try {
-    await cockpit.spawn(
-      ['podman', 'search', 'registry.redhat.io/rhel10', '--limit', '1'],
-      { superuser: 'require' },
-    );
+    await cockpit.spawn(['podman', 'search', IMAGE_REGISTRY, '--limit', '1'], {
+      superuser: 'require',
+    });
     return true;
   } catch {
     return false;

--- a/src/store/api/backend/onprem/composerApi/registry.ts
+++ b/src/store/api/backend/onprem/composerApi/registry.ts
@@ -1,5 +1,6 @@
 import cockpit from 'cockpit';
 
+import { IMAGE_REGISTRY_HOST } from '@/store/api/backend/onprem/constants';
 import { OnPremBuilder, onPremQueryHandler } from '@/store/api/shared';
 
 import { checkImageExists, checkRegistryAuth } from './helpers';
@@ -25,7 +26,7 @@ export const registryEndpoints = (builder: OnPremBuilder) => ({
               '--username',
               username,
               '--password-stdin',
-              'registry.redhat.io',
+              IMAGE_REGISTRY_HOST,
             ],
             { superuser: 'require', err: 'message' },
           )
@@ -36,7 +37,7 @@ export const registryEndpoints = (builder: OnPremBuilder) => ({
   }),
   registryLogout: builder.mutation<void, void>({
     queryFn: onPremQueryHandler(async () => {
-      await cockpit.spawn(['podman', 'logout', 'registry.redhat.io'], {
+      await cockpit.spawn(['podman', 'logout', IMAGE_REGISTRY_HOST], {
         superuser: 'require',
       });
     }),

--- a/src/store/api/backend/onprem/constants.ts
+++ b/src/store/api/backend/onprem/constants.ts
@@ -4,13 +4,13 @@ export type KnownImage = Omit<BootcDistributionItem, 'arch'>;
 
 export const KNOWN_IMAGES: KnownImage[] = [
   {
-    reference: 'registry.redhat.io/rhel10/rhel-kvm:latest',
+    reference: 'registry.redhat.io/rhel10/rhel-bootc-kvm:latest',
     distro: 'rhel-10.3',
     name: 'Red Hat Enterprise Linux (RHEL) 10.3',
     type: 'guest-image',
   },
   {
-    reference: 'registry.redhat.io/rhel10/rhel-aws:latest',
+    reference: 'registry.redhat.io/rhel10/rhel-bootc-aws:latest',
     distro: 'rhel-10.3',
     name: 'Red Hat Enterprise Linux (RHEL) 10.3',
     type: 'aws',

--- a/src/store/api/backend/onprem/constants.ts
+++ b/src/store/api/backend/onprem/constants.ts
@@ -2,15 +2,30 @@ import type { BootcDistributionItem } from '@/store/api/backend';
 
 export type KnownImage = Omit<BootcDistributionItem, 'arch'>;
 
+// The repository path holding the official images. Development builds
+// (make cockpit/devel DEV_REGISTRY=...) can point it at a registry
+// holding unpublished containers; the value is baked in at build time
+// via webpack DefinePlugin. Everything derives from this one constant -
+// the UI, the wizard state, stored blueprints, podman, and the
+// image-builder CLI all use the same references - so a development
+// build behaves exactly like a production build pointed at a
+// different registry, and the UI always shows the registry that is
+// actually used.
+export const IMAGE_REGISTRY =
+  process.env.DEV_REGISTRY?.replace(/\/+$/, '') || 'registry.redhat.io/rhel10';
+
+// The bare host, for podman login and logout.
+export const IMAGE_REGISTRY_HOST = IMAGE_REGISTRY.split('/')[0];
+
 export const KNOWN_IMAGES: KnownImage[] = [
   {
-    reference: 'registry.redhat.io/rhel10/rhel-bootc-kvm:latest',
+    reference: `${IMAGE_REGISTRY}/rhel-bootc-kvm:latest`,
     distro: 'rhel-10.3',
     name: 'Red Hat Enterprise Linux (RHEL) 10.3',
     type: 'guest-image',
   },
   {
-    reference: 'registry.redhat.io/rhel10/rhel-bootc-aws:latest',
+    reference: `${IMAGE_REGISTRY}/rhel-bootc-aws:latest`,
     distro: 'rhel-10.3',
     name: 'Red Hat Enterprise Linux (RHEL) 10.3',
     type: 'aws',

--- a/src/store/api/backend/onprem/tests/constants.test.ts
+++ b/src/store/api/backend/onprem/tests/constants.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// The registry constants are evaluated at module load, mirroring the
+// webpack DefinePlugin substitution in the cockpit build, so the
+// DEV_REGISTRY override is tested through a fresh module import.
+const importConstants = async () => {
+  vi.resetModules();
+  return await import('../constants');
+};
+
+describe('IMAGE_REGISTRY', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('defaults to the official registry path', async () => {
+    const { IMAGE_REGISTRY, IMAGE_REGISTRY_HOST, KNOWN_IMAGES } =
+      await importConstants();
+
+    expect(IMAGE_REGISTRY).toBe('registry.redhat.io/rhel10');
+    expect(IMAGE_REGISTRY_HOST).toBe('registry.redhat.io');
+    expect(KNOWN_IMAGES[0].reference).toBe(
+      'registry.redhat.io/rhel10/rhel-bootc-kvm:latest',
+    );
+  });
+
+  it('uses DEV_REGISTRY when set, ignoring trailing slashes', async () => {
+    vi.stubEnv('DEV_REGISTRY', 'registry.stage.redhat.io/rhel10/');
+
+    const { IMAGE_REGISTRY, IMAGE_REGISTRY_HOST, KNOWN_IMAGES } =
+      await importConstants();
+
+    expect(IMAGE_REGISTRY).toBe('registry.stage.redhat.io/rhel10');
+    expect(IMAGE_REGISTRY_HOST).toBe('registry.stage.redhat.io');
+    expect(KNOWN_IMAGES[0].reference).toBe(
+      'registry.stage.redhat.io/rhel10/rhel-bootc-kvm:latest',
+    );
+  });
+
+  it('keeps the port in the registry host', async () => {
+    vi.stubEnv('DEV_REGISTRY', 'registry.example.com:5000/myorg');
+
+    const { IMAGE_REGISTRY_HOST } = await importConstants();
+
+    expect(IMAGE_REGISTRY_HOST).toBe('registry.example.com:5000');
+  });
+});


### PR DESCRIPTION
When hacking on cockpit-image-builder, next-release containers aren't available on registry.redhat.io (they become available at GA) so to do proper end to end testing we need to be able to point to a custom registry such as stage. This pull request supports that and also updates the container names to be correct for what will ultimately be hosted on registry.redhat.io.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>