### PR TITLE
cockpit/spec: do not run unit tests during rpm build

### DIFF
--- a/cockpit/cockpit-image-builder.spec
+++ b/cockpit/cockpit-image-builder.spec
@@ -46,9 +46,6 @@ install -m 0644 -vp cockpit/tmpfiles.d/cockpit-image-builder.conf %{buildroot}%{
 
 %check
 appstream-util validate-relax --nonet %{buildroot}/%{_datadir}/metainfo/*
-%if 0%{?fedora}
-npm run test:cockpit
-%endif
 
 %files
 %doc cockpit/README.md


### PR DESCRIPTION
They do not work on anything other than Fedora, and Fedora Rawhide's npm seems broken ("Error: Cannot find native binding"). This needs further investigation. Let's revisit it later after RHEL deadlines.