### PR TITLE
dependabot: Update github-actions (HMS-11225)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,13 @@
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 2
+    rebase-strategy: "auto"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:


### PR DESCRIPTION
This adds github actions to the dependabot updates schedule. Setting is the same as for the npm packages, including a cooldown period. The limit of open pull request is slightly lower. There's no specific reason for it, happy to update that.

JIRA: [HMS-11225](https://issues.redhat.com/browse/HMS-11225)

[HMS-11225]: https://redhat.atlassian.net/browse/HMS-11225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ