### PR TITLE
fix: prevent duplicate wheel group in setUserAdministratorByIndex (HMS-10912)

### DIFF
--- a/src/store/slices/wizard/system/slice.ts
+++ b/src/store/slices/wizard/system/slice.ts
@@ -259,7 +259,9 @@ export const systemSlice = createSlice({
 
       user.isAdministrator = isAdministrator;
       if (isAdministrator) {
-        user.groups.push('wheel');
+        if (!user.groups.includes('wheel')) {
+          user.groups.push('wheel');
+        }
       } else {
         user.groups = user.groups.filter((group) => group !== 'wheel');
       }

--- a/src/store/slices/wizard/system/tests/users.test.ts
+++ b/src/store/slices/wizard/system/tests/users.test.ts
@@ -176,6 +176,19 @@ describe('user reducers', () => {
 
       expect(result.system.users[0].groups).toEqual(['developers', 'docker']);
     });
+
+    it('should not duplicate wheel when user already has it', () => {
+      const state = createUserState([
+        createDefaultUser({ groups: ['wheel'], isAdministrator: true }),
+      ]);
+
+      const result = wizardReducer(
+        state,
+        setUserAdministratorByIndex({ index: 0, isAdministrator: true }),
+      );
+
+      expect(result.system.users[0].groups).toEqual(['wheel']);
+    });
   });
 
   describe('addGroupToUserByUserIndex', () => {


### PR DESCRIPTION
Guard against adding wheel to a user's groups array when it is already present. Without the check, toggling administrator status multiple times or setting it on a user who already belongs to wheel produces duplicate entries.


JIRA: HMS-10912