### PR TITLE
Refactor hostname validation to use Zod schema (HMS-11227)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "react-dom": "18.3.1",
         "react-redux": "9.3.0",
         "react-router-dom": "6.30.4",
-        "smol-toml": "1.8.0"
+        "smol-toml": "1.8.0",
+        "zod": "4.4.3"
       },
       "devDependencies": {
         "@aws-sdk/client-ec2": "3.1113.0",
@@ -23060,7 +23061,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-dom": "18.3.1",
     "react-redux": "9.3.0",
     "react-router-dom": "6.30.4",
-    "smol-toml": "1.8.0"
+    "smol-toml": "1.8.0",
+    "zod": "4.4.3"
   },
   "devDependencies": {
     "@aws-sdk/client-ec2": "3.1113.0",

--- a/src/Components/CreateImageWizard/steps/Hostname/tests/Hostname.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Hostname/tests/Hostname.test.tsx
@@ -112,7 +112,9 @@ describe('Hostname Component', () => {
       await enterHostname(user, 'a'.repeat(65));
       await tabAway(user);
 
-      expect(await screen.findByText(/Invalid hostname/i)).toBeInTheDocument();
+      expect(
+        await screen.findByText(/Hostname must be no more than 64 characters/i),
+      ).toBeInTheDocument();
     });
 
     test('does not show error for valid hostname', async () => {

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -70,6 +70,7 @@ import {
   selectUserGroups,
   selectUsers,
   UserWithAdditionalInfo,
+  validateHostname,
 } from '@/store/slices/wizard';
 import useDebounce from '@/Utilities/useDebounce';
 
@@ -90,7 +91,6 @@ import {
   isDiskMinSizeValid,
   isGcpDomainValid,
   isGcpEmailValid,
-  isHostnameValid,
   isKernelArgumentValid,
   isMountpointMinSizeValid,
   isNtpServerValid,
@@ -643,19 +643,11 @@ export function useFirstBootValidation(): StepValidation {
 
 export function useHostnameValidation(): StepValidation {
   const hostname = useAppSelector(selectHostname);
-
-  // Error message taken from hostname man page (`man 5 hostname`)
-  const errorMessage =
-    'Invalid hostname. The hostname should be composed of up to 64 7-bit ASCII lower-case alphanumeric characters or hyphens forming a valid DNS domain name. It is recommended that this name contains only a single label, i.e. without any dots.';
-
-  const hostnameError =
-    hostname && !isHostnameValid(hostname) ? errorMessage : '';
+  const errors = validateHostname(hostname);
 
   return {
-    errors: {
-      hostname: hostnameError,
-    },
-    disabledNext: !!hostnameError,
+    errors,
+    disabledNext: 'hostname' in errors,
   };
 }
 

--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -254,15 +254,6 @@ export const isNtpServerValid = (ntpServer: string) => {
   return /^([a-z0-9-]+)?(([.:/]{1,3}[a-z0-9-]+)){1,}$/.test(ntpServer);
 };
 
-export const isHostnameValid = (hostname: string) => {
-  return (
-    hostname.length < 65 &&
-    /^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$/.test(
-      hostname,
-    )
-  );
-};
-
 export const isKernelArgumentValid = (arg: string) => {
   return /^[a-zA-Z0-9=\-_,."'/:#+;\\]*$/.test(arg);
 };

--- a/src/store/slices/wizard/system/index.ts
+++ b/src/store/slices/wizard/system/index.ts
@@ -6,3 +6,4 @@ export * from './slice';
 export { initialState as systemState } from './state';
 export * from './types';
 export * from './utilities';
+export * from './validators';

--- a/src/store/slices/wizard/system/schemas.ts
+++ b/src/store/slices/wizard/system/schemas.ts
@@ -1,0 +1,12 @@
+import z from 'zod';
+
+export const hostnameSchema = z
+  .string()
+  .max(64, 'Hostname must be no more than 64 characters.')
+  // TODO: Consider splitting this complex regex into multiple Zod .regex() / .refine()
+  // checks to provide more specific, user-friendly error messages (e.g., "cannot contain
+  // consecutive dots", "cannot start with hyphen", etc.)
+  .regex(
+    /^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$/,
+    'Invalid hostname. The hostname should be composed of 7-bit ASCII lower-case alphanumeric characters or hyphens forming a valid DNS domain name. It is recommended that this name contains only a single label, i.e. without any dots.',
+  );

--- a/src/store/slices/wizard/system/tests/validators.test.ts
+++ b/src/store/slices/wizard/system/tests/validators.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import { isHostnameValid } from '@/Components/CreateImageWizard/validators';
+
+describe('hostname validation', () => {
+  describe('valid hostnames', () => {
+    it('accepts a simple hostname', () => {
+      expect(isHostnameValid('my-host')).toBe(true);
+    });
+
+    it('accepts a single character hostname', () => {
+      expect(isHostnameValid('a')).toBe(true);
+    });
+
+    it('accepts a numeric hostname', () => {
+      expect(isHostnameValid('123')).toBe(true);
+    });
+
+    it('accepts a hostname with dots (FQDN)', () => {
+      expect(isHostnameValid('host.example.com')).toBe(true);
+    });
+
+    it('accepts a hostname at max length (64 characters)', () => {
+      const hostname = 'a'.repeat(64);
+      expect(isHostnameValid(hostname)).toBe(true);
+    });
+
+    it('accepts hyphens in the middle', () => {
+      expect(isHostnameValid('my-cool-host')).toBe(true);
+    });
+  });
+
+  describe('invalid hostnames', () => {
+    it('rejects an empty string', () => {
+      expect(isHostnameValid('')).toBe(false);
+    });
+
+    it('rejects a hostname over 64 characters', () => {
+      const hostname = 'a'.repeat(65);
+      expect(isHostnameValid(hostname)).toBe(false);
+    });
+
+    it('rejects uppercase characters', () => {
+      expect(isHostnameValid('My-Host')).toBe(false);
+    });
+
+    it('rejects a leading hyphen', () => {
+      expect(isHostnameValid('-my-host')).toBe(false);
+    });
+
+    it('rejects a trailing hyphen', () => {
+      expect(isHostnameValid('my-host-')).toBe(false);
+    });
+
+    it('rejects special characters', () => {
+      expect(isHostnameValid('my_host!')).toBe(false);
+    });
+
+    it('rejects underscores', () => {
+      expect(isHostnameValid('my_host')).toBe(false);
+    });
+
+    it('rejects spaces', () => {
+      expect(isHostnameValid('my host')).toBe(false);
+    });
+
+    it('rejects a trailing dot', () => {
+      expect(isHostnameValid('host.')).toBe(false);
+    });
+
+    it('rejects a leading dot', () => {
+      expect(isHostnameValid('.host')).toBe(false);
+    });
+
+    it('rejects consecutive dots', () => {
+      expect(isHostnameValid('host..example')).toBe(false);
+    });
+  });
+});

--- a/src/store/slices/wizard/system/tests/validators.test.ts
+++ b/src/store/slices/wizard/system/tests/validators.test.ts
@@ -1,79 +1,79 @@
 import { describe, expect, it } from 'vitest';
 
-import { isHostnameValid } from '@/Components/CreateImageWizard/validators';
+import { hostnameSchema } from '../schemas';
 
 describe('hostname validation', () => {
   describe('valid hostnames', () => {
     it('accepts a simple hostname', () => {
-      expect(isHostnameValid('my-host')).toBe(true);
+      expect(hostnameSchema.safeParse('my-host').success).toBe(true);
     });
 
     it('accepts a single character hostname', () => {
-      expect(isHostnameValid('a')).toBe(true);
+      expect(hostnameSchema.safeParse('a').success).toBe(true);
     });
 
     it('accepts a numeric hostname', () => {
-      expect(isHostnameValid('123')).toBe(true);
+      expect(hostnameSchema.safeParse('123').success).toBe(true);
     });
 
     it('accepts a hostname with dots (FQDN)', () => {
-      expect(isHostnameValid('host.example.com')).toBe(true);
+      expect(hostnameSchema.safeParse('host.example.com').success).toBe(true);
     });
 
     it('accepts a hostname at max length (64 characters)', () => {
       const hostname = 'a'.repeat(64);
-      expect(isHostnameValid(hostname)).toBe(true);
+      expect(hostnameSchema.safeParse(hostname).success).toBe(true);
     });
 
     it('accepts hyphens in the middle', () => {
-      expect(isHostnameValid('my-cool-host')).toBe(true);
+      expect(hostnameSchema.safeParse('my-cool-host').success).toBe(true);
     });
   });
 
   describe('invalid hostnames', () => {
     it('rejects an empty string', () => {
-      expect(isHostnameValid('')).toBe(false);
+      expect(hostnameSchema.safeParse('').success).toBe(false);
     });
 
     it('rejects a hostname over 64 characters', () => {
       const hostname = 'a'.repeat(65);
-      expect(isHostnameValid(hostname)).toBe(false);
+      expect(hostnameSchema.safeParse(hostname).success).toBe(false);
     });
 
     it('rejects uppercase characters', () => {
-      expect(isHostnameValid('My-Host')).toBe(false);
+      expect(hostnameSchema.safeParse('My-Host').success).toBe(false);
     });
 
     it('rejects a leading hyphen', () => {
-      expect(isHostnameValid('-my-host')).toBe(false);
+      expect(hostnameSchema.safeParse('-my-host').success).toBe(false);
     });
 
     it('rejects a trailing hyphen', () => {
-      expect(isHostnameValid('my-host-')).toBe(false);
+      expect(hostnameSchema.safeParse('my-host-').success).toBe(false);
     });
 
     it('rejects special characters', () => {
-      expect(isHostnameValid('my_host!')).toBe(false);
+      expect(hostnameSchema.safeParse('my_host!').success).toBe(false);
     });
 
     it('rejects underscores', () => {
-      expect(isHostnameValid('my_host')).toBe(false);
+      expect(hostnameSchema.safeParse('my_host').success).toBe(false);
     });
 
     it('rejects spaces', () => {
-      expect(isHostnameValid('my host')).toBe(false);
+      expect(hostnameSchema.safeParse('my host').success).toBe(false);
     });
 
     it('rejects a trailing dot', () => {
-      expect(isHostnameValid('host.')).toBe(false);
+      expect(hostnameSchema.safeParse('host.').success).toBe(false);
     });
 
     it('rejects a leading dot', () => {
-      expect(isHostnameValid('.host')).toBe(false);
+      expect(hostnameSchema.safeParse('.host').success).toBe(false);
     });
 
     it('rejects consecutive dots', () => {
-      expect(isHostnameValid('host..example')).toBe(false);
+      expect(hostnameSchema.safeParse('host..example').success).toBe(false);
     });
   });
 });

--- a/src/store/slices/wizard/system/validators.ts
+++ b/src/store/slices/wizard/system/validators.ts
@@ -1,0 +1,18 @@
+import { hostnameSchema } from './schemas';
+
+import type { ValidationErrors } from '../types';
+
+export const validateHostname = (hostname: string): ValidationErrors => {
+  if (!hostname) return {};
+
+  const result = hostnameSchema.safeParse(hostname);
+  if (result.success) {
+    return {};
+  }
+
+  return {
+    // NOTE: just return the first issue for now, this
+    // is all our frontend currently support
+    hostname: result.error.issues[0]?.message ?? 'Invalid hostname',
+  };
+};

--- a/src/store/slices/wizard/types.ts
+++ b/src/store/slices/wizard/types.ts
@@ -4,6 +4,11 @@ import {
   ImageRequest,
 } from '@/store/api/backend';
 
+// Field-level validation errors for wizard subslices.
+// Empty record = valid; non-empty = one or more fields have errors.
+// Consumers derive disabledNext from this rather than tracking it separately.
+export type ValidationErrors = Record<string, string>;
+
 type BlueprintWithImageRequests = BlueprintExportResponse & {
   image_requests?: ImageRequest[] | undefined;
 };


### PR DESCRIPTION
## Summary

Refactor hostname validation to use Zod schema for runtime validation, moving validator logic from component utilities to the Redux store for better reusability and maintainability. This centralizes schema definitions and ensures consistent validation across the application.

## Changes

- Add Zod schema for hostname validation in `src/store/slices/wizard/system/schemas.ts`
- Create dedicated validator module in `src/store/slices/wizard/system/validators.ts` with hostname validation function
- Migrate `useValidation` hook to use the new `validateHostname` function instead of inline validation logic
- Update Hostname component tests to verify validation through the new validator
- Add comprehensive test coverage for hostname validation edge cases in store slice tests
- Add Zod as a runtime dependency for schema validation
