### PR TITLE
Wizard/Packages: Refetch package info in edit mode (HMS-11206)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -66,7 +66,6 @@ import {
   selectRecommendedRepositories,
   selectSnapshotDate,
   selectTemplate,
-  selectWizardMode,
 } from '@/store/slices/wizard';
 import { getEpelUrlForDistribution } from '@/Utilities/epel';
 import { releaseToVersion } from '@/Utilities/releaseToVersion';
@@ -109,7 +108,6 @@ const PackageSearch = ({
   const recommendedRepositories = useAppSelector(selectRecommendedRepositories);
   const template = useAppSelector(selectTemplate);
   const snapshotDate = useAppSelector(selectSnapshotDate);
-  const wizardMode = useAppSelector(selectWizardMode);
 
   const { packages: requiredPackages } = useSecuritySummary();
   const requiredSet = useMemo(
@@ -238,11 +236,6 @@ const PackageSearch = ({
       isLoading: isLoadingRecommendedGroups,
     },
   ] = useSearchPackageGroupMutation();
-
-  const [
-    searchPackageInfo,
-    { data: dataPackageInfo, isSuccess: isSuccessPackageInfo },
-  ] = useSearchRpmMutation();
 
   useEffect(() => {
     if (packageType === 'groups') {
@@ -382,62 +375,6 @@ const PackageSearch = ({
     isOnPremise,
     epelRepoUrlByDistribution,
   ]);
-
-  useEffect(() => {
-    if (
-      wizardMode !== 'create' &&
-      isSuccessDistroRepositories &&
-      packages.length > 0
-    ) {
-      searchPackageInfo({
-        apiContentUnitSearchRequest: {
-          exact_names: packages.map((pkg) => pkg.name),
-          urls: [...distroUrls, epelRepoUrlByDistribution],
-          include_package_sources: true,
-        },
-      });
-    }
-  }, [isSuccessDistroRepositories, distroUrls]);
-
-  useEffect(() => {
-    if (!isSuccessPackageInfo) return;
-
-    dataPackageInfo.forEach((rpm) => {
-      const existingPackage = packages.find(
-        (pkg) => pkg.name === rpm.package_name,
-      );
-      if (!existingPackage) return;
-
-      const enabledModule = modules.find((m) =>
-        rpm.package_sources?.some(
-          (s) => s.name === m.name && s.stream === m.stream,
-        ),
-      );
-
-      if (enabledModule) {
-        const source = rpm.package_sources?.find(
-          (s) =>
-            s.name === enabledModule.name && s.stream === enabledModule.stream,
-        );
-        dispatch(
-          addPackage({
-            ...existingPackage,
-            type: 'module',
-            module_name: enabledModule.name,
-            stream: enabledModule.stream,
-            ...(source?.end_date && { end_date: source.end_date }),
-          }),
-        );
-      } else if (rpm.package_sources?.[0]?.end_date) {
-        dispatch(
-          addPackage({
-            ...existingPackage,
-            end_date: rpm.package_sources[0].end_date,
-          }),
-        );
-      }
-    });
-  }, [dataPackageInfo, dispatch, isSuccessPackageInfo, modules]);
 
   const [
     fetchRecommendationDescriptions,

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -42,7 +42,6 @@ import {
   useGetTemplateQuery,
   useListRepositoriesQuery,
   useSearchPackageGroupMutation,
-  useSearchRepositoryModuleStreamsMutation,
   useSearchRpmMutation,
 } from '@/store/api/contentSources';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
@@ -241,9 +240,9 @@ const PackageSearch = ({
   ] = useSearchPackageGroupMutation();
 
   const [
-    searchModulesInfo,
-    { data: dataModulesInfo, isSuccess: isSuccessModulesInfo },
-  ] = useSearchRepositoryModuleStreamsMutation();
+    searchPackageInfo,
+    { data: dataPackageInfo, isSuccess: isSuccessPackageInfo },
+  ] = useSearchRpmMutation();
 
   useEffect(() => {
     if (packageType === 'groups') {
@@ -388,44 +387,57 @@ const PackageSearch = ({
     if (
       wizardMode !== 'create' &&
       isSuccessDistroRepositories &&
-      modules.length > 0
+      packages.length > 0
     ) {
-      searchModulesInfo({
-        apiSearchModuleStreamsRequest: {
-          rpm_names: modules.map((module) => module.name),
+      searchPackageInfo({
+        apiContentUnitSearchRequest: {
+          exact_names: packages.map((pkg) => pkg.name),
           urls: [...distroUrls, epelRepoUrlByDistribution],
-          uuids: [],
+          include_package_sources: true,
         },
       });
     }
-  }, [isSuccessDistroRepositories, modules, distroUrls]);
+  }, [isSuccessDistroRepositories, distroUrls]);
 
   useEffect(() => {
-    if (!isSuccessModulesInfo) return;
+    if (!isSuccessPackageInfo) return;
 
-    dataModulesInfo.forEach((module) => {
-      const enabledModule = modules.find((m) => m.name === module.module_name);
+    dataPackageInfo.forEach((rpm) => {
+      const existingPackage = packages.find(
+        (pkg) => pkg.name === rpm.package_name,
+      );
+      if (!existingPackage) return;
 
-      module.streams
-        ?.find((stream) => stream.stream === enabledModule?.stream)
-        ?.package_names?.forEach((packageName) => {
-          const existingPackage = packages.find(
-            (pkg) => pkg.name === packageName,
-          );
+      const enabledModule = modules.find((m) =>
+        rpm.package_sources?.some(
+          (s) => s.name === m.name && s.stream === m.stream,
+        ),
+      );
 
-          if (existingPackage && module.module_name && enabledModule) {
-            dispatch(
-              addPackage({
-                ...existingPackage,
-                type: 'module',
-                module_name: module.module_name,
-                stream: enabledModule.stream,
-              }),
-            );
-          }
-        });
+      if (enabledModule) {
+        const source = rpm.package_sources?.find(
+          (s) =>
+            s.name === enabledModule.name && s.stream === enabledModule.stream,
+        );
+        dispatch(
+          addPackage({
+            ...existingPackage,
+            type: 'module',
+            module_name: enabledModule.name,
+            stream: enabledModule.stream,
+            ...(source?.end_date && { end_date: source.end_date }),
+          }),
+        );
+      } else if (rpm.package_sources?.[0]?.end_date) {
+        dispatch(
+          addPackage({
+            ...existingPackage,
+            end_date: rpm.package_sources[0].end_date,
+          }),
+        );
+      }
     });
-  }, [dataModulesInfo, dispatch, isSuccessModulesInfo, modules]);
+  }, [dataPackageInfo, dispatch, isSuccessPackageInfo, modules]);
 
   const [
     fetchRecommendationDescriptions,

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useMemo, useState } from 'react';
+import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 
 import { Content, Label } from '@patternfly/react-core';
 import {
@@ -11,20 +11,33 @@ import {
   Tr,
 } from '@patternfly/react-table';
 
-import { useSecuritySummary } from '@/store/api/backend';
-import { ApiRepositoryCollectionResponseRead } from '@/store/api/contentSources';
+import { EPEL_10_REPO_DEFINITION } from '@/constants';
+import {
+  useGetArchitecturesQuery,
+  useSecuritySummary,
+} from '@/store/api/backend';
+import {
+  ApiRepositoryCollectionResponseRead,
+  useSearchRpmMutation,
+} from '@/store/api/contentSources';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
+  addPackage,
   GroupWithRepositoryInfo,
   IBPackageWithRepositoryInfo,
   removeModule,
   removePackage,
   removePackageGroup,
   removeRecommendedRepository,
+  selectArchitecture,
+  selectDistribution,
+  selectModules,
   selectPackageGroups,
   selectPackages,
   selectRecommendedRepositories,
+  selectWizardMode,
 } from '@/store/slices/wizard';
+import { getEpelUrlForDistribution } from '@/Utilities/epel';
 
 import EmptySearch from './EmptySearch';
 import RemovePackageButton from './RemovePackageButton';
@@ -40,11 +53,91 @@ const PackagesTable = ({ isSuccessEpelRepo, epelRepo }: PackagesTableProps) => {
   const recommendedRepositories = useAppSelector(selectRecommendedRepositories);
   const packages = useAppSelector(selectPackages);
   const groups = useAppSelector(selectPackageGroups);
+  const wizardMode = useAppSelector(selectWizardMode);
+  const distribution = useAppSelector(selectDistribution);
+  const arch = useAppSelector(selectArchitecture);
+  const modules = useAppSelector(selectModules);
+
   const { packages: requiredPkgNames } = useSecuritySummary();
   const requiredSet = useMemo(
     () => new Set(requiredPkgNames),
     [requiredPkgNames],
   );
+
+  const { data: distroRepositories, isSuccess: isSuccessDistroRepositories } =
+    useGetArchitecturesQuery({ distribution });
+
+  const distroUrls = useMemo(() => {
+    const urls = distroRepositories
+      ?.find((archItem) => archItem.arch === arch)
+      ?.repositories.filter((repo) => !!repo.baseurl)
+      .map((repo) => repo.baseurl!);
+    return urls ?? [];
+  }, [distroRepositories, arch]);
+
+  const epelRepoUrl =
+    getEpelUrlForDistribution(distribution) ?? EPEL_10_REPO_DEFINITION.url;
+
+  const [
+    searchPackageInfo,
+    { data: dataPackageInfo, isSuccess: isSuccessPackageInfo },
+  ] = useSearchRpmMutation();
+
+  useEffect(() => {
+    if (
+      wizardMode !== 'create' &&
+      isSuccessDistroRepositories &&
+      packages.length > 0
+    ) {
+      searchPackageInfo({
+        apiContentUnitSearchRequest: {
+          exact_names: packages.map((pkg) => pkg.name),
+          urls: [...distroUrls, epelRepoUrl],
+          include_package_sources: true,
+        },
+      });
+    }
+  }, [isSuccessDistroRepositories, distroUrls]);
+
+  useEffect(() => {
+    if (!isSuccessPackageInfo) return;
+
+    dataPackageInfo.forEach((rpm) => {
+      const existingPackage = packages.find(
+        (pkg) => pkg.name === rpm.package_name,
+      );
+      if (!existingPackage) return;
+
+      const enabledModule = modules.find((m) =>
+        rpm.package_sources?.some(
+          (s) => s.name === m.name && s.stream === m.stream,
+        ),
+      );
+
+      if (enabledModule) {
+        const source = rpm.package_sources?.find(
+          (s) =>
+            s.name === enabledModule.name && s.stream === enabledModule.stream,
+        );
+        dispatch(
+          addPackage({
+            ...existingPackage,
+            type: 'module',
+            module_name: enabledModule.name,
+            stream: enabledModule.stream,
+            ...(source?.end_date && { end_date: source.end_date }),
+          }),
+        );
+      } else if (rpm.package_sources?.[0]?.end_date) {
+        dispatch(
+          addPackage({
+            ...existingPackage,
+            end_date: rpm.package_sources[0].end_date,
+          }),
+        );
+      }
+    });
+  }, [dataPackageInfo, dispatch, isSuccessPackageInfo, modules]);
 
   const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set());
 

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackagesTable.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement, useEffect, useMemo, useState } from 'react';
 
-import { Content, Label } from '@patternfly/react-core';
+import { Content, Label, Spinner } from '@patternfly/react-core';
 import {
   ExpandableRowContent,
   Table,
@@ -80,7 +80,11 @@ const PackagesTable = ({ isSuccessEpelRepo, epelRepo }: PackagesTableProps) => {
 
   const [
     searchPackageInfo,
-    { data: dataPackageInfo, isSuccess: isSuccessPackageInfo },
+    {
+      data: dataPackageInfo,
+      isSuccess: isSuccessPackageInfo,
+      isLoading: isLoadingPackageInfo,
+    },
   ] = useSearchRpmMutation();
 
   useEffect(() => {
@@ -267,9 +271,21 @@ const PackagesTable = ({ isSuccessEpelRepo, epelRepo }: PackagesTableProps) => {
               <Td>
                 {pkg.name} {isRequired && <Label isCompact>Required</Label>}
               </Td>
-              <Td>{pkg.stream ? pkg.stream : '--'}</Td>
               <Td>
-                <RetirementDate date={pkg.end_date} />
+                {isLoadingPackageInfo && !pkg.stream ? (
+                  <Spinner size='sm' />
+                ) : pkg.stream ? (
+                  pkg.stream
+                ) : (
+                  '--'
+                )}
+              </Td>
+              <Td>
+                {isLoadingPackageInfo && !pkg.end_date ? (
+                  <Spinner size='sm' />
+                ) : (
+                  <RetirementDate date={pkg.end_date} />
+                )}
               </Td>
               <Td>
                 <RemovePackageButton
@@ -295,7 +311,14 @@ const PackagesTable = ({ isSuccessEpelRepo, epelRepo }: PackagesTableProps) => {
     return composePkgTable();
     // Would need significant rewrite to fix this
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [packages, groups, recommendedRepositories, expandedGroups, requiredSet]);
+  }, [
+    packages,
+    groups,
+    recommendedRepositories,
+    expandedGroups,
+    requiredSet,
+    isLoadingPackageInfo,
+  ]);
 
   return (
     <Table data-testid='packages-table' style={{ tableLayout: 'fixed' }}>

--- a/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/Packages.test.tsx
@@ -27,6 +27,7 @@ import {
   mockOscapCustomizations,
   mockOscapProfile,
   mockOscapSearchResults,
+  mockPackageInfoResults,
   mockRecommendations,
   mockSearchResults,
 } from './mocks';
@@ -987,6 +988,76 @@ describe('Packages Component', () => {
       await clickWithWait(user, testLibOptionAgain);
       expect(store.getState().wizard.content.packages).toHaveLength(1);
       expect(store.getState().wizard.content.packages[0].name).toBe('test-lib');
+    });
+
+    test('end_date is re-fetched for packages in edit mode', async () => {
+      fetchMock.mockResponse(
+        createFetchHandler({ rpms: mockPackageInfoResults }),
+      );
+
+      renderPackagesStep({
+        details: {
+          mode: 'edit',
+          blueprint: {
+            name: 'test-blueprint',
+            isCustomName: true,
+            description: '',
+            mode: 'package',
+          },
+        },
+        content: {
+          ...initialState.content,
+          packages: [
+            {
+              name: 'vim',
+              summary: '',
+              repository: 'distro',
+            },
+          ],
+        },
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText(/Jun 2030/)).toBeInTheDocument();
+      });
+    });
+
+    test('module stream and end_date are re-fetched in edit mode', async () => {
+      fetchMock.mockResponse(
+        createFetchHandler({ rpms: mockPackageInfoResults }),
+      );
+
+      const { store } = renderPackagesStep({
+        details: {
+          mode: 'edit',
+          blueprint: {
+            name: 'test-blueprint',
+            isCustomName: true,
+            description: '',
+            mode: 'package',
+          },
+        },
+        content: {
+          ...initialState.content,
+          packages: [
+            {
+              name: 'nginx',
+              summary: '',
+              repository: 'distro',
+            },
+          ],
+          enabledModules: [{ name: 'nginx', stream: '1.24' }],
+        },
+      });
+
+      await waitFor(() => {
+        const packages = store.getState().wizard.content.packages;
+        expect(packages[0].type).toBe('module');
+        expect(packages[0].stream).toBe('1.24');
+        expect(packages[0].end_date).toBe('2028-11-01');
+      });
+
+      expect(screen.getByText(/Nov 2028/)).toBeInTheDocument();
     });
 
     test('required package not yet selected can still be added via search', async () => {

--- a/src/Components/CreateImageWizard/steps/Packages/tests/mocks/fixtures.ts
+++ b/src/Components/CreateImageWizard/steps/Packages/tests/mocks/fixtures.ts
@@ -82,6 +82,35 @@ export const mockArchitectures: Record<string, Architectures> = {
   ],
 };
 
+export const mockPackageInfoResults: ApiSearchRpmResponse[] = [
+  {
+    package_name: 'vim',
+    package_sources: [
+      {
+        type: 'package',
+        end_date: '2030-06-15',
+      },
+    ],
+  },
+  {
+    package_name: 'nginx',
+    package_sources: [
+      {
+        name: 'nginx',
+        type: 'module',
+        stream: '1.22',
+        end_date: '2026-05-01',
+      },
+      {
+        name: 'nginx',
+        type: 'module',
+        stream: '1.24',
+        end_date: '2028-11-01',
+      },
+    ],
+  },
+];
+
 export const mockRecommendations: string[] = [
   'recommendedPackage1',
   'recommendedPackage2',


### PR DESCRIPTION
Since the packages are stored in a flat list of names, we need to re-fetch application stream and end date when the blueprint is opened in edit mode.

Fixes #2122

JIRA: [HMS-11206](https://issues.redhat.com/browse/HMS-11206)

[HMS-11206]: https://redhat.atlassian.net/browse/HMS-11206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ