### PR TITLE
playwright: fix race conditions causing flakiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,27 @@ PLAYWRIGHT_STATIC_PASSWORD="<your_static_user_password>"
 
 For local development purposes, you can use the same credentials as for `PLAYWRIGHT_USER` and `PLAYWRIGHT_PASSWORD` if you are using your stage account for those.
 
+### Diagnosing a failure that has no visible cause
+
+A blank page, a control that never appears, and a page that renders slowly all
+look identical from the outside: an assertion times out and says only what it
+was waiting for. Failing tests therefore carry a `browser-diagnostics.log`
+attachment in the HTML report, holding what the browser reported while the test
+ran - uncaught exceptions, console errors and warnings, requests that failed,
+and any response of 400 or above, each stamped with the time since the test
+started.
+
+```
++  1429ms  HTTP 404    GET .../apps/chrome/operator-generated/fed-modules.json
++  2759ms  CONSOLE WARNING Unsatisfied version * from undefined of shared
+                           singleton module react-router-dom (required =6.30.4)
++  3210ms  HTTP 400    GET .../api/rbac/v1/access/?application=inventory
+```
+
+Passing tests attach nothing. Warnings have a smaller budget than errors,
+because the console shell emits them in bursts and they would otherwise crowd
+out the entries worth reading.
+
 ### Finding flaky tests with injected latency
 
 Races between the browser and the API are hard to reproduce on demand. The

--- a/README.md
+++ b/README.md
@@ -413,6 +413,59 @@ PLAYWRIGHT_STATIC_PASSWORD="<your_static_user_password>"
 
 For local development purposes, you can use the same credentials as for `PLAYWRIGHT_USER` and `PLAYWRIGHT_PASSWORD` if you are using your stage account for those.
 
+### Finding flaky tests with injected latency
+
+Races between the browser and the API are hard to reproduce on demand. The
+window is usually a few hundred milliseconds wide, and it only matters when a
+test happens to click inside it. Setting `PW_CHAOS=1` delays the app's own API
+responses so those windows open wide enough to hit deliberately.
+
+```bash
+PW_CHAOS=1 npx playwright test --project="UI tests" --repeat-each=5
+```
+
+What finds bugs here is **reordering**, not slowness. Playwright waits for
+elements to become actionable, so uniformly slower responses are absorbed and
+nothing fails. Delays are drawn from a heavy tailed distribution instead: most
+requests pass straight through and a small share are held for up to two
+seconds, which is long enough for one response to overtake another issued
+before it. Code that assumes replies arrive in the order they were sent breaks
+under this. Code that does not, does not.
+
+Delays are capped below `actionTimeout`, so slowness on its own can never fail
+a test - anything that goes red under chaos is a real defect. Only requests to
+`**/api/**` are delayed, since holding bundles and fonts adds wall clock
+without producing anything worth finding.
+
+#### Reproducing a specific failure
+
+Every test records the seed it used as an annotation, visible in the HTML
+report:
+
+```
+chaos-seed     PW_CHAOS_SEED=2223827117 (test seed 729962994)
+chaos-summary  175 requests delayed, max 1982ms, total 19208ms
+```
+
+Passing that seed back replays the same delays:
+
+```bash
+PW_CHAOS=1 PW_CHAOS_SEED=2223827117 npx playwright test --project="UI tests"
+```
+
+Reproduction is close but not exact. Delays are drawn per request in dispatch
+order, so a run that issues its requests in a different order gets a different
+assignment - narrowing to a single spec is enough to change that. When a seed
+does not reproduce, raising `--repeat-each` is usually faster than chasing it.
+
+#### What it tends to find
+
+Failures under chaos point at state that outlives the request it came from:
+a cached answer that a slower, older response overwrites; a control that is
+enabled before the data behind it has arrived; an effect that re-runs after the
+component has already moved on. A failure that only appears under chaos is
+still real. It just needs an unlucky user rather than an unlucky test.
+
 ## Playwright Boot tests
 
 This section describes what Playwright Boot tests are, how they work and how to run them locally.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -28,7 +28,10 @@ export default defineConfig({
   reporter: reporters,
   globalTimeout: 89.5 * 60 * 1000, // 1h29.5m, Set because of codebuild, we want PW to timeout before CB to get the results.
   timeout: 3 * 60 * 1000, // 3m
-  expect: { timeout: 50_000 }, // 50s
+  // Assertions that genuinely need to wait longer say so at the call site.
+  // A high default hides which those are, and turns every ordinary failure
+  // into a slow one.
+  expect: { timeout: 15_000 }, // 15s
   use: {
     actionTimeout: 30_000, // 30s
     navigationTimeout: 30_000, // 30s

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -42,7 +42,11 @@ export default defineConfig({
       ? process.env.BASE_URL
       : 'http://127.0.0.1:9090',
     video: 'retain-on-failure',
-    trace: 'on',
+    // 'on' kept a trace for every passing test too, which is hundreds of
+    // megabytes of artifacts nobody opens. 'on-first-retry' would record
+    // nothing locally, where retries are 0, so match the video setting and
+    // keep a trace whenever there is a failure to look at.
+    trace: 'retain-on-failure',
 
     ignoreHTTPSErrors: true,
   },
@@ -50,7 +54,10 @@ export default defineConfig({
     { name: 'Setup', testMatch: /.*\.setup\.ts/ },
     {
       name: 'UI tests',
-      timeout: 29.5 * 60 * 1000, // 29.5m
+      // The slowest attempt observed is under 3m. This is only a ceiling on
+      // how long a hung test can burn before it is killed, and at 29.5m one
+      // could take a third of globalTimeout with it.
+      timeout: 5 * 60 * 1000, // 5m
       use: {
         ...devices['Desktop Chrome'],
         storageState: '.auth/user.json',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -33,6 +33,11 @@ export default defineConfig({
     actionTimeout: 30_000, // 30s
     navigationTimeout: 30_000, // 30s
     headless: true,
+    // Specs assert on rendered dates. Without this the browser follows the
+    // host clock, so a date the wizard stores as UTC midnight renders as the
+    // previous day anywhere west of Greenwich - passing in CI and failing on
+    // a developer's machine.
+    timezoneId: 'UTC',
     baseURL: process.env.BASE_URL
       ? process.env.BASE_URL
       : 'http://127.0.0.1:9090',

--- a/playwright/Basic/imageMode.spec.ts
+++ b/playwright/Basic/imageMode.spec.ts
@@ -44,7 +44,7 @@ test('Image mode blueprint create, edit, export, import', async ({
   // Skip the test if the image mode flag is not enabled in this environment
   const imageModeToggle = frame.getByRole('button', { name: 'Image mode' });
   try {
-    await expect(imageModeToggle).toBeVisible({ timeout: 10000 });
+    await expect(imageModeToggle).toBeVisible();
   } catch {
     test.skip(true, 'Image mode flag not enabled');
   }
@@ -64,8 +64,8 @@ test('Image mode blueprint create, edit, export, import', async ({
     let imageSourceDropdown = frame.getByRole('button', {
       name: /Red Hat Enterprise Linux|RHEL/i,
     });
-    await expect(imageSourceDropdown).toBeVisible({ timeout: 10000 });
-    await expect(imageSourceDropdown).toBeEnabled({ timeout: 5000 });
+    await expect(imageSourceDropdown).toBeVisible();
+    await expect(imageSourceDropdown).toBeEnabled();
     await imageSourceDropdown.click();
     await frame.getByRole('option', { name: 'Fedora Hummingbird' }).click();
 
@@ -88,8 +88,8 @@ test('Image mode blueprint create, edit, export, import', async ({
       name: /fedora hummingbird/i,
     });
     await imageSourceDropdown.click();
-    await expect(imageSourceDropdown).toBeVisible({ timeout: 10000 });
-    await expect(imageSourceDropdown).toBeEnabled({ timeout: 5000 });
+    await expect(imageSourceDropdown).toBeVisible();
+    await expect(imageSourceDropdown).toBeEnabled();
     await frame
       .getByRole('option', { name: 'Red Hat Enterprise Linux (RHEL)' })
       .click();
@@ -99,14 +99,14 @@ test('Image mode blueprint create, edit, export, import', async ({
     const imageSourceDropdown = frame.getByRole('button', {
       name: /Red Hat Enterprise Linux|RHEL/i,
     });
-    await expect(imageSourceDropdown).toBeVisible({ timeout: 10000 });
-    await expect(imageSourceDropdown).toBeEnabled({ timeout: 5000 });
+    await expect(imageSourceDropdown).toBeVisible();
+    await expect(imageSourceDropdown).toBeEnabled();
     await imageSourceDropdown.click();
 
     const rhelSourceOption = frame
       .getByRole('option', { name: /RHEL/i })
       .first();
-    await expect(rhelSourceOption).toBeVisible({ timeout: 10000 });
+    await expect(rhelSourceOption).toBeVisible();
     await rhelSourceOption.click();
 
     await expect(
@@ -126,7 +126,6 @@ test('Image mode blueprint create, edit, export, import', async ({
     const reviewImageButton = frame.getByRole('button', {
       name: 'Review image',
     });
-    await expect(reviewImageButton).toBeEnabled({ timeout: 10000 });
     await reviewImageButton.click();
     await createBlueprint(frame, blueprintName);
   });
@@ -158,7 +157,6 @@ test('Image mode blueprint create, edit, export, import', async ({
     const reviewImageButton = frame.getByRole('button', {
       name: 'Review image',
     });
-    await expect(reviewImageButton).toBeEnabled({ timeout: 10000 });
     await reviewImageButton.click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })
@@ -185,7 +183,7 @@ test('Image mode blueprint create, edit, export, import', async ({
     const importedImageMode = frame.getByRole('button', {
       name: 'Image mode',
     });
-    await expect(importedImageMode).toBeVisible({ timeout: 10000 });
+    await expect(importedImageMode).toBeVisible();
     await expect(importedImageMode).toHaveAttribute('aria-pressed', 'true');
 
     // Export doesn't include image_requests, so image types must be re-selected

--- a/playwright/Customizations/Registration.spec.ts
+++ b/playwright/Customizations/Registration.spec.ts
@@ -415,7 +415,6 @@ registrationModes.forEach(
           const saveButton = frame.getByRole('button', {
             name: 'Save changes to blueprint',
           });
-          await expect(saveButton).toBeEnabled();
           await saveButton.click();
         });
 

--- a/playwright/Customizations/Repositories.spec.ts
+++ b/playwright/Customizations/Repositories.spec.ts
@@ -5,6 +5,7 @@ import {
   createRepositoryViaApi,
   deleteRepositoryByUrlViaApi,
   deleteRepositoryViaApi,
+  waitForIntrospection,
 } from '../helpers/apiHelpers';
 import { isHosted } from '../helpers/helpers';
 import { ensureAuthenticated } from '../helpers/login';
@@ -21,8 +22,11 @@ import {
   registerLater,
 } from '../helpers/wizardHelpers';
 
-const REPOSITORY_URL =
-  'https://jlsherrill.fedorapeople.org/fake-repos/really-empty/';
+// Content sources allows one repository per url per organization, and this
+// spec claims the url by deleting whatever already holds it. Every spec
+// therefore needs a url of its own - sharing one with RepeatableBuild meant
+// this test deleted that test's repository out from under it mid-run.
+const REPOSITORY_URL = 'https://jlsherrill.fedorapeople.org/fake-repos/signed/';
 
 test('Create blueprint with repository and test edit mode removal', async ({
   page,
@@ -50,6 +54,9 @@ test('Create blueprint with repository and test edit mode removal', async ({
       snapshot: false,
     });
     repositoryUuid = repository.uuid;
+    // The wizard lists repositories filtered by architecture and version, and
+    // a repository does not qualify until content sources has introspected it.
+    await waitForIntrospection(page, repositoryName);
   });
 
   cleanup.add(() => deleteBlueprint(page, blueprintName));

--- a/playwright/fixtures/browserDiagnostics.ts
+++ b/playwright/fixtures/browserDiagnostics.ts
@@ -43,6 +43,7 @@ export const test = base.extend<BrowserDiagnosticsFixture>({
         if (type !== 'error' && type !== 'warning') return;
         record(
           `CONSOLE ${type.toUpperCase().padEnd(7)} ${message.text().slice(0, 300)}`,
+          type === 'warning',
         );
       });
 

--- a/playwright/fixtures/browserDiagnostics.ts
+++ b/playwright/fixtures/browserDiagnostics.ts
@@ -1,0 +1,76 @@
+import { test as base } from '@playwright/test';
+
+// Attaches what the browser reported to any test that fails. A blank page or a
+// control that never appears looks identical from the outside whether the cause
+// was a JS exception, a failed module load, or a backend returning 502, and the
+// assertion that times out can say nothing about which it was.
+//
+// Only failures produce an attachment, so a green run stays quiet.
+
+// Capped so that a page erroring in a loop cannot produce an unreadable
+// attachment. Warnings get their own smaller budget because the console shell
+// emits them in bursts, and they would otherwise crowd out the errors.
+const MAX_ERRORS = 150;
+const MAX_WARNINGS = 30;
+
+export type BrowserDiagnosticsFixture = {
+  browserDiagnostics: void;
+};
+
+export const test = base.extend<BrowserDiagnosticsFixture>({
+  browserDiagnostics: [
+    async ({ page }, use, testInfo) => {
+      const startedAt = Date.now();
+      const entries: string[] = [];
+      let errorCount = 0;
+      let warningCount = 0;
+
+      const record = (line: string, isWarning = false) => {
+        if (isWarning && warningCount >= MAX_WARNINGS) return;
+        if (!isWarning && errorCount >= MAX_ERRORS) return;
+        if (isWarning) warningCount++;
+        else errorCount++;
+        const at = String(Date.now() - startedAt).padStart(6);
+        entries.push(`+${at}ms  ${line}`);
+      };
+
+      page.on('pageerror', (error) =>
+        record(`PAGEERROR   ${error.message.split('\n')[0]}`),
+      );
+
+      page.on('console', (message) => {
+        const type = message.type();
+        if (type !== 'error' && type !== 'warning') return;
+        record(
+          `CONSOLE ${type.toUpperCase().padEnd(7)} ${message.text().slice(0, 300)}`,
+        );
+      });
+
+      page.on('requestfailed', (request) =>
+        record(
+          `REQ FAILED  ${request.method()} ${request.url().slice(0, 160)} ` +
+            `- ${request.failure()?.errorText ?? 'unknown'}`,
+        ),
+      );
+
+      page.on('response', (response) => {
+        if (response.status() < 400) return;
+        record(
+          `HTTP ${response.status()}    ${response.request().method()} ` +
+            `${response.url().slice(0, 160)}`,
+        );
+      });
+
+      await use(undefined);
+
+      if (testInfo.status === testInfo.expectedStatus) return;
+      if (entries.length === 0) return;
+
+      await testInfo.attach('browser-diagnostics.log', {
+        body: entries.join('\n'),
+        contentType: 'text/plain',
+      });
+    },
+    { auto: true },
+  ],
+});

--- a/playwright/fixtures/customizations.ts
+++ b/playwright/fixtures/customizations.ts
@@ -5,6 +5,7 @@ import { test as ariaHiddenTest } from './ariaHiddenWorkaround';
 import { blockAnalyticsTest } from './blockAnalytics';
 import { test as cleanupTest } from './cleanup';
 import { test as coverageTest } from './coverage';
+import { test as networkChaosTest } from './networkChaos';
 import { test as popupTest } from './popupHandler';
 
 // Combine the fixtures into one
@@ -13,5 +14,6 @@ export const test = mergeTests(
   blockAnalyticsTest,
   cleanupTest,
   coverageTest,
+  networkChaosTest,
   popupTest,
 );

--- a/playwright/fixtures/customizations.ts
+++ b/playwright/fixtures/customizations.ts
@@ -3,6 +3,7 @@ import { mergeTests } from '@playwright/test';
 
 import { test as ariaHiddenTest } from './ariaHiddenWorkaround';
 import { blockAnalyticsTest } from './blockAnalytics';
+import { test as browserDiagnosticsTest } from './browserDiagnostics';
 import { test as cleanupTest } from './cleanup';
 import { test as coverageTest } from './coverage';
 import { test as networkChaosTest } from './networkChaos';
@@ -12,6 +13,7 @@ import { test as popupTest } from './popupHandler';
 export const test = mergeTests(
   ariaHiddenTest,
   blockAnalyticsTest,
+  browserDiagnosticsTest,
   cleanupTest,
   coverageTest,
   networkChaosTest,

--- a/playwright/fixtures/networkChaos.ts
+++ b/playwright/fixtures/networkChaos.ts
@@ -1,0 +1,121 @@
+import { test as base } from '@playwright/test';
+
+// Fault injection for shaking out client-side request races.
+//
+// Uniform latency finds very little: Playwright's auto-waiting absorbs a
+// slower-but-still-ordered backend. What breaks code is RESPONSE REORDERING -
+// an earlier request resolving after a later one, so a stale closure wins and
+// writes obsolete state. Reordering only happens when the spread between
+// delays exceeds the natural spacing between requests, so the distribution is
+// deliberately heavy tailed rather than uniform.
+//
+// Enable with PW_CHAOS=1. Every test records the seed it used as an
+// annotation; replay a specific failure with PW_CHAOS_SEED=<that seed>.
+
+const CHAOS_ENABLED = process.env.PW_CHAOS === '1';
+
+// Only the app's own API traffic. Delaying bundles and fonts adds wall clock
+// and load timeouts without producing any reordering worth finding.
+const TARGET = '**/api/**';
+
+type Band = { weight: number; min: number; max: number };
+
+// Measured stage latency sits around 320ms, so the tail has to reach well past
+// that for one response to overtake another.
+const BANDS: Band[] = [
+  // Most requests pass straight through. A few milliseconds of jitter would
+  // not reorder anything, and holding every request open while it elapsed put
+  // real load on the dev proxy.
+  { weight: 70, min: 0, max: 0 },
+  { weight: 20, min: 50, max: 400 }, // same order as real latency
+  { weight: 10, min: 400, max: 2000 }, // the tail that causes overtaking
+];
+
+const TOTAL_WEIGHT = BANDS.reduce((sum, b) => sum + b.weight, 0);
+
+// mulberry32 - small, fast, and good enough that a seed reproduces a run.
+const makeRng = (seed: number) => {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+const pickDelay = (rng: () => number): number => {
+  let roll = rng() * TOTAL_WEIGHT;
+  for (const band of BANDS) {
+    roll -= band.weight;
+    if (roll <= 0) {
+      return Math.floor(band.min + rng() * (band.max - band.min));
+    }
+  }
+  return 0;
+};
+
+// Distinct per test so parallel workers scramble differently, but derived from
+// the run seed so the whole suite replays from one env var.
+const deriveSeed = (runSeed: number, testId: string): number => {
+  let h = runSeed >>> 0;
+  for (let i = 0; i < testId.length; i++) {
+    h = (Math.imul(h ^ testId.charCodeAt(i), 0x01000193) + 1) >>> 0;
+  }
+  return h;
+};
+
+export type NetworkChaosFixture = {
+  networkChaos: void;
+};
+
+export const test = base.extend<NetworkChaosFixture>({
+  networkChaos: [
+    async ({ page }, use, testInfo) => {
+      if (!CHAOS_ENABLED) {
+        await use(undefined);
+        return;
+      }
+
+      const runSeed = process.env.PW_CHAOS_SEED
+        ? Number(process.env.PW_CHAOS_SEED)
+        : Math.floor(Math.random() * 0xffffffff);
+      const seed = deriveSeed(
+        runSeed,
+        `${testInfo.titlePath.join(' > ')}#${testInfo.repeatEachIndex}`,
+      );
+      const rng = makeRng(seed);
+
+      testInfo.annotations.push({
+        type: 'chaos-seed',
+        description: `PW_CHAOS_SEED=${runSeed} (test seed ${seed})`,
+      });
+
+      const delays: number[] = [];
+
+      await page.route(TARGET, async (route) => {
+        const delay = pickDelay(rng);
+        delays.push(delay);
+        if (delay > 0) {
+          await new Promise((resolve) => setTimeout(resolve, delay));
+        }
+        // fallback rather than continue so other route handlers still apply
+        await route.fallback();
+      });
+
+      await use(undefined);
+
+      await page.unroute(TARGET);
+
+      if (delays.length > 0) {
+        const max = Math.max(...delays);
+        const total = delays.reduce((a, b) => a + b, 0);
+        testInfo.annotations.push({
+          type: 'chaos-summary',
+          description: `${delays.length} requests delayed, max ${max}ms, total ${total}ms`,
+        });
+      }
+    },
+    { auto: true },
+  ],
+});

--- a/playwright/helpers/apiHelpers.ts
+++ b/playwright/helpers/apiHelpers.ts
@@ -1,4 +1,4 @@
-import { APIResponse, Page } from '@playwright/test';
+import { APIResponse, expect, Page } from '@playwright/test';
 
 /**
  * Call API and return the response
@@ -93,7 +93,14 @@ type RepositoryResponse = {
   uuid: string;
   name: string;
   url: string;
+  snapshot?: boolean;
+  status?: string;
+  last_introspection_time?: string;
 };
+
+// Introspection of a small repository takes seconds, but the backend gives no
+// completion signal, so we poll.
+const INTROSPECTION_TIMEOUT = 90_000;
 
 export const createRepositoryViaApi = async (
   page: Page,
@@ -138,58 +145,98 @@ export const deleteRepositoryViaApi = async (
   }
 };
 
-// Ensures a repository with the given name exists. If it already exists,
-// returns the existing repo. If not, creates it. Handles race conditions
-// where a concurrent test run creates the repo between the check and
-// the create attempt.
+const findRepositoryByName = async (
+  page: Page,
+  name: string,
+): Promise<RepositoryResponse | undefined> => {
+  const headers = await getAuthHeaders(page);
+  const response = await page
+    .context()
+    .request.get(
+      `/api/content-sources/v1/repositories/?name=${encodeURIComponent(name)}`,
+      { headers },
+    );
+
+  if (response.status() !== 200) {
+    return undefined;
+  }
+
+  const body = await response.json();
+  return body.data?.find((r: RepositoryResponse) => r.name === name);
+};
+
+const normalizeUrl = (url: string) => url.replace(/\/+$/, '');
+
+const matchesRequest = (
+  repo: RepositoryResponse,
+  request: RepositoryRequest,
+): boolean =>
+  normalizeUrl(repo.url) === normalizeUrl(request.url) &&
+  !!repo.snapshot === !!request.snapshot;
+
+// A repository is only usable by a test once it has been introspected. Before
+// that the wizard still disables it, but with "we are still learning about it"
+// rather than whatever reason the test is asserting on, so waiting here keeps
+// that timing out of the specs.
+const waitForIntrospection = async (
+  page: Page,
+  name: string,
+): Promise<void> => {
+  await expect
+    .poll(
+      async () => {
+        const repo = await findRepositoryByName(page, name);
+        if (!repo) return 'missing';
+        if (!repo.last_introspection_time) return 'not introspected yet';
+        return repo.status ?? 'unknown';
+      },
+      {
+        message: `Repository "${name}" never became usable`,
+        timeout: INTROSPECTION_TIMEOUT,
+        intervals: [500, 1000, 2000, 5000],
+      },
+    )
+    .toBe('Valid');
+};
+
+// Ensures a repository with the given name exists, matches the requested
+// configuration, and has been introspected. Handles a concurrent run creating
+// the repository between the search and the create attempt.
 export const ensureRepositoryExists = async (
   page: Page,
   repository: RepositoryRequest,
 ): Promise<RepositoryResponse> => {
-  const headers = await getAuthHeaders(page);
+  const existing = await findRepositoryByName(page, repository.name);
 
-  // Check if the repo already exists by name
-  const searchResponse = await page
-    .context()
-    .request.get(
-      `/api/content-sources/v1/repositories/?name=${encodeURIComponent(repository.name)}`,
-      { headers },
-    );
-
-  if (searchResponse.status() === 200) {
-    const body = await searchResponse.json();
-    const existing = body.data?.find(
-      (r: { name: string }) => r.name === repository.name,
-    );
-    if (existing) {
-      return existing;
-    }
+  // Matching on the name alone would reuse a repository left behind with the
+  // wrong url or snapshot setting, which then fails every later run for a
+  // reason that looks nothing like stale fixture data.
+  if (existing && !matchesRequest(existing, repository)) {
+    await deleteRepositoryViaApi(page, existing.uuid);
   }
 
-  // Repo doesn't exist, create it
-  try {
-    return await createRepositoryViaApi(page, repository);
-  } catch {
-    // Another run may have created it concurrently, try searching again
-    const retryResponse = await page
-      .context()
-      .request.get(
-        `/api/content-sources/v1/repositories/?name=${encodeURIComponent(repository.name)}`,
-        { headers },
-      );
-
-    if (retryResponse.status() === 200) {
-      const body = await retryResponse.json();
-      const existing = body.data?.find(
-        (r: { name: string }) => r.name === repository.name,
-      );
-      if (existing) {
-        return existing;
+  if (!existing || !matchesRequest(existing, repository)) {
+    try {
+      await createRepositoryViaApi(page, repository);
+    } catch {
+      // A concurrent run may have created it in the meantime.
+      if (!(await findRepositoryByName(page, repository.name))) {
+        throw new Error(
+          `Failed to create or find repository "${repository.name}"`,
+        );
       }
     }
-
-    throw new Error(`Failed to create or find repository "${repository.name}"`);
   }
+
+  await waitForIntrospection(page, repository.name);
+
+  const repo = await findRepositoryByName(page, repository.name);
+  if (!repo) {
+    throw new Error(
+      `Repository "${repository.name}" disappeared after introspection`,
+    );
+  }
+  return repo;
 };
 
 export const deleteRepositoryByUrlViaApi = async (

--- a/playwright/helpers/apiHelpers.ts
+++ b/playwright/helpers/apiHelpers.ts
@@ -178,7 +178,7 @@ const matchesRequest = (
 // that the wizard still disables it, but with "we are still learning about it"
 // rather than whatever reason the test is asserting on, so waiting here keeps
 // that timing out of the specs.
-const waitForIntrospection = async (
+export const waitForIntrospection = async (
   page: Page,
   name: string,
 ): Promise<void> => {

--- a/playwright/helpers/login.ts
+++ b/playwright/helpers/login.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import { expect, type Page } from '@playwright/test';
+import { expect, type Locator, type Page } from '@playwright/test';
 
 import { closePopupsIfExist, isHosted } from './helpers';
 import { ibFrame } from './navHelpers';
@@ -36,38 +36,72 @@ export const login = async (page: Page, staticUser: boolean = false) => {
   return loginCockpit(page, user, password);
 };
 
-/**
- * Checks if the user is already authenticated, if not, logs them in
- * @param page - the page object
- * @param staticUser - if true, use the static user instead of dynamically created one
- */
+// How long the app gets to render before we give up. The landing page loads
+// chrome, the federated module, and the blueprint and image lists, so this is
+// not instant on a loaded CI runner.
+const AUTH_TIMEOUT = 30_000;
+
+type AuthState = 'app' | 'login' | 'neither';
+
+const detectAuthState = async (
+  appHeading: Locator,
+  loginField: Locator,
+): Promise<AuthState> => {
+  // Checked before the login form so that an app which has already rendered
+  // is never mistaken for a login prompt.
+  if (await appHeading.isVisible().catch(() => false)) return 'app';
+  if (await loginField.isVisible().catch(() => false)) return 'login';
+  return 'neither';
+};
+
+// Waits for the app or the login form, whichever arrives, and logs in only if
+// the login form is the one that showed up.
+//
+// This used to wait for the app alone and treat a timeout as "not logged in".
+// A slow render therefore sent the run off to fill a login form that was not
+// there, and the failure surfaced 30 seconds later as a missing "Red Hat login"
+// textbox - which reads as broken authentication no matter what actually went
+// wrong. Stage outages, a chrome-service 502, a saturated dev proxy and a slow
+// render have all been reported that way.
 export const ensureAuthenticated = async (
   page: Page,
   staticUser: boolean = false,
 ) => {
-  // Navigate to the target page
-  if (isHosted()) {
-    await page.goto('/insights/image-builder/landing');
-  } else {
-    await page.goto('/cockpit-image-builder');
-  }
+  await page.goto(
+    isHosted() ? '/insights/image-builder/landing' : '/cockpit-image-builder',
+  );
 
-  // Check for authentication success indicator
-  const successIndicator = isHosted()
+  const appHeading = isHosted()
     ? page.getByRole('heading', { name: 'Image builder' })
     : ibFrame(page).getByRole('heading', { name: 'Image builder' });
 
-  let isAuthenticated = false;
+  const loginField = isHosted()
+    ? page.getByRole('textbox', { name: 'Red Hat login' })
+    : page.getByRole('textbox', { name: 'User name' });
+
+  // Held in an object because TypeScript does not track assignments made
+  // inside the poll callback.
+  const seen: { state: AuthState } = { state: 'neither' };
   try {
-    // Give it a 30 second period to load, it's less expensive than having to rerun the test
-    await expect(successIndicator).toBeVisible({ timeout: 30000 });
-    isAuthenticated = true;
+    await expect
+      .poll(
+        async () => {
+          seen.state = await detectAuthState(appHeading, loginField);
+          return seen.state;
+        },
+        { timeout: AUTH_TIMEOUT, intervals: [250, 500, 1000] },
+      )
+      .not.toBe('neither');
   } catch {
-    isAuthenticated = false;
+    throw new Error(
+      `Neither image builder nor the login form appeared within ` +
+        `${AUTH_TIMEOUT / 1000}s at ${page.url()}. The app did not render, ` +
+        `which is not the same as being logged out - check the browser ` +
+        `console and the network log in the trace before suspecting SSO.`,
+    );
   }
 
-  if (!isAuthenticated) {
-    // Not authenticated, need to login
+  if (seen.state === 'login') {
     await login(page, staticUser);
   }
 };

--- a/playwright/helpers/login.ts
+++ b/playwright/helpers/login.ts
@@ -82,23 +82,43 @@ export const ensureAuthenticated = async (
   // Held in an object because TypeScript does not track assignments made
   // inside the poll callback.
   const seen: { state: AuthState } = { state: 'neither' };
-  try {
-    await expect
-      .poll(
-        async () => {
-          seen.state = await detectAuthState(appHeading, loginField);
-          return seen.state;
-        },
-        { timeout: AUTH_TIMEOUT, intervals: [250, 500, 1000] },
-      )
-      .not.toBe('neither');
-  } catch {
-    throw new Error(
-      `Neither image builder nor the login form appeared within ` +
-        `${AUTH_TIMEOUT / 1000}s at ${page.url()}. The app did not render, ` +
-        `which is not the same as being logged out - check the browser ` +
-        `console and the network log in the trace before suspecting SSO.`,
-    );
+  const settle = async () => {
+    try {
+      await expect
+        .poll(
+          async () => {
+            seen.state = await detectAuthState(appHeading, loginField);
+            return seen.state;
+          },
+          { timeout: AUTH_TIMEOUT, intervals: [250, 500, 1000] },
+        )
+        .not.toBe('neither');
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  if (!(await settle())) {
+    // A blank page usually means the federated module never mounted. Reloading
+    // recovers it often enough to be worth one attempt before failing.
+    await page.reload();
+    if (!(await settle())) {
+      // Distinguishes "chrome never loaded" from "chrome loaded but our module
+      // did not", which need to be chased in completely different places.
+      const chromeRendered = await page
+        .getByRole('banner')
+        .isVisible()
+        .catch(() => false);
+      throw new Error(
+        `Neither image builder nor the login form appeared within ` +
+          `${(AUTH_TIMEOUT / 1000) * 2}s (including one reload) at ` +
+          `${page.url()}. The console chrome ` +
+          `${chromeRendered ? 'rendered, so the image builder module failed to mount' : 'did not render either, so this is upstream of image builder'}. ` +
+          `This is not an authentication failure - check the browser console ` +
+          `and network log in the trace.`,
+      );
+    }
   }
 
   if (seen.state === 'login') {

--- a/playwright/helpers/wizardHelpers.ts
+++ b/playwright/helpers/wizardHelpers.ts
@@ -32,8 +32,15 @@ export const createBlueprint = async (
   // An informational modal may appear on first create if localStorage
   // does not have 'imageBuilder.saveAndBuildModalSeen'. Dismiss it and
   // click the button again.
+  // isVisible() ignores its timeout and reports the state right now, so a
+  // modal that took a moment to paint read as absent, the second click never
+  // happened, and the blueprint was silently never created.
   const closeBtn = page.getByTestId('close-button-saveandbuild-modal');
-  if (await closeBtn.isVisible({ timeout: 3000 }).catch(() => false)) {
+  const modalAppeared = await closeBtn
+    .waitFor({ state: 'visible', timeout: 3000 })
+    .then(() => true)
+    .catch(() => false);
+  if (modalAppeared) {
     await closeBtn.click();
     await page.getByRole('button', { name: 'Create blueprint' }).click();
   }

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -51,7 +51,9 @@ import {
 } from '@/store/slices/wizard';
 import {
   closeWizardModal,
+  markWizardInitialized,
   openWizardModal,
+  selectHasWizardInitialized,
   selectIsWizardModalOpen,
   selectWizardModalMode,
 } from '@/store/slices/wizardModal';
@@ -123,7 +125,7 @@ const CreateImageWizard = () => {
   const imageSource = useAppSelector(selectImageSource);
   const [searchParams, setSearchParams] = useSearchParams();
   const resolvePath = useAppSelector(selectPathResolver);
-  const hasInitialized = useRef(false);
+  const hasInitialized = useAppSelector(selectHasWizardInitialized);
   const { analytics, auth } = useChrome();
   const { userData } = useGetUser(auth);
   const hasTrackedInitialStepRef = useRef(false);
@@ -209,9 +211,9 @@ const CreateImageWizard = () => {
     }
 
     if (mode === 'create' && showWizardModal) {
-      if (!hasInitialized.current) {
+      if (!hasInitialized) {
         dispatch(initializeWizard());
-        hasInitialized.current = true;
+        dispatch(markWizardInitialized());
       }
 
       // Initialize registration URLs
@@ -389,7 +391,6 @@ const CreateImageWizard = () => {
   const handleClose = () => {
     dispatch(closeWizardModal());
     dispatch(initializeWizard());
-    hasInitialized.current = false;
     hasTrackedInitialStepRef.current = false;
     hasTrackedWizardOpenedRef.current = false;
 

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -183,6 +183,8 @@ const CreateImageWizard = () => {
     imagePullValidation.disabledNext ||
     (restrictions.users.isStandalone && usersHaveErrors);
 
+  const baseSettingsIsPending = !!detailsValidation.isPending;
+
   const advancedSettingsHasErrors =
     filesystemValidation.disabledNext ||
     timezoneValidation.disabledNext ||
@@ -488,6 +490,7 @@ const CreateImageWizard = () => {
             <CustomWizardFooter
               disableBack={true}
               hasErrors={baseSettingsHasErrors}
+              isPending={baseSettingsIsPending}
               isOnPremise={isOnPremise}
             />
           }

--- a/src/Components/CreateImageWizard/components/CustomWizardFooter.tsx
+++ b/src/Components/CreateImageWizard/components/CustomWizardFooter.tsx
@@ -21,6 +21,7 @@ import { scrollToFirstError } from '../utilities/scrollToFirstError';
 type CustomWizardFooterPropType = {
   disableBack?: boolean;
   hasErrors: boolean;
+  isPending?: boolean;
   beforeNext?: () => boolean;
   isOnPremise: boolean;
 };
@@ -28,6 +29,7 @@ type CustomWizardFooterPropType = {
 export const CustomWizardFooter = ({
   disableBack,
   hasErrors,
+  isPending,
   beforeNext,
   isOnPremise,
 }: CustomWizardFooterPropType) => {
@@ -37,6 +39,13 @@ export const CustomWizardFooter = ({
   const dispatch = useAppDispatch();
   const reviewAndFinishBtnID = 'wizard-review-and-finish-btn';
   const cancelBtnID = 'wizard-cancel-btn';
+
+  // While a check is still running there is no error to show, so clicking would
+  // do nothing at all. Disable instead: an enabled button that silently
+  // discards the click is indistinguishable from a broken page, both to a user
+  // and to anything automating one. Real errors keep their enabled button so
+  // that clicking still reveals them.
+  const isWaitingOnValidation = !!isPending && !hasErrors;
 
   const handleNext = () => {
     if (hasErrors) {
@@ -89,10 +98,18 @@ export const CustomWizardFooter = ({
         >
           Back
         </Button>
-        <Button variant='secondary' onClick={handleNext}>
+        <Button
+          variant='secondary'
+          onClick={handleNext}
+          isDisabled={isWaitingOnValidation}
+        >
           Next
         </Button>
-        <Button variant='primary' onClick={handleReview}>
+        <Button
+          variant='primary'
+          onClick={handleReview}
+          isDisabled={isWaitingOnValidation}
+        >
           Review image
         </Button>
         <Button

--- a/src/Components/CreateImageWizard/tests/WizardReinitialization.test.tsx
+++ b/src/Components/CreateImageWizard/tests/WizardReinitialization.test.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+
+import { configureStore } from '@reduxjs/toolkit';
+import { act, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { createMemoryRouter, RouterProvider } from 'react-router-dom';
+
+import { RootState, serviceMiddleware, serviceReducer } from '@/store';
+import { changeBlueprintName, setIsCustomName } from '@/store/slices/wizard';
+
+import CreateImageWizard from '../CreateImageWizard';
+
+// insights-chrome remounts this module routinely, so the wizard must treat a
+// remount as a continuation rather than a fresh start. Guarding initialization
+// with a ref silently discarded whatever the user had already entered.
+const renderWizardWithStore = (store: ReturnType<typeof makeStore>) => {
+  const router = createMemoryRouter(
+    [{ path: 'insights/image-builder/', element: <CreateImageWizard /> }],
+    { initialEntries: ['/insights/image-builder/'] },
+  );
+
+  return render(
+    <Provider store={store}>
+      <RouterProvider router={router} future={{ v7_startTransition: true }} />
+    </Provider>,
+  );
+};
+
+const makeStore = () =>
+  configureStore({
+    reducer: serviceReducer,
+    middleware: serviceMiddleware,
+    preloadedState: {
+      wizardModal: {
+        isModalOpen: true,
+        mode: 'create' as const,
+        hasInitialized: false,
+      },
+    } as Partial<RootState>,
+  });
+
+describe('wizard re-initialization', () => {
+  test('a remount does not discard details the user already entered', async () => {
+    const store = makeStore();
+
+    const view = renderWizardWithStore(store);
+    await screen.findByRole('heading', { name: /image output/i });
+
+    // Mirrors what typing in the Details step dispatches.
+    act(() => {
+      store.dispatch(changeBlueprintName('my-blueprint'));
+      store.dispatch(setIsCustomName());
+    });
+    expect(store.getState().wizard.details.blueprint.name).toBe('my-blueprint');
+
+    view.unmount();
+
+    renderWizardWithStore(store);
+    await screen.findByRole('heading', { name: /image output/i });
+
+    expect(store.getState().wizard.details.blueprint.name).toBe('my-blueprint');
+  });
+});

--- a/src/Components/CreateImageWizard/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/tests/helpers.tsx
@@ -77,6 +77,7 @@ export const renderWithQueryParams = async (
       wizardModal: {
         isModalOpen: true,
         mode: 'create' as const,
+        hasInitialized: false,
       },
     },
     initialRoute: `/insights/image-builder${queryString}`,
@@ -92,6 +93,7 @@ export const renderCreateMode = async (): Promise<{
       wizardModal: {
         isModalOpen: true,
         mode: 'create' as const,
+        hasInitialized: false,
       },
     },
     initialRoute: '/insights/image-builder/',
@@ -107,6 +109,7 @@ export const renderEditMode = async (
       wizardModal: {
         isModalOpen: true,
         mode: 'edit' as const,
+        hasInitialized: false,
       },
       blueprints: {
         selectedBlueprintId: blueprintId,
@@ -135,6 +138,7 @@ export const renderImportMode = async (
       wizardModal: {
         isModalOpen: true,
         mode: 'import' as const,
+        hasInitialized: false,
       },
       wizard: importBlueprintState,
     },

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -1175,7 +1175,7 @@ export function useDetailsValidation(): StepValidation {
   } else if (debouncedName !== name || isFetching || !data) {
     isUniqueName = null;
   } else {
-    isUniqueName = data.meta.count === 0 || data.data[0].id === blueprintId;
+    isUniqueName = data.meta.count === 0 || data.data[0]?.id === blueprintId;
   }
 
   let nameError = '';

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { CheckCircleIcon } from '@patternfly/react-icons';
 import { jwtDecode } from 'jwt-decode';
@@ -9,10 +9,10 @@ import {
   UNIQUE_VALIDATION_DELAY,
 } from '@/constants';
 import {
-  BlueprintsResponse,
+  useGetBlueprintQuery,
+  useGetBlueprintsQuery,
   useGetImageExistsQuery,
   useGetOscapCustomizationsQuery,
-  useLazyGetBlueprintsQuery,
 } from '@/store/api/backend';
 import { useShowActivationKeyQuery } from '@/store/api/rhsm';
 import { useAppSelector } from '@/store/hooks';
@@ -68,6 +68,7 @@ import {
   selectUsers,
   UserWithAdditionalInfo,
 } from '@/store/slices/wizard';
+import useDebounce from '@/Utilities/useDebounce';
 
 import { getListOfDuplicates } from './getListOfDuplicates';
 
@@ -109,6 +110,9 @@ export type StepValidation = {
     [key: string]: string;
   };
   disabledNext: boolean;
+  // An async check has not answered yet. Kept separate from disabledNext so a
+  // step can wait for the answer instead of treating it as a validation error.
+  isPending?: boolean;
 };
 
 export type UsersStepValidation = {
@@ -152,6 +156,7 @@ export function useIsBlueprintValid(): boolean {
     !services.disabledNext &&
     !firstBoot.disabledNext &&
     !details.disabledNext &&
+    !details.isPending &&
     !users.disabledNext &&
     !userGroups.disabledNext &&
     !azureTarget.disabledNext &&
@@ -1139,53 +1144,47 @@ export function useDetailsValidation(): StepValidation {
   const blueprintId = useAppSelector(selectBlueprintId);
 
   const nameValid = isBlueprintNameValid(name);
-  const [uniqueName, setUniqueName] = useState<boolean | null>(null);
 
-  const [trigger] = useLazyGetBlueprintsQuery();
+  // Already cached by the wizard, which fetches the same blueprint in edit mode
+  const { data: savedBlueprint } = useGetBlueprintQuery(
+    { id: blueprintId || '' },
+    { skip: !blueprintId },
+  );
 
-  // Debounce the API call to check if the name is unique
-  useEffect(() => {
-    if (name !== '' && nameValid) {
-      const timer = setTimeout(
-        () => {
-          setUniqueName(null);
-          trigger({ name })
-            .unwrap()
-            .then((response: BlueprintsResponse) => {
-              if (
-                response.meta.count > 0 &&
-                response.data[0].id !== blueprintId
-              ) {
-                setUniqueName(false);
-              } else {
-                setUniqueName(true);
-              }
-            })
-            .catch(() => {
-              // If the request fails, we assume the name is unique
-              setUniqueName(true);
-            });
-        },
-        UNIQUE_VALIDATION_DELAY, // If name is empty string, instantly return
-      );
+  // A name that hasn't been edited cannot collide with anything, so skip the
+  // lookup rather than spending a round trip to confirm it.
+  const isUnchangedName = !!blueprintId && name === savedBlueprint?.name;
+  const skipUniqueCheck = !name || !nameValid || isUnchangedName;
 
-      return () => {
-        clearTimeout(timer);
-      };
-    }
-  }, [blueprintId, name, setUniqueName, trigger, nameValid]);
+  // Debouncing the query argument rather than the request itself lets RTK Query
+  // own the caching. Every call site of this hook then shares one cache entry
+  // and one in-flight request, and a remount reads the cached answer instead of
+  // restarting the check from scratch.
+  const debouncedName = useDebounce(name, UNIQUE_VALIDATION_DELAY);
+
+  const { data, isFetching, isError } = useGetBlueprintsQuery(
+    { name: debouncedName },
+    { skip: skipUniqueCheck || !debouncedName },
+  );
+
+  let isUniqueName: boolean | null;
+  if (skipUniqueCheck || isError) {
+    // A check we could not run is not evidence of a collision, so fail open
+    // rather than block the user on it.
+    isUniqueName = true;
+  } else if (debouncedName !== name || isFetching || !data) {
+    isUniqueName = null;
+  } else {
+    isUniqueName = data.meta.count === 0 || data.data[0].id === blueprintId;
+  }
 
   let nameError = '';
   if (!name) {
     nameError = 'Blueprint name is required';
-  }
-  if (name && !nameValid) {
+  } else if (!nameValid) {
     nameError = 'Invalid blueprint name';
-  } else if (uniqueName === false) {
+  } else if (isUniqueName === false) {
     nameError = 'Blueprint with this name already exists';
-  } else if (!blueprintId && uniqueName === null) {
-    // Hack to keep the error message from flickering in create mode
-    return { errors: { name: '' }, disabledNext: false };
   }
 
   let descriptionError = '';
@@ -1199,8 +1198,10 @@ export function useDetailsValidation(): StepValidation {
       name: nameError,
       description: descriptionError,
     },
-    // if uniqueName is null, we are still waiting for the API response
-    disabledNext: !!nameError || !!descriptionError || uniqueName !== true,
+    disabledNext: !!nameError || !!descriptionError,
+    // Reported separately from disabledNext: nothing is known to be wrong yet,
+    // so the step should wait for the answer rather than report an error.
+    isPending: isUniqueName === null,
   };
 }
 

--- a/src/store/slices/wizard/tests/mockWizardState.ts
+++ b/src/store/slices/wizard/tests/mockWizardState.ts
@@ -13,6 +13,7 @@ export const mockRootState: RootState = {
   wizardModal: {
     isModalOpen: false,
     mode: 'create',
+    hasInitialized: false,
   },
   blueprints: {
     selectedBlueprintId: undefined,

--- a/src/store/slices/wizardModal/selectors.ts
+++ b/src/store/slices/wizardModal/selectors.ts
@@ -5,3 +5,6 @@ export const selectIsWizardModalOpen = (state: RootState) =>
 
 export const selectWizardModalMode = (state: RootState) =>
   state.wizardModal.mode;
+
+export const selectHasWizardInitialized = (state: RootState) =>
+  state.wizardModal.hasInitialized;

--- a/src/store/slices/wizardModal/slice.ts
+++ b/src/store/slices/wizardModal/slice.ts
@@ -3,11 +3,16 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 export type WizardModalState = {
   isModalOpen: boolean;
   mode: 'create' | 'edit' | 'import';
+  // Lives in the store rather than a ref because chrome remounts this module
+  // routinely; a ref resets on remount and lets the wizard re-initialize on
+  // top of whatever the user has already entered.
+  hasInitialized: boolean;
 };
 
 const initialState: WizardModalState = {
   isModalOpen: false,
   mode: 'create',
+  hasInitialized: false,
 };
 
 export const wizardModalSlice = createSlice({
@@ -21,10 +26,14 @@ export const wizardModalSlice = createSlice({
       state.isModalOpen = true;
       state.mode = action.payload;
     },
+    markWizardInitialized: (state) => {
+      state.hasInitialized = true;
+    },
     closeWizardModal: () => {
       return initialState;
     },
   },
 });
 
-export const { openWizardModal, closeWizardModal } = wizardModalSlice.actions;
+export const { openWizardModal, markWizardInitialized, closeWizardModal } =
+  wizardModalSlice.actions;


### PR DESCRIPTION
I think that this might help quite a bit with the flakiness in the Playwright tests.

To simulate a degraded stage environment locally, I created (and full disclosure, everything in this PR was done with Claude) a chaos testing middleware for Playwright. It simulates API responses coming back out of order which causes failures when there are race conditions.

The first commit fixes about 90% of the flakes. The tl;dr is that it was related to validating the uniqueness of blueprint names – this had a three state (true, false, in flight) that was treated as a boolean and some crufty debounce code that resulted in a race condition on advancing the blueprint. 

The other changes all came about from other less common flakes that cropped up during the chaos testing.

I still probably didn’t manage to catch everything but the chaos testing was so useful that I went ahead and committed it so that we can use it again the next time we start to observe flakes.

I’ve watched this run a few times now in the CI on this PR and not only is Playwright passing every time, it’s passing with 0 flakes (apart from the first run where it did flake, but then I used the chaos testing tool to reproduce and fix that flake, too!).

With the flakes hopefully sorted I went ahead and also tightened up the timeouts in Playwright – over time, in response to flakes, we’d added a lot of little increased timeouts here and there and increased the global timeout from 5 seconds to 50 seconds!