### PR TITLE
Wizard: handle missing `share_with_accounts` in gcp

### DIFF
--- a/src/Components/ImagesTable/components/ImageDetails/components/GcpDetails.tsx
+++ b/src/Components/ImagesTable/components/ImageDetails/components/GcpDetails.tsx
@@ -22,7 +22,7 @@ import {
 export const parseGcpSharedWith = (
   sharedWith: GcpUploadRequestOptions['share_with_accounts'],
 ) => {
-  if (sharedWith) {
+  if (sharedWith?.[0]) {
     const splitGCPSharedWith = sharedWith[0].split(':');
     return splitGCPSharedWith[1];
   }


### PR DESCRIPTION
This is a rare edge case - our validation in UI requires a valid email/domain before the user can proceed past the GCP step, but the API does not. That means, if there is an image request sent with no `share_with_account` option through API, it will be an empty list, the condition `if (sharedWith)` will be true, and the UI will crash with Sentry saying that null cannot be split - as in the first item of an empty list cannot be split. This way, the UI checks if there is anything in the list.