### PR TITLE
Split hostname validation into granular checks with a pure validator

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -44,11 +44,13 @@ import {
   loadWizardState,
   parseStateFromRequest,
   selectDistribution,
+  selectHostname,
   selectImageSource,
   selectImageSourceType,
   selectImageTypes,
   selectIsImageMode,
   selectTimezone,
+  validateHostname,
 } from '@/store/slices/wizard';
 import {
   closeWizardModal,
@@ -101,7 +103,6 @@ import {
   useFirewallValidation,
   useFirstBootValidation,
   useGcpValidation,
-  useHostnameValidation,
   useImagePullValidation,
   useKernelValidation,
   useLocaleValidation,
@@ -158,7 +159,6 @@ const CreateImageWizard = () => {
   const filesystemValidation = useFilesystemValidation();
   const timezoneValidation = useTimezoneValidation();
   const localeValidation = useLocaleValidation();
-  const hostnameValidation = useHostnameValidation();
   const kernelValidation = useKernelValidation();
   const servicesValidation = useServicesValidation();
   const firewallValidation = useFirewallValidation();
@@ -166,6 +166,8 @@ const CreateImageWizard = () => {
   const usersValidation = useUsersValidation();
   const userGroupsValidation = useUserGroupsValidation();
   const imagePullValidation = useImagePullValidation();
+
+  const hostnameErrors = validateHostname(useAppSelector(selectHostname));
 
   const { restrictions } = useCustomizationRestrictions({
     selectedImageTypes: targetEnvironments,
@@ -200,7 +202,7 @@ const CreateImageWizard = () => {
     filesystemValidation.disabledNext ||
     timezoneValidation.disabledNext ||
     localeValidation.disabledNext ||
-    hostnameValidation.disabledNext ||
+    hostnameErrors.length > 0 ||
     kernelValidation.disabledNext ||
     servicesValidation.disabledNext ||
     firewallValidation.disabledNext ||

--- a/src/Components/CreateImageWizard/steps/Hostname/components/HostnameInput.tsx
+++ b/src/Components/CreateImageWizard/steps/Hostname/components/HostnameInput.tsx
@@ -11,15 +11,18 @@ import {
 } from '@patternfly/react-core';
 import { TimesIcon } from '@patternfly/react-icons';
 
-import { useHostnameValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
-import { changeHostname, selectHostname } from '@/store/slices/wizard';
+import {
+  changeHostname,
+  selectHostname,
+  validateHostname,
+} from '@/store/slices/wizard';
 
 const HostnameInput = () => {
   const dispatch = useAppDispatch();
   const hostname = useAppSelector(selectHostname);
   const [isPristine, setIsPristine] = useState(!hostname);
-  const stepValidation = useHostnameValidation();
+  const errors = validateHostname(hostname);
 
   const handleChange = (
     _e: React.FormEvent<HTMLInputElement>,
@@ -44,7 +47,7 @@ const HostnameInput = () => {
     }
   };
 
-  const hasError = !isPristine && !!stepValidation.errors.hostname;
+  const hasError = !isPristine && errors.length > 0;
 
   return (
     <FormGroup label='Hostname'>
@@ -70,9 +73,11 @@ const HostnameInput = () => {
       </TextInputGroup>
       {hasError && (
         <HelperText>
-          <HelperTextItem variant='error'>
-            {stepValidation.errors.hostname}
-          </HelperTextItem>
+          {errors.map((error) => (
+            <HelperTextItem key={error.message} variant='error'>
+              {error.message}
+            </HelperTextItem>
+          ))}
         </HelperText>
       )}
     </FormGroup>

--- a/src/Components/CreateImageWizard/steps/Hostname/tests/Hostname.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Hostname/tests/Hostname.test.tsx
@@ -92,7 +92,9 @@ describe('Hostname Component', () => {
       await enterHostname(user, '-invalid');
       await tabAway(user);
 
-      expect(await screen.findByText(/Invalid hostname/i)).toBeInTheDocument();
+      expect(
+        await screen.findByText(/labels cannot start or end with a hyphen/i),
+      ).toBeInTheDocument();
     });
 
     test('shows error for hostname with uppercase letters', async () => {
@@ -102,7 +104,9 @@ describe('Hostname Component', () => {
       await enterHostname(user, 'INVALID');
       await tabAway(user);
 
-      expect(await screen.findByText(/Invalid hostname/i)).toBeInTheDocument();
+      expect(
+        await screen.findByText(/may only contain lowercase letters/i),
+      ).toBeInTheDocument();
     });
 
     test('shows error for hostname exceeding 64 characters', async () => {
@@ -143,13 +147,17 @@ describe('Hostname Component', () => {
 
       await enterHostname(user, '-invalid');
       await tabAway(user);
-      expect(await screen.findByText(/Invalid hostname/i)).toBeInTheDocument();
+      expect(
+        await screen.findByText(/labels cannot start or end with a hyphen/i),
+      ).toBeInTheDocument();
 
       await clearHostname(user);
       await enterHostname(user, 'valid-hostname');
       await tabAway(user);
 
-      expect(screen.queryByText(/Invalid hostname/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/labels cannot start or end with a hyphen/i),
+      ).not.toBeInTheDocument();
     });
 
     test('does not show error before interaction', async () => {
@@ -166,10 +174,14 @@ describe('Hostname Component', () => {
 
       await enterHostname(user, '-invalid');
       await tabAway(user);
-      expect(await screen.findByText(/Invalid hostname/i)).toBeInTheDocument();
+      expect(
+        await screen.findByText(/labels cannot start or end with a hyphen/i),
+      ).toBeInTheDocument();
 
       await clearHostname(user);
-      expect(screen.queryByText(/Invalid hostname/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/labels cannot start or end with a hyphen/i),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
+++ b/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
@@ -203,7 +203,9 @@ describe('ImportMode', () => {
     );
 
     // Hostname
-    expect(await screen.findByText(/Invalid hostname/)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/labels cannot start or end with a hyphen/),
+    ).toBeInTheDocument();
     await clearWithWait(
       user,
       screen.getByRole('textbox', {

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -135,7 +135,6 @@ export function useIsBlueprintValid(): boolean {
   const snapshot = useSnapshotValidation();
   const timezone = useTimezoneValidation();
   const locale = useLocaleValidation();
-  const hostname = useHostnameValidation();
   const kernel = useKernelValidation();
   const firewall = useFirewallValidation();
   const services = useServicesValidation();
@@ -146,6 +145,9 @@ export function useIsBlueprintValid(): boolean {
   const azureTarget = useAzureValidation();
   const gcpTarget = useGcpValidation();
   const awsTarget = useAwsValidation();
+
+  const hostnameErrors = validateHostname(useAppSelector(selectHostname));
+
   return (
     !aap.disabledNext &&
     !registration.disabledNext &&
@@ -153,7 +155,7 @@ export function useIsBlueprintValid(): boolean {
     !snapshot.disabledNext &&
     !timezone.disabledNext &&
     !locale.disabledNext &&
-    !hostname.disabledNext &&
+    hostnameErrors.length === 0 &&
     !kernel.disabledNext &&
     !firewall.disabledNext &&
     !services.disabledNext &&
@@ -638,16 +640,6 @@ export function useFirstBootValidation(): StepValidation {
       script: valid ? '' : 'Missing shebang at first line, e.g. #!/bin/bash',
     },
     disabledNext: !valid,
-  };
-}
-
-export function useHostnameValidation(): StepValidation {
-  const hostname = useAppSelector(selectHostname);
-  const errors = validateHostname(hostname);
-
-  return {
-    errors,
-    disabledNext: 'hostname' in errors,
   };
 }
 

--- a/src/store/slices/wizard/system/schemas.ts
+++ b/src/store/slices/wizard/system/schemas.ts
@@ -3,10 +3,20 @@ import z from 'zod';
 export const hostnameSchema = z
   .string()
   .max(64, 'Hostname must be no more than 64 characters.')
-  // TODO: Consider splitting this complex regex into multiple Zod .regex() / .refine()
-  // checks to provide more specific, user-friendly error messages (e.g., "cannot contain
-  // consecutive dots", "cannot start with hyphen", etc.)
   .regex(
-    /^(([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])\.)*([a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$/,
-    'Invalid hostname. The hostname should be composed of 7-bit ASCII lower-case alphanumeric characters or hyphens forming a valid DNS domain name. It is recommended that this name contains only a single label, i.e. without any dots.',
+    /^[a-z0-9.-]*$/,
+    'Hostname may only contain lowercase letters, digits, hyphens, and dots.',
+  )
+  .refine((hostname) => !hostname.startsWith('.') && !hostname.endsWith('.'), {
+    error: 'Hostname cannot start or end with a dot.',
+  })
+  .refine((hostname) => !hostname.includes('..'), {
+    error: 'Hostname cannot contain consecutive dots.',
+  })
+  .refine(
+    (hostname) =>
+      hostname
+        .split('.')
+        .every((label) => !label.startsWith('-') && !label.endsWith('-')),
+    { error: 'Hostname labels cannot start or end with a hyphen.' },
   );

--- a/src/store/slices/wizard/system/tests/validators.test.ts
+++ b/src/store/slices/wizard/system/tests/validators.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { hostnameSchema } from '../schemas';
+import { validateHostname } from '../validators';
 
 describe('hostname validation', () => {
   describe('valid hostnames', () => {
@@ -106,5 +107,26 @@ describe('hostname validation', () => {
         'Hostname labels cannot start or end with a hyphen.',
       ]);
     });
+  });
+});
+
+describe('validateHostname', () => {
+  it('returns no issues for an empty string', () => {
+    expect(validateHostname('')).toEqual([]);
+  });
+
+  it('returns no issues for a valid hostname', () => {
+    expect(validateHostname('host.example.com')).toEqual([]);
+  });
+
+  it('maps every schema violation to a format issue', () => {
+    const issues = validateHostname('.-foo');
+    expect(issues).toHaveLength(2);
+    expect(issues.map((issue) => issue.kind)).toEqual(['format', 'format']);
+    expect(issues.map((issue) => issue.value)).toEqual(['.-foo', '.-foo']);
+    expect(issues.map((issue) => issue.message)).toEqual([
+      'Hostname cannot start or end with a dot.',
+      'Hostname labels cannot start or end with a hyphen.',
+    ]);
   });
 });

--- a/src/store/slices/wizard/system/tests/validators.test.ts
+++ b/src/store/slices/wizard/system/tests/validators.test.ts
@@ -28,13 +28,13 @@ describe('hostname validation', () => {
     it('accepts hyphens in the middle', () => {
       expect(hostnameSchema.safeParse('my-cool-host').success).toBe(true);
     });
+
+    it('accepts an empty string (hostname is not required)', () => {
+      expect(hostnameSchema.safeParse('').success).toBe(true);
+    });
   });
 
   describe('invalid hostnames', () => {
-    it('rejects an empty string', () => {
-      expect(hostnameSchema.safeParse('').success).toBe(false);
-    });
-
     it('rejects a hostname over 64 characters', () => {
       const hostname = 'a'.repeat(65);
       expect(hostnameSchema.safeParse(hostname).success).toBe(false);
@@ -74,6 +74,37 @@ describe('hostname validation', () => {
 
     it('rejects consecutive dots', () => {
       expect(hostnameSchema.safeParse('host..example').success).toBe(false);
+    });
+  });
+
+  describe('rule-specific messages', () => {
+    const messagesFor = (hostname: string) =>
+      hostnameSchema.safeParse(hostname).error?.issues.map((i) => i.message) ??
+      [];
+
+    it('names the dot-placement rule for a leading dot', () => {
+      expect(messagesFor('.invalid')).toContain(
+        'Hostname cannot start or end with a dot.',
+      );
+    });
+
+    it('names the consecutive-dots rule', () => {
+      expect(messagesFor('a..b')).toContain(
+        'Hostname cannot contain consecutive dots.',
+      );
+    });
+
+    it('names the label-hyphen rule for a non-leading label', () => {
+      expect(messagesFor('host.-label')).toContain(
+        'Hostname labels cannot start or end with a hyphen.',
+      );
+    });
+
+    it('reports every violation at once rather than short-circuiting', () => {
+      expect(messagesFor('.-foo')).toEqual([
+        'Hostname cannot start or end with a dot.',
+        'Hostname labels cannot start or end with a hyphen.',
+      ]);
     });
   });
 });

--- a/src/store/slices/wizard/system/validators.ts
+++ b/src/store/slices/wizard/system/validators.ts
@@ -1,18 +1,16 @@
 import { hostnameSchema } from './schemas';
 
-import type { ValidationErrors } from '../types';
+import type { ValidationResult } from '../types';
 
-export const validateHostname = (hostname: string): ValidationErrors => {
-  if (!hostname) return {};
+export const validateHostname = (hostname: string): ValidationResult => {
+  if (!hostname) return [];
 
   const result = hostnameSchema.safeParse(hostname);
-  if (result.success) {
-    return {};
-  }
+  if (result.success) return [];
 
-  return {
-    // NOTE: just return the first issue for now, this
-    // is all our frontend currently support
-    hostname: result.error.issues[0]?.message ?? 'Invalid hostname',
-  };
+  return result.error.issues.map((issue) => ({
+    kind: 'format' as const,
+    message: issue.message,
+    value: hostname,
+  }));
 };

--- a/src/store/slices/wizard/types.ts
+++ b/src/store/slices/wizard/types.ts
@@ -4,10 +4,13 @@ import {
   ImageRequest,
 } from '@/store/api/backend';
 
-// Field-level validation errors for wizard subslices.
-// Empty record = valid; non-empty = one or more fields have errors.
-// Consumers derive disabledNext from this rather than tracking it separately.
-export type ValidationErrors = Record<string, string>;
+export type ValidationIssue = {
+  message: string;
+  value?: string;
+  kind?: 'format' | 'duplicate';
+};
+
+export type ValidationResult = ValidationIssue[];
 
 type BlueprintWithImageRequests = BlueprintExportResponse & {
   image_requests?: ImageRequest[] | undefined;


### PR DESCRIPTION
## Summary

Follow-up to the hostname validation work: splits the catch-all regex into granular, per-rule checks and replaces the validation hook with a pure `validateHostname` function, so the wizard surfaces specific, actionable errors instead of one generic message.

## Changes

- Split the hostname schema into granular Zod checks (character set, dot placement, label hyphens) so every violation is reported at once with a targeted message.
- Replace the `useHostnameValidation` hook with a pure `validateHostname` that returns structured `ValidationIssue[]`, dropping unnecessary React overhead and making the logic independently testable.
- Render every validation issue in `HostnameInput` rather than only the first failure.
- Populate each issue's `value` with the offending input.
- Add unit coverage for the granular rule messages (including multiple-error stacking) and the `validateHostname` contract.
