### PR TITLE
FileSystem: convert partition table from Table to Flex layout (HMS-11067)

### DIFF
--- a/playwright/Customizations/Disk.spec.ts
+++ b/playwright/Customizations/Disk.spec.ts
@@ -1,7 +1,7 @@
 import * as fsPromises from 'fs/promises';
 import * as path from 'path';
 
-import { expect } from '@playwright/test';
+import { expect, FrameLocator, Page } from '@playwright/test';
 
 import { test } from '../fixtures/customizations';
 import { exportedDiskBP } from '../fixtures/data/exportBlueprintContents';
@@ -22,6 +22,20 @@ import {
   registerLater,
   verifyExportedBlueprint,
 } from '../helpers/wizardHelpers';
+
+const getPlainPartitionRow = (frame: FrameLocator | Page, index: number) =>
+  frame
+    .getByLabel('File system table')
+    .first()
+    .locator('[data-testid^="partition-row-"]')
+    .nth(index);
+
+const getLvmPartitionRow = (frame: FrameLocator | Page, index: number) =>
+  frame
+    .getByLabel('File system table')
+    .nth(1)
+    .locator('[data-testid^="partition-row-"]')
+    .nth(index);
 
 test('Create a blueprint with Disk customization', async ({
   page,
@@ -76,10 +90,7 @@ test('Create a blueprint with Disk customization', async ({
 
   await test.step('Fill in some partitions and add a volume group', async () => {
     await frame.getByRole('button', { name: 'Add plain partition' }).click();
-    await frame
-      .getByRole('gridcell', { name: '/home' })
-      .getByPlaceholder('Define mount point')
-      .fill('/var/usb');
+    await frame.locator('input[value="/home"]').fill('/var/usb');
 
     await frame.getByPlaceholder('Define minimum size').nth(1).fill('10');
     await frame.getByRole('button', { name: 'GiB' }).nth(1).click();
@@ -87,10 +98,9 @@ test('Create a blueprint with Disk customization', async ({
 
     await frame.getByRole('button', { name: 'Volume Group Manager' }).click();
     await expect(
-      frame
-        .getByRole('row')
-        .nth(1)
-        .getByRole('button', { name: 'Remove partition' }),
+      getPlainPartitionRow(frame, 0).getByRole('button', {
+        name: 'Remove partition',
+      }),
     ).toBeEnabled();
 
     await frame
@@ -108,18 +118,16 @@ test('Create a blueprint with Disk customization', async ({
       .fill('lv1');
     await frame.getByRole('button', { name: 'Add logical volume' }).click();
     await frame
-      .getByRole('gridcell', { name: /\/home/ })
-      .getByPlaceholder('Define mount point')
+      .getByLabel('File system table')
+      .nth(1)
+      .locator('input[value="/home"]')
       .fill('/tmp/usb');
 
-    await frame
-      .getByRole('row', { name: /lv1/ })
+    const lv1Row = getLvmPartitionRow(frame, 0);
+    await lv1Row
       .getByRole('textbox', { name: 'Partition name input' })
       .fill('lv2');
-    await frame
-      .getByRole('row', { name: /lv2/ })
-      .getByPlaceholder('Define minimum size')
-      .fill('10');
+    await lv1Row.getByPlaceholder('Define minimum size').fill('10');
     await frame.getByRole('button', { name: 'GiB' }).nth(1).click();
     await frame.getByRole('option', { name: 'MiB' }).click();
   });
@@ -142,13 +150,15 @@ test('Create a blueprint with Disk customization', async ({
       }),
     ).toBeVisible();
 
-    const removeRootButton = frame
-      .getByRole('row')
-      .nth(1)
-      .getByRole('button', { name: 'Remove partition' });
+    const removeRootButton = getPlainPartitionRow(frame, 0).getByRole(
+      'button',
+      {
+        name: 'Remove partition',
+      },
+    );
     await expect(removeRootButton).toBeEnabled();
 
-    const secondRow = frame.getByRole('row').nth(2);
+    const secondRow = getPlainPartitionRow(frame, 1);
 
     const removeTmpButton = secondRow.getByRole('button', {
       name: 'Remove partition',
@@ -218,25 +228,25 @@ test('Create a blueprint with Disk customization', async ({
       }),
     ).toBeVisible();
 
-    const removeRootButton = frame
-      .getByRole('row')
-      .nth(1)
-      .getByRole('button', { name: 'Remove partition' });
+    const removeRootButton = getPlainPartitionRow(frame, 0).getByRole(
+      'button',
+      {
+        name: 'Remove partition',
+      },
+    );
 
     await expect(removeRootButton).toBeEnabled();
 
-    const secondRow = frame.getByRole('row').nth(2);
+    const secondRow = getPlainPartitionRow(frame, 1);
 
     const removeTmpButton = secondRow.getByRole('button', {
       name: 'Remove partition',
     });
     await expect(removeTmpButton).toBeEnabled();
 
-    await expect(
-      secondRow
-        .getByRole('gridcell', { name: '/srv/data' })
-        .getByPlaceholder('Define mount point'),
-    ).toBeVisible();
+    await expect(secondRow.getByPlaceholder('Define mount point')).toHaveValue(
+      '/srv/data',
+    );
 
     const size = secondRow.getByPlaceholder('Define minimum size');
     await expect(size).toHaveValue('5');

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/DiskRow.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/DiskRow.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 
-import { Button, Split, SplitItem } from '@patternfly/react-core';
+import {
+  Button,
+  Flex,
+  FlexItem,
+  Split,
+  SplitItem,
+} from '@patternfly/react-core';
 import { MinusCircleIcon } from '@patternfly/react-icons';
-import { Td, Tr } from '@patternfly/react-table';
 
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
@@ -36,19 +41,26 @@ const DiskRow = ({ partition }: DiskRowPropTypes) => {
   }
 
   return (
-    <Tr id={partition.id}>
+    <Flex
+      id={partition.id}
+      data-testid={`partition-row-${partition.id}`}
+      alignItems={{ default: 'alignItemsFlexStart' }}
+      className='pf-v6-u-pb-sm'
+    >
       {partition.type !== 'plain' && (
-        <Td width={30}>
+        <FlexItem style={{ flex: '0 0 25%' }}>
           <PartitionName partition={partition} customization={customization} />
-        </Td>
+        </FlexItem>
       )}
-      <Td width={30}>
+      <FlexItem
+        style={{ flex: partition.type !== 'plain' ? '0 0 25%' : '0 0 30%' }}
+      >
         <Mountpoint partition={partition} customization={customization} />
-      </Td>
-      <Td width={10}>
+      </FlexItem>
+      <FlexItem style={{ flex: '0 0 10%' }}>
         <PartitionType partition={partition} customization={customization} />
-      </Td>
-      <Td width={30}>
+      </FlexItem>
+      <FlexItem style={{ flex: '1 1 auto' }}>
         <Split hasGutter>
           <SplitItem isFilled>
             <MinimumSize partition={partition} customization={customization} />
@@ -57,14 +69,12 @@ const DiskRow = ({ partition }: DiskRowPropTypes) => {
             <SizeUnit partition={partition} customization={customization} />
           </SplitItem>
         </Split>
-      </Td>
-      <Td isActionCell>
+      </FlexItem>
+      <FlexItem style={{ flex: '0 0 auto' }}>
         <Button
           variant='plain'
           icon={<MinusCircleIcon />}
           onClick={() => handleRemovePartition(partition.id)}
-          // there needs to be at least one logical volume in a volume group
-          // this disables the "remove partition" button until another volume is added
           isDisabled={diskPartitions.some(
             (vg) =>
               vg.type === 'lvm' &&
@@ -73,8 +83,8 @@ const DiskRow = ({ partition }: DiskRowPropTypes) => {
           )}
           aria-label='Remove partition'
         />
-      </Td>
-    </Tr>
+      </FlexItem>
+    </Flex>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/DiskRow.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/DiskRow.tsx
@@ -42,25 +42,27 @@ const DiskRow = ({ partition }: DiskRowPropTypes) => {
 
   return (
     <Flex
+      role='row'
       id={partition.id}
       data-testid={`partition-row-${partition.id}`}
       alignItems={{ default: 'alignItemsFlexStart' }}
       className='pf-v6-u-pb-sm'
     >
       {partition.type !== 'plain' && (
-        <FlexItem style={{ flex: '0 0 25%' }}>
+        <FlexItem role='cell' style={{ flex: '0 0 25%' }}>
           <PartitionName partition={partition} customization={customization} />
         </FlexItem>
       )}
       <FlexItem
-        style={{ flex: partition.type !== 'plain' ? '0 0 25%' : '0 0 30%' }}
+        role='cell'
+        style={{ flex: partition.type !== 'plain' ? '0 0 25%' : '0 0 40%' }}
       >
         <Mountpoint partition={partition} customization={customization} />
       </FlexItem>
-      <FlexItem style={{ flex: '0 0 10%' }}>
+      <FlexItem role='cell' style={{ flex: '0 0 10%' }}>
         <PartitionType partition={partition} customization={customization} />
       </FlexItem>
-      <FlexItem style={{ flex: '1 1 auto' }}>
+      <FlexItem role='cell' style={{ flex: '1 1 auto' }}>
         <Split hasGutter>
           <SplitItem isFilled>
             <MinimumSize partition={partition} customization={customization} />
@@ -70,7 +72,7 @@ const DiskRow = ({ partition }: DiskRowPropTypes) => {
           </SplitItem>
         </Split>
       </FlexItem>
-      <FlexItem style={{ flex: '0 0 auto' }}>
+      <FlexItem role='cell' style={{ flex: '0 0 auto' }}>
         <Button
           variant='plain'
           icon={<MinusCircleIcon />}

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
@@ -65,14 +65,15 @@ const FileSystemTable = ({ partitions, mode }: FileSystemTableTypes) => {
   );
 
   return (
-    <div aria-label='File system table'>
-      <Flex className='pf-v6-u-pb-sm'>
+    <div role='table' aria-label='File system table'>
+      <Flex role='row' className='pf-v6-u-pb-sm'>
         {mode === 'disk-lvm' && (
-          <FlexItem style={{ flex: '0 0 25%' }}>
+          <FlexItem role='columnheader' style={{ flex: '0 0 25%' }}>
             <Content component='small'>Name</Content>
           </FlexItem>
         )}
         <FlexItem
+          role='columnheader'
           style={{
             flex: mode === 'disk-lvm' ? '0 0 25%' : '0 0 40%',
           }}
@@ -80,16 +81,17 @@ const FileSystemTable = ({ partitions, mode }: FileSystemTableTypes) => {
           <Content component='small'>Mount point</Content>
         </FlexItem>
         <FlexItem
+          role='columnheader'
           style={{
             flex: mode === 'filesystem' ? '0 0 20%' : '0 0 10%',
           }}
         >
           <Content component='small'>Type</Content>
         </FlexItem>
-        <FlexItem style={{ flex: '1 1 auto' }}>
+        <FlexItem role='columnheader' style={{ flex: '1 1 auto' }}>
           <Content component='small'>Minimum size</Content>
         </FlexItem>
-        <FlexItem style={{ flex: '0 0 auto' }}>
+        <FlexItem role='columnheader' style={{ flex: '0 0 auto' }}>
           <Content component='small' aria-label='Remove mount point'>
             {' '}
           </Content>

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/FileSystemTable.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo } from 'react';
 
-import { Table, Tbody, Th, Thead, Tr } from '@patternfly/react-table';
+import { Content, Flex, FlexItem } from '@patternfly/react-core';
 
 import { useGetOscapCustomizationsQuery } from '@/store/api/backend';
 import { useAppSelector } from '@/store/hooks';
@@ -65,42 +65,54 @@ const FileSystemTable = ({ partitions, mode }: FileSystemTableTypes) => {
   );
 
   return (
-    <Table
-      aria-label='File system table'
-      variant='compact'
-      borders={false}
-      style={{ backgroundColor: 'transparent' }}
-    >
-      <Thead>
-        <Tr>
-          {mode === 'disk-lvm' && <Th>Name</Th>}
-          <Th>Mount point</Th>
-          <Th>Type</Th>
-          <Th>Minimum size</Th>
-          <Th aria-label='Remove mount point' />
-        </Tr>
-      </Thead>
-
-      <Tbody>
-        {partitions.length > 0 && mode === 'filesystem'
-          ? partitions.map((partition) => (
-              <Row
-                key={partition.id}
-                partition={partition as FilesystemPartition}
-                isRemovingDisabled={
-                  rootPartitionsCount === 1 && partition.mountpoint === '/'
-                }
-                {...getOscapPartitionInfo(partition.mountpoint)}
-              />
-            ))
-          : partitions.map((partition) => (
-              <DiskRow
-                key={partition.id}
-                partition={partition as DiskPartition}
-              />
-            ))}
-      </Tbody>
-    </Table>
+    <div aria-label='File system table'>
+      <Flex className='pf-v6-u-pb-sm'>
+        {mode === 'disk-lvm' && (
+          <FlexItem style={{ flex: '0 0 25%' }}>
+            <Content component='small'>Name</Content>
+          </FlexItem>
+        )}
+        <FlexItem
+          style={{
+            flex: mode === 'disk-lvm' ? '0 0 25%' : '0 0 40%',
+          }}
+        >
+          <Content component='small'>Mount point</Content>
+        </FlexItem>
+        <FlexItem
+          style={{
+            flex: mode === 'filesystem' ? '0 0 20%' : '0 0 10%',
+          }}
+        >
+          <Content component='small'>Type</Content>
+        </FlexItem>
+        <FlexItem style={{ flex: '1 1 auto' }}>
+          <Content component='small'>Minimum size</Content>
+        </FlexItem>
+        <FlexItem style={{ flex: '0 0 auto' }}>
+          <Content component='small' aria-label='Remove mount point'>
+            {' '}
+          </Content>
+        </FlexItem>
+      </Flex>
+      {partitions.length > 0 && mode === 'filesystem'
+        ? partitions.map((partition) => (
+            <Row
+              key={partition.id}
+              partition={partition as FilesystemPartition}
+              isRemovingDisabled={
+                rootPartitionsCount === 1 && partition.mountpoint === '/'
+              }
+              {...getOscapPartitionInfo(partition.mountpoint)}
+            />
+          ))
+        : partitions.map((partition) => (
+            <DiskRow
+              key={partition.id}
+              partition={partition as DiskPartition}
+            />
+          ))}
+    </div>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
@@ -2,13 +2,14 @@ import React from 'react';
 
 import {
   Button,
+  Flex,
+  FlexItem,
   Split,
   SplitItem,
   TextInput,
   Tooltip,
 } from '@patternfly/react-core';
 import { LockIcon, MinusCircleIcon } from '@patternfly/react-icons';
-import { Td, Tr } from '@patternfly/react-table';
 
 import { useAppDispatch } from '@/store/hooks';
 import { FilesystemPartition, removePartition } from '@/store/slices/wizard';
@@ -57,23 +58,28 @@ const Row = ({
   );
 
   return (
-    <Tr id={partition.id}>
-      <Td width={40}>
+    <Flex
+      id={partition.id}
+      data-testid={`partition-row-${partition.id}`}
+      alignItems={{ default: 'alignItemsFlexStart' }}
+      className='pf-v6-u-pb-sm'
+    >
+      <FlexItem style={{ flex: '0 0 40%' }}>
         <Mountpoint
           partition={partition}
           customization={customization}
           isOscapRequired={isOscapRequired}
         />
-      </Td>
-      <Td width={20}>
+      </FlexItem>
+      <FlexItem style={{ flex: '0 0 20%' }}>
         <TextInput
           value='xfs'
           type='text'
           aria-label='Partition type'
           isDisabled
         />
-      </Td>
-      <Td width={40}>
+      </FlexItem>
+      <FlexItem style={{ flex: '1 1 auto' }}>
         <Split hasGutter>
           <SplitItem isFilled>
             <MinimumSize
@@ -91,8 +97,8 @@ const Row = ({
             />
           </SplitItem>
         </Split>
-      </Td>
-      <Td isActionCell>
+      </FlexItem>
+      <FlexItem style={{ flex: '0 0 auto' }}>
         {isOscapRequired || isRemovingDisabled ? (
           <Tooltip
             content={
@@ -106,8 +112,8 @@ const Row = ({
         ) : (
           removeButton
         )}
-      </Td>
-    </Tr>
+      </FlexItem>
+    </Flex>
   );
 };
 

--- a/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/components/Row.tsx
@@ -59,19 +59,20 @@ const Row = ({
 
   return (
     <Flex
+      role='row'
       id={partition.id}
       data-testid={`partition-row-${partition.id}`}
       alignItems={{ default: 'alignItemsFlexStart' }}
       className='pf-v6-u-pb-sm'
     >
-      <FlexItem style={{ flex: '0 0 40%' }}>
+      <FlexItem role='cell' style={{ flex: '0 0 40%' }}>
         <Mountpoint
           partition={partition}
           customization={customization}
           isOscapRequired={isOscapRequired}
         />
       </FlexItem>
-      <FlexItem style={{ flex: '0 0 20%' }}>
+      <FlexItem role='cell' style={{ flex: '0 0 20%' }}>
         <TextInput
           value='xfs'
           type='text'
@@ -79,7 +80,7 @@ const Row = ({
           isDisabled
         />
       </FlexItem>
-      <FlexItem style={{ flex: '1 1 auto' }}>
+      <FlexItem role='cell' style={{ flex: '1 1 auto' }}>
         <Split hasGutter>
           <SplitItem isFilled>
             <MinimumSize
@@ -98,7 +99,7 @@ const Row = ({
           </SplitItem>
         </Split>
       </FlexItem>
-      <FlexItem style={{ flex: '0 0 auto' }}>
+      <FlexItem role='cell' style={{ flex: '0 0 auto' }}>
         {isOscapRequired || isRemovingDisabled ? (
           <Tooltip
             content={

--- a/src/Components/CreateImageWizard/steps/FileSystem/tests/FileSystem.test.tsx
+++ b/src/Components/CreateImageWizard/steps/FileSystem/tests/FileSystem.test.tsx
@@ -157,13 +157,8 @@ describe('FileSystem Component', () => {
         name: /File system configuration/i,
       });
 
-      const partitionsTable = screen.getByRole('grid', {
-        name: /file system table/i,
-      });
-      const rows = within(partitionsTable).getAllByRole('row');
-      const thirdRow = rows[3];
-
-      const thirdRowMountpoint = within(thirdRow).getByDisplayValue('/var');
+      const varRow = screen.getByTestId('partition-row-3');
+      const thirdRowMountpoint = within(varRow).getByDisplayValue('/var');
       await clickWithWait(user, thirdRowMountpoint);
       await clearWithWait(user, thirdRowMountpoint);
       await typeWithWait(user, thirdRowMountpoint, '/home');
@@ -211,12 +206,7 @@ describe('FileSystem Component', () => {
       );
       expect(mountPointAlerts.length).toBeGreaterThanOrEqual(1);
 
-      const partitionsTable = screen.getByRole('grid', {
-        name: /file system table/i,
-      });
-      const rows = within(partitionsTable).getAllByRole('row');
-      const thirdRow = rows[3];
-
+      const thirdRow = screen.getByTestId('partition-row-3');
       const thirdRowMountpoint = within(thirdRow).getByDisplayValue('/home');
       await clickWithWait(user, thirdRowMountpoint);
       await clearWithWait(user, thirdRowMountpoint);
@@ -664,12 +654,11 @@ describe('FileSystem Component', () => {
         },
       });
 
-      const table = await screen.findByRole('grid', {
-        name: /file system table/i,
+      const table = await screen.findByLabelText(/file system table/i);
+      const mountpoints = within(table).getAllByRole('textbox', {
+        name: /mount point input/i,
       });
-      const rows = within(table).getAllByRole('row');
-      // Header row + 1 partition row
-      expect(rows).toHaveLength(2);
+      expect(mountpoints).toHaveLength(1);
     });
   });
 
@@ -694,7 +683,7 @@ describe('FileSystem Component', () => {
       });
 
       expect(
-        await screen.findByRole('grid', { name: /file system table/i }),
+        await screen.findByLabelText(/file system table/i),
       ).toBeInTheDocument();
     });
 
@@ -715,7 +704,7 @@ describe('FileSystem Component', () => {
       });
 
       expect(
-        screen.queryByRole('grid', { name: /file system table/i }),
+        screen.queryByLabelText(/file system table/i),
       ).not.toBeInTheDocument();
     });
 
@@ -797,14 +786,11 @@ describe('FileSystem Component', () => {
     test('OSCAP-required partition has disabled mountpoint input', async () => {
       renderWithOscapPartitions();
 
-      const table = await screen.findByRole('grid', {
-        name: /file system table/i,
-      });
-      const rows = within(table).getAllByRole('row');
-      const requiredRow = rows[2]; // /home
+      await screen.findByLabelText(/file system table/i);
+      const homeRow = screen.getByTestId('partition-row-2');
       await waitFor(() =>
         expect(
-          within(requiredRow).getByRole('textbox', {
+          within(homeRow).getByRole('textbox', {
             name: /mount point input/i,
           }),
         ).toBeDisabled(),
@@ -814,14 +800,11 @@ describe('FileSystem Component', () => {
     test('OSCAP-required partition has disabled remove button', async () => {
       renderWithOscapPartitions();
 
-      const table = await screen.findByRole('grid', {
-        name: /file system table/i,
-      });
-      const rows = within(table).getAllByRole('row');
-      const requiredRow = rows[3]; // /var
+      await screen.findByLabelText(/file system table/i);
+      const varRow = screen.getByTestId('partition-row-3');
       await waitFor(() =>
         expect(
-          within(requiredRow).getByRole('button', {
+          within(varRow).getByRole('button', {
             name: /remove partition/i,
           }),
         ).toBeDisabled(),
@@ -831,14 +814,11 @@ describe('FileSystem Component', () => {
     test('OSCAP-required partition has disabled size unit dropdown', async () => {
       renderWithOscapPartitions();
 
-      const table = await screen.findByRole('grid', {
-        name: /file system table/i,
-      });
-      const rows = within(table).getAllByRole('row');
-      const requiredRow = rows[2]; // /home
+      await screen.findByLabelText(/file system table/i);
+      const homeRow = screen.getByTestId('partition-row-2');
       await waitFor(() =>
         expect(
-          within(requiredRow).getByRole('button', { name: 'GiB' }),
+          within(homeRow).getByRole('button', { name: 'GiB' }),
         ).toBeDisabled(),
       );
     });
@@ -846,43 +826,33 @@ describe('FileSystem Component', () => {
     test('non-required partition controls remain enabled', async () => {
       renderWithOscapPartitions();
 
-      const table = await screen.findByRole('grid', {
-        name: /file system table/i,
-      });
-      const rows = within(table).getAllByRole('row');
+      await screen.findByLabelText(/file system table/i);
 
-      // Check that a required row is locked
-      const requiredRow = rows[2]; // /home — OSCAP-required
+      const homeRow = screen.getByTestId('partition-row-2');
       await waitFor(() =>
         expect(
-          within(requiredRow).getByRole('textbox', {
+          within(homeRow).getByRole('textbox', {
             name: /mount point input/i,
           }),
         ).toBeDisabled(),
       );
 
-      // Verify the non-required row remains enabled
-      const userRow = rows[4]; // /tmp — not in OSCAP profile
+      const tmpRow = screen.getByTestId('partition-row-4');
       expect(
-        within(userRow).getByRole('textbox', { name: /mount point input/i }),
+        within(tmpRow).getByRole('textbox', { name: /mount point input/i }),
       ).toBeEnabled();
       expect(
-        within(userRow).getByRole('button', { name: /remove partition/i }),
+        within(tmpRow).getByRole('button', { name: /remove partition/i }),
       ).toBeEnabled();
-      expect(
-        within(userRow).getByRole('button', { name: 'GiB' }),
-      ).toBeEnabled();
+      expect(within(tmpRow).getByRole('button', { name: 'GiB' })).toBeEnabled();
     });
 
     test('shows validation error when size is below OSCAP minimum', async () => {
       const user = createUser();
       renderWithOscapPartitions();
 
-      const table = await screen.findByRole('grid', {
-        name: /file system table/i,
-      });
-      const rows = within(table).getAllByRole('row');
-      const varRow = rows[3]; // /var
+      await screen.findByLabelText(/file system table/i);
+      const varRow = screen.getByTestId('partition-row-3');
 
       await waitFor(() =>
         expect(
@@ -908,11 +878,8 @@ describe('FileSystem Component', () => {
     test('no validation error when size meets OSCAP minimum', async () => {
       renderWithOscapPartitions();
 
-      const table = await screen.findByRole('grid', {
-        name: /file system table/i,
-      });
-      const rows = within(table).getAllByRole('row');
-      const varRow = rows[3]; // /var
+      await screen.findByLabelText(/file system table/i);
+      const varRow = screen.getByTestId('partition-row-3');
 
       await waitFor(() =>
         expect(

--- a/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
+++ b/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
@@ -77,15 +77,11 @@ describe('ImportMode', () => {
     await clickNext();
 
     // File system
-    const partitionsTable = await screen.findByRole('grid', {
-      name: /file system table/i,
-    });
+    const partitionsTable = await screen.findByLabelText(/file system table/i);
     expect(
       await within(partitionsTable).findByDisplayValue('/var'),
     ).toBeInTheDocument();
-    expect(
-      within(partitionsTable).getByRole('cell', { name: /2/i }),
-    ).toBeInTheDocument();
+    expect(within(partitionsTable).getByDisplayValue('2')).toBeInTheDocument();
 
     // Timezone
     await screen.findByRole('heading', { name: 'Time' });


### PR DESCRIPTION
Replace PatternFly Table/Tr/Td with Flex/FlexItem for tighter, more consistent spacing in the FileSystem step.
Before:
<img width="1321" height="537" alt="Screenshot 2026-08-17 at 10 22 28" src="https://github.com/user-attachments/assets/16ed732b-56b2-4842-bf3f-fd79f7f3777e" />
After:
<img width="1398" height="525" alt="Screenshot 2026-08-17 at 10 24 05" src="https://github.com/user-attachments/assets/2ceba928-d278-4d39-a238-d4ea94d92814" />




[HMS-11067]: https://redhat.atlassian.net/browse/HMS-11067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ