### PR TITLE
Wizard: hide the standalone users steps for unsupported targets

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -190,7 +190,9 @@ const CreateImageWizard = () => {
     aapValidation.disabledNext ||
     snapshotValidation.disabledNext ||
     imagePullValidation.disabledNext ||
-    (restrictions.users.isStandalone && usersHaveErrors);
+    (!restrictions.users.shouldHide &&
+      restrictions.users.isStandalone &&
+      usersHaveErrors);
 
   const baseSettingsIsPending = !!detailsValidation.isPending;
 
@@ -528,10 +530,12 @@ const CreateImageWizard = () => {
               !(
                 restrictions.openscap.shouldHide && restrictions.fips.shouldHide
               ) && <OscapStep key='oscap' />,
-              restrictions.users.isStandalone && <UsersStep key='users' />,
-              restrictions.users.isStandalone && (
-                <UserGroupsStep key='groups' />
-              ),
+              !restrictions.users.shouldHide &&
+                restrictions.users.isStandalone && <UsersStep key='users' />,
+              !restrictions.users.shouldHide &&
+                restrictions.users.isStandalone && (
+                  <UserGroupsStep key='groups' />
+                ),
             ]
               .filter(Boolean)
               .flatMap((component, index, array) =>


### PR DESCRIPTION
In image mode the standalone Users and Groups steps rendered whenever isStandalone was set, ignoring shouldHide. Selecting only the container installer, which supports no customizations, still showed both steps. Guard the two consumer sites with shouldHide.