### PR TITLE
Wizard: Differentiate between OpenSCAP and compliance in labels (HMS-11236)

### DIFF
--- a/src/Components/CreateImageWizard/steps/Kernel/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/index.tsx
@@ -6,12 +6,13 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import { useSecuritySummary } from '@/store/api/backend';
 import { useAppSelector } from '@/store/hooks';
-import { selectFips } from '@/store/slices/wizard';
+import { selectComplianceType, selectFips } from '@/store/slices/wizard';
 
 import KernelArguments from './components/KernelArguments';
 import KernelName from './components/KernelName';
 
 const KernelStep = () => {
+  const complianceType = useAppSelector(selectComplianceType);
   const fips = useAppSelector(selectFips);
 
   const {
@@ -30,7 +31,8 @@ const KernelStep = () => {
           Kernel
           {requiredByOpenSCAP.length > 0 && (
             <Label icon={<InfoCircleIcon />} className='pf-v6-u-ml-sm'>
-              {requiredByOpenSCAP.length} Added by OpenSCAP
+              {requiredByOpenSCAP.length} Added by{' '}
+              {complianceType === 'openscap' ? 'OpenSCAP' : 'compliance'}
             </Label>
           )}
         </Title>

--- a/src/Components/CreateImageWizard/steps/Kernel/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Alert, Content, Label, Title } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { Alert, Content, Title } from '@patternfly/react-core';
 
+import AddedByLabel from '@/Components/sharedComponents/AddedByLabel';
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import { useSecuritySummary } from '@/store/api/backend';
 import { useAppSelector } from '@/store/hooks';
@@ -29,12 +29,10 @@ const KernelStep = () => {
           className='pf-v6-u-display-flex pf-v6-u-align-items-center'
         >
           Kernel
-          {requiredByOpenSCAP.length > 0 && (
-            <Label icon={<InfoCircleIcon />} className='pf-v6-u-ml-sm'>
-              {requiredByOpenSCAP.length} Added by{' '}
-              {complianceType === 'openscap' ? 'OpenSCAP' : 'compliance'}
-            </Label>
-          )}
+          <AddedByLabel
+            count={requiredByOpenSCAP.length}
+            complianceType={complianceType}
+          />
         </Title>
         <Content component='small'>
           Choose a kernel package and append specific boot parameters to

--- a/src/Components/CreateImageWizard/steps/Packages/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/index.tsx
@@ -7,12 +7,13 @@ import { CustomizationLabels } from '@/Components/sharedComponents/Customization
 import { useSecuritySummary } from '@/store/api/backend/hooks';
 import { useAppSelector } from '@/store/hooks';
 import { selectIsOnPremise } from '@/store/slices/env';
-import { selectPackages } from '@/store/slices/wizard';
+import { selectComplianceType, selectPackages } from '@/store/slices/wizard';
 
 import Packages from './components/Packages';
 
 const PackagesStep = () => {
   const isOnPremise = useAppSelector(selectIsOnPremise);
+  const complianceType = useAppSelector(selectComplianceType);
   const packages = useAppSelector(selectPackages);
 
   const { packages: oscapPackages } = useSecuritySummary();
@@ -33,7 +34,8 @@ const PackagesStep = () => {
           Packages
           {requiredByOpenSCAPCount > 0 && (
             <Label icon={<InfoCircleIcon />} className='pf-v6-u-ml-sm'>
-              {requiredByOpenSCAPCount} Added by OpenSCAP
+              {requiredByOpenSCAPCount} Added by{' '}
+              {complianceType === 'openscap' ? 'OpenSCAP' : 'compliance'}
             </Label>
           )}
         </Title>

--- a/src/Components/CreateImageWizard/steps/Packages/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Content, Label, Title } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { Content, Title } from '@patternfly/react-core';
 
+import AddedByLabel from '@/Components/sharedComponents/AddedByLabel';
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import { useSecuritySummary } from '@/store/api/backend/hooks';
 import { useAppSelector } from '@/store/hooks';
@@ -32,12 +32,10 @@ const PackagesStep = () => {
           className='pf-v6-u-display-flex pf-v6-u-align-items-center'
         >
           Packages
-          {requiredByOpenSCAPCount > 0 && (
-            <Label icon={<InfoCircleIcon />} className='pf-v6-u-ml-sm'>
-              {requiredByOpenSCAPCount} Added by{' '}
-              {complianceType === 'openscap' ? 'OpenSCAP' : 'compliance'}
-            </Label>
-          )}
+          <AddedByLabel
+            count={requiredByOpenSCAPCount}
+            complianceType={complianceType}
+          />
         </Title>
         <Content component='small'>
           Search and add individual packages to include in your image. You can

--- a/src/Components/CreateImageWizard/steps/Services/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/index.tsx
@@ -5,11 +5,14 @@ import { InfoCircleIcon } from '@patternfly/react-icons';
 
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import { useSecuritySummary } from '@/store/api/backend';
+import { useAppSelector } from '@/store/hooks';
+import { selectComplianceType } from '@/store/slices';
 
 import ServicesInput from './components/ServicesInputs';
 
 const ServicesStep = () => {
   const { services: requiredByOpenSCAP } = useSecuritySummary();
+  const complianceType = useAppSelector(selectComplianceType);
 
   return (
     <>
@@ -23,7 +26,8 @@ const ServicesStep = () => {
           Systemd services
           {requiredByOpenSCAP.total > 0 && (
             <Label icon={<InfoCircleIcon />} className='pf-v6-u-ml-sm'>
-              {requiredByOpenSCAP.total} Added by OpenSCAP
+              {requiredByOpenSCAP.total} Added by{' '}
+              {complianceType === 'openscap' ? 'OpenSCAP' : 'compliance'}
             </Label>
           )}
         </Title>

--- a/src/Components/CreateImageWizard/steps/Services/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { Content, Label, Title } from '@patternfly/react-core';
-import { InfoCircleIcon } from '@patternfly/react-icons';
+import { Content, Title } from '@patternfly/react-core';
 
+import AddedByLabel from '@/Components/sharedComponents/AddedByLabel';
 import { CustomizationLabels } from '@/Components/sharedComponents/CustomizationLabels';
 import { useSecuritySummary } from '@/store/api/backend';
 import { useAppSelector } from '@/store/hooks';
@@ -24,12 +24,10 @@ const ServicesStep = () => {
           className='pf-v6-u-display-flex pf-v6-u-align-items-center'
         >
           Systemd services
-          {requiredByOpenSCAP.total > 0 && (
-            <Label icon={<InfoCircleIcon />} className='pf-v6-u-ml-sm'>
-              {requiredByOpenSCAP.total} Added by{' '}
-              {complianceType === 'openscap' ? 'OpenSCAP' : 'compliance'}
-            </Label>
-          )}
+          <AddedByLabel
+            count={requiredByOpenSCAP.total}
+            complianceType={complianceType}
+          />
         </Title>
         <Content component='small'>
           Configure systemd units to manage your system’s services and startup

--- a/src/Components/sharedComponents/AddedByLabel.tsx
+++ b/src/Components/sharedComponents/AddedByLabel.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { Label } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
+
+import { ComplianceType } from '@/store/slices';
+
+type AddedByLabelProps = {
+  count: number;
+  complianceType: ComplianceType;
+};
+
+const AddedByLabel = ({ count, complianceType }: AddedByLabelProps) => {
+  return (
+    count > 0 && (
+      <Label icon={<InfoCircleIcon />} className='pf-v6-u-ml-sm'>
+        {count} Added by{' '}
+        {complianceType === 'openscap' ? 'OpenSCAP' : 'compliance'}
+      </Label>
+    )
+  );
+};
+
+export default AddedByLabel;


### PR DESCRIPTION
Label "<amount> added by OpenSCAP" said OpenSCAP even in cases when the services/kernel were added by compliance. This adds logic to differentiate between the two.

<img width="776" height="218" alt="image" src="https://github.com/user-attachments/assets/862b108e-e342-4bed-8067-1316f8ce587d" />

<img width="778" height="220" alt="image" src="https://github.com/user-attachments/assets/f4b15c71-f064-4f15-9020-0a39b435fb09" />


JIRA: [HMS-11236](https://issues.redhat.com/browse/HMS-11236)

[HMS-11236]: https://redhat.atlassian.net/browse/HMS-11236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ