### PR TITLE
Add kernel argument validation and reusable ValidatedListInput component (HMS-11247)

### DIFF
--- a/playwright/Customizations/Kernel.spec.ts
+++ b/playwright/Customizations/Kernel.spec.ts
@@ -128,9 +128,7 @@ test('Create a blueprint with Kernel customization', async ({
       .fill('invalid$argument');
     await frame.getByPlaceholder('Add kernel argument').press('Enter');
     await expect(
-      frame.getByText(
-        'Expected format: <kernel-argument>. Example: console=tty0',
-      ),
+      frame.getByText('Kernel argument contains invalid characters'),
     ).toBeVisible();
     await frame.getByPlaceholder('Add kernel argument').fill('console=tty0');
     await frame.getByPlaceholder('Add kernel argument').press('Enter');

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -49,8 +49,10 @@ import {
   selectImageSourceType,
   selectImageTypes,
   selectIsImageMode,
+  selectKernel,
   selectTimezone,
   validateHostname,
+  validateKernel,
 } from '@/store/slices/wizard';
 import {
   closeWizardModal,
@@ -104,7 +106,6 @@ import {
   useFirstBootValidation,
   useGcpValidation,
   useImagePullValidation,
-  useKernelValidation,
   useLocaleValidation,
   useRegistrationValidation,
   useServicesValidation,
@@ -159,7 +160,6 @@ const CreateImageWizard = () => {
   const filesystemValidation = useFilesystemValidation();
   const timezoneValidation = useTimezoneValidation();
   const localeValidation = useLocaleValidation();
-  const kernelValidation = useKernelValidation();
   const servicesValidation = useServicesValidation();
   const firewallValidation = useFirewallValidation();
   const firstBootValidation = useFirstBootValidation();
@@ -168,6 +168,7 @@ const CreateImageWizard = () => {
   const imagePullValidation = useImagePullValidation();
 
   const hostnameErrors = validateHostname(useAppSelector(selectHostname));
+  const kernelErrors = validateKernel(useAppSelector(selectKernel));
 
   const { restrictions } = useCustomizationRestrictions({
     selectedImageTypes: targetEnvironments,
@@ -200,7 +201,7 @@ const CreateImageWizard = () => {
     timezoneValidation.disabledNext ||
     localeValidation.disabledNext ||
     hostnameErrors.length > 0 ||
-    kernelValidation.disabledNext ||
+    kernelErrors.length > 0 ||
     servicesValidation.disabledNext ||
     firewallValidation.disabledNext ||
     firstBootValidation.disabledNext ||

--- a/src/Components/CreateImageWizard/ValidatedListInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedListInput.tsx
@@ -1,0 +1,197 @@
+import React, { useId, useMemo, useState } from 'react';
+
+import {
+  Button,
+  Flex,
+  FlexItem,
+  HelperText,
+  HelperTextItem,
+  Label,
+  LabelGroup,
+  TextInputGroup,
+  TextInputGroupMain,
+  Truncate,
+} from '@patternfly/react-core/dist/esm';
+import { PlusCircleIcon } from '@patternfly/react-icons';
+
+import type { ValidationResult } from '@/store/slices/wizard/types';
+import type { MergedListItem } from '@/Utilities/mergeListItems';
+
+const DEFAULT_TRUNCATE_LENGTH = 20;
+const DEFAULT_CHIP_COLLAPSE_THRESHOLD = 4;
+
+type ValidatedListInputProps = {
+  ariaLabel: string;
+  placeholder: string;
+  validator: (items: string[]) => ValidationResult;
+  items: MergedListItem[];
+  onAdd: (value: string) => void;
+  onRemove: (value: string) => void;
+  truncateLength?: number;
+  isCompact?: boolean;
+  chipCollapseThreshold?: number;
+  hideAddLabel?: boolean;
+  helperText?: string;
+  addButtonAriaLabel?: string;
+};
+
+const ValidatedListInput = ({
+  ariaLabel,
+  placeholder,
+  validator,
+  items,
+  onAdd,
+  onRemove,
+  truncateLength = DEFAULT_TRUNCATE_LENGTH,
+  isCompact = false,
+  chipCollapseThreshold = DEFAULT_CHIP_COLLAPSE_THRESHOLD,
+  hideAddLabel = false,
+  helperText,
+  addButtonAriaLabel = 'Add',
+}: ValidatedListInputProps) => {
+  const [inputValue, setInputValue] = useState('');
+  // The value from the last rejected add attempt. Errors are derived from it
+  // against the current items, so removing a conflicting chip clears them.
+  const [attemptedValue, setAttemptedValue] = useState<string | null>(null);
+  const helperTextId = useId();
+
+  const onTextInputChange = (
+    _event: React.FormEvent<HTMLInputElement>,
+    value: string,
+  ) => {
+    setInputValue(value);
+    setAttemptedValue(null);
+  };
+
+  const allValues = useMemo(() => items.map((item) => item.value), [items]);
+
+  const addItem = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return;
+    }
+
+    // Only block the add when the new value itself is the problem (bad
+    // format or a duplicate). Pre-existing invalid items in the store must
+    // not prevent the user from adding otherwise-valid input.
+    const newValueIssues = validator([...allValues, trimmed]).filter(
+      (issue) => issue.value === trimmed,
+    );
+    if (newValueIssues.length > 0) {
+      setAttemptedValue(trimmed);
+      return;
+    }
+
+    onAdd(trimmed);
+    setInputValue('');
+    setAttemptedValue(null);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent, value: string) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      addItem(value);
+    }
+  };
+
+  // Errors attributable to the last rejected add attempt only.
+  const attemptErrors = useMemo(
+    () =>
+      attemptedValue !== null
+        ? validator([...allValues, attemptedValue]).filter(
+            (issue) => issue.value === attemptedValue,
+          )
+        : [],
+    [attemptedValue, allValues, validator],
+  );
+
+  // Validate items already in the store (e.g. loaded from a blueprint).
+  const storeIssues = useMemo(
+    () => (allValues.length > 0 ? validator(allValues) : []),
+    [allValues, validator],
+  );
+
+  const allErrors = [...attemptErrors, ...storeIssues];
+
+  return (
+    <Flex flexWrap={{ default: 'nowrap' }}>
+      <FlexItem grow={{ default: 'grow' }}>
+        <TextInputGroup validated={allErrors.length > 0 ? 'error' : 'default'}>
+          <TextInputGroupMain
+            aria-label={ariaLabel}
+            placeholder={placeholder}
+            onChange={onTextInputChange}
+            value={inputValue}
+            onKeyDown={(e) => handleKeyDown(e, inputValue)}
+            inputProps={{
+              'aria-describedby': helperTextId,
+              'aria-invalid': allErrors.length > 0 || undefined,
+            }}
+          >
+            {items.length > 0 && (
+              <LabelGroup
+                isCompact={isCompact}
+                numLabels={chipCollapseThreshold}
+                expandedText='Show less'
+                collapsedText={
+                  items.length > chipCollapseThreshold
+                    ? `${items.length - chipCollapseThreshold} more`
+                    : undefined
+                }
+                className='pf-v6-u-mr-sm'
+              >
+                {items.map((item) =>
+                  item.required ? (
+                    <Label key={item.value}>{item.value}</Label>
+                  ) : (
+                    <Label
+                      key={item.value}
+                      color='blue'
+                      isCompact={isCompact}
+                      onClose={() => onRemove(item.value)}
+                      closeBtnAriaLabel={`Remove ${item.value}`}
+                    >
+                      <Truncate
+                        content={item.value}
+                        maxCharsDisplayed={truncateLength}
+                      />
+                    </Label>
+                  ),
+                )}
+              </LabelGroup>
+            )}
+          </TextInputGroupMain>
+        </TextInputGroup>
+        <HelperText id={helperTextId}>
+          {allErrors.length > 0 ? (
+            allErrors.map((issue, index) => (
+              <HelperTextItem
+                key={`${issue.value ?? ''}-${issue.message}-${index}`}
+                variant='error'
+              >
+                {issue.message}
+              </HelperTextItem>
+            ))
+          ) : (
+            <HelperTextItem>
+              {helperText && `${helperText} `}
+              Press Enter or click {hideAddLabel ? 'the add icon' : 'Add'}.
+            </HelperTextItem>
+          )}
+        </HelperText>
+      </FlexItem>
+      <FlexItem alignSelf={{ default: 'alignSelfFlexStart' }}>
+        <Button
+          variant='control'
+          aria-label={addButtonAriaLabel}
+          icon={<PlusCircleIcon />}
+          onClick={() => addItem(inputValue)}
+        >
+          {!hideAddLabel && 'Add'}
+        </Button>
+      </FlexItem>
+    </Flex>
+  );
+};
+
+export default ValidatedListInput;

--- a/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/components/KernelArguments.tsx
@@ -1,42 +1,40 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { FormGroup } from '@patternfly/react-core';
 
-import LabelInput from '@/Components/CreateImageWizard/LabelInput';
-import { useKernelValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
-import { isKernelArgumentValid } from '@/Components/CreateImageWizard/validators';
+import ValidatedListInput from '@/Components/CreateImageWizard/ValidatedListInput';
 import { useSecuritySummary } from '@/store/api/backend';
-import { useAppSelector } from '@/store/hooks';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   addKernelArg,
   removeKernelArg,
   selectKernel,
+  validateKernelArgs,
 } from '@/store/slices/wizard';
+import {
+  type MergedListItem,
+  mergeListItems,
+} from '@/Utilities/mergeListItems';
 
 const KernelArguments = () => {
+  const dispatch = useAppDispatch();
   const kernelAppend = useAppSelector(selectKernel).append;
-
-  const stepValidation = useKernelValidation();
-
   const { kernel: requiredKernel } = useSecuritySummary();
 
-  const requiredByProfile = kernelAppend.filter((arg) =>
-    requiredKernel.append.includes(arg),
+  const items: MergedListItem[] = useMemo(
+    () => mergeListItems(requiredKernel.append, kernelAppend),
+    [kernelAppend, requiredKernel.append],
   );
 
   return (
     <FormGroup isRequired={false} label='Arguments'>
-      <LabelInput
+      <ValidatedListInput
         ariaLabel='Add kernel argument'
         placeholder='Add kernel argument'
-        validator={isKernelArgumentValid}
-        list={kernelAppend.filter((arg) => !requiredByProfile.includes(arg))}
-        requiredList={requiredByProfile}
-        item='Kernel argument'
-        addAction={addKernelArg}
-        removeAction={removeKernelArg}
-        stepValidation={stepValidation}
-        fieldName='kernelAppend'
+        validator={validateKernelArgs}
+        items={items}
+        onAdd={(value) => dispatch(addKernelArg(value))}
+        onRemove={(value) => dispatch(removeKernelArg(value))}
         helperText='Enter additional kernel boot parameters. Examples: nomodeset or console=ttyS0.'
       />
     </FormGroup>

--- a/src/Components/CreateImageWizard/steps/Kernel/tests/Kernel.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Kernel/tests/Kernel.test.tsx
@@ -160,7 +160,7 @@ describe('Kernel Component', () => {
       await addKernelArgument(user, 'invalid$argument');
 
       expect(
-        screen.getByText(/Expected format: <kernel-argument>/i),
+        screen.getByText(/Kernel argument contains invalid characters/i),
       ).toBeInTheDocument();
     });
   });

--- a/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
+++ b/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
@@ -215,7 +215,7 @@ describe('ImportMode', () => {
 
     // Kernel
     expect(
-      await screen.findByText(/Invalid kernel arguments/),
+      await screen.findByText(/Kernel argument contains invalid characters/),
     ).toBeInTheDocument();
     await clickWithWait(
       user,

--- a/src/Components/CreateImageWizard/tests/ValidatedListInput.test.tsx
+++ b/src/Components/CreateImageWizard/tests/ValidatedListInput.test.tsx
@@ -1,0 +1,180 @@
+import React, { type ComponentProps } from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import type { ValidationResult } from '@/store/slices/wizard/types';
+import {
+  clickWithWait,
+  createUser,
+  keyboardWithWait,
+  typeWithWait,
+} from '@/test/testUtils';
+
+import ValidatedListInput from '../ValidatedListInput';
+
+// Mirrors the real validators: flags format violations and duplicates.
+const validator = (values: string[]): ValidationResult => {
+  const issues: ValidationResult = [];
+  const seen = new Set<string>();
+  values.forEach((value) => {
+    if (!/^[a-z]+$/.test(value)) {
+      issues.push({ message: 'Invalid value', kind: 'format', value });
+    }
+    if (seen.has(value)) {
+      issues.push({ message: 'Duplicate value', kind: 'duplicate', value });
+    }
+    seen.add(value);
+  });
+  return issues;
+};
+
+const onAdd = vi.fn();
+const onRemove = vi.fn();
+
+const renderComponent = (
+  props: Partial<ComponentProps<typeof ValidatedListInput>> = {},
+) => {
+  const defaultProps: ComponentProps<typeof ValidatedListInput> = {
+    ariaLabel: 'Add kernel argument',
+    placeholder: 'Add kernel argument',
+    validator,
+    items: [],
+    onAdd,
+    onRemove,
+  };
+
+  return render(<ValidatedListInput {...defaultProps} {...props} />);
+};
+
+describe('ValidatedListInput', () => {
+  beforeEach(() => {
+    onAdd.mockClear();
+    onRemove.mockClear();
+  });
+
+  test('adds a valid value via the Add button and clears the input', async () => {
+    renderComponent();
+    const user = createUser();
+
+    const input = screen.getByPlaceholderText('Add kernel argument');
+    await typeWithWait(user, input, 'quiet');
+    await clickWithWait(user, screen.getByRole('button', { name: 'Add' }));
+
+    expect(onAdd).toHaveBeenCalledWith('quiet');
+    expect(input).toHaveValue('');
+  });
+
+  test('adds a valid value when pressing Enter', async () => {
+    renderComponent();
+    const user = createUser();
+
+    await typeWithWait(
+      user,
+      screen.getByPlaceholderText('Add kernel argument'),
+      'splash{Enter}',
+    );
+
+    expect(onAdd).toHaveBeenCalledWith('splash');
+  });
+
+  test('trims surrounding whitespace before adding', async () => {
+    renderComponent();
+    const user = createUser();
+
+    await typeWithWait(
+      user,
+      screen.getByPlaceholderText('Add kernel argument'),
+      '  quiet  {Enter}',
+    );
+
+    expect(onAdd).toHaveBeenCalledWith('quiet');
+  });
+
+  test('does not add empty input via the button or Enter', async () => {
+    renderComponent();
+    const user = createUser();
+
+    const input = screen.getByPlaceholderText('Add kernel argument');
+    await clickWithWait(user, screen.getByRole('button', { name: 'Add' }));
+    await clickWithWait(user, input);
+    await keyboardWithWait(user, '{Enter}');
+
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  test('shows a validation error and does not add an invalid value', async () => {
+    renderComponent();
+    const user = createUser();
+
+    await typeWithWait(
+      user,
+      screen.getByPlaceholderText('Add kernel argument'),
+      'BAD',
+    );
+    await clickWithWait(user, screen.getByRole('button', { name: 'Add' }));
+
+    expect(screen.getByText('Invalid value')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('Add kernel argument'),
+    ).toHaveAccessibleDescription(/Invalid value/);
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  test('clears the validation error when the input changes', async () => {
+    renderComponent();
+    const user = createUser();
+
+    const input = screen.getByPlaceholderText('Add kernel argument');
+    await typeWithWait(user, input, 'BAD');
+    await clickWithWait(user, screen.getByRole('button', { name: 'Add' }));
+    expect(screen.getByText('Invalid value')).toBeInTheDocument();
+
+    await typeWithWait(user, input, 'x');
+    expect(screen.queryByText('Invalid value')).not.toBeInTheDocument();
+  });
+
+  test('validates items already present in the store (blueprint restore)', () => {
+    renderComponent({ items: [{ value: 'BAD', required: false }] });
+
+    expect(screen.getByText('Invalid value')).toBeInTheDocument();
+  });
+
+  test('removes a non-required chip', async () => {
+    renderComponent({ items: [{ value: 'quiet', required: false }] });
+    const user = createUser();
+
+    await clickWithWait(
+      user,
+      screen.getByRole('button', { name: 'Remove quiet' }),
+    );
+
+    expect(onRemove).toHaveBeenCalledWith('quiet');
+  });
+
+  test('renders required items without a remove button', () => {
+    renderComponent({ items: [{ value: 'audit', required: true }] });
+
+    expect(screen.getByText('audit')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Remove audit' }),
+    ).not.toBeInTheDocument();
+  });
+
+  test('gives the add button a label distinct from the input', () => {
+    renderComponent();
+
+    const input = screen.getByPlaceholderText('Add kernel argument');
+    const addButton = screen.getByRole('button', { name: 'Add' });
+
+    expect(input).not.toBe(addButton);
+    expect(addButton).toHaveAccessibleName('Add');
+  });
+
+  test('associates the helper text with the input via aria-describedby', () => {
+    renderComponent();
+
+    expect(
+      screen.getByPlaceholderText('Add kernel argument'),
+    ).toHaveAccessibleDescription('Press Enter or click Add.');
+  });
+});

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -70,6 +70,7 @@ import {
   selectUsers,
   UserWithAdditionalInfo,
   validateHostname,
+  validateKernel,
 } from '@/store/slices/wizard';
 import useDebounce from '@/Utilities/useDebounce';
 
@@ -90,7 +91,6 @@ import {
   isDiskMinSizeValid,
   isGcpDomainValid,
   isGcpEmailValid,
-  isKernelArgumentValid,
   isMountpointMinSizeValid,
   isNtpServerValid,
   isPartitionNameValid,
@@ -134,7 +134,6 @@ export function useIsBlueprintValid(): boolean {
   const snapshot = useSnapshotValidation();
   const timezone = useTimezoneValidation();
   const locale = useLocaleValidation();
-  const kernel = useKernelValidation();
   const firewall = useFirewallValidation();
   const services = useServicesValidation();
   const firstBoot = useFirstBootValidation();
@@ -146,6 +145,7 @@ export function useIsBlueprintValid(): boolean {
   const awsTarget = useAwsValidation();
 
   const hostnameErrors = validateHostname(useAppSelector(selectHostname));
+  const kernelErrors = validateKernel(useAppSelector(selectKernel));
 
   return (
     !aap.disabledNext &&
@@ -155,7 +155,7 @@ export function useIsBlueprintValid(): boolean {
     !timezone.disabledNext &&
     !locale.disabledNext &&
     hostnameErrors.length === 0 &&
-    !kernel.disabledNext &&
+    kernelErrors.length === 0 &&
     !firewall.disabledNext &&
     !services.disabledNext &&
     !firstBoot.disabledNext &&
@@ -632,36 +632,6 @@ export function useFirstBootValidation(): StepValidation {
       script: valid ? '' : 'Missing shebang at first line, e.g. #!/bin/bash',
     },
     disabledNext: !valid,
-  };
-}
-
-export function useKernelValidation(): StepValidation {
-  const kernel = useAppSelector(selectKernel);
-
-  const invalidArgs = [];
-  if (kernel.append.length > 0) {
-    for (const arg of kernel.append) {
-      if (!isKernelArgumentValid(arg)) {
-        invalidArgs.push(arg);
-      }
-    }
-  }
-
-  const duplicateKernelArgs = getListOfDuplicates(kernel.append);
-
-  const kernelAppendError =
-    invalidArgs.length > 0 ? `Invalid kernel arguments: ${invalidArgs}` : '';
-
-  const duplicateKernelArgsError =
-    duplicateKernelArgs.length > 0
-      ? `Includes duplicate kernel arguments: ${duplicateKernelArgs.join(', ')}`
-      : '';
-
-  return {
-    errors: {
-      kernelAppend: kernelAppendError + '|' + duplicateKernelArgsError,
-    },
-    disabledNext: kernelAppendError !== '' || duplicateKernelArgs.length > 0,
   };
 }
 

--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -254,10 +254,6 @@ export const isNtpServerValid = (ntpServer: string) => {
   return /^([a-z0-9-]+)?(([.:/]{1,3}[a-z0-9-]+)){1,}$/.test(ntpServer);
 };
 
-export const isKernelArgumentValid = (arg: string) => {
-  return /^[a-zA-Z0-9=\-_,."'/:#+;\\]*$/.test(arg);
-};
-
 export const isPortValid = (port: string) => {
   return /^(\d{1,5}|[a-z]{1,6})(-\d{1,5})?[:][a-z]{1,6}$/.test(port);
 };

--- a/src/Utilities/mergeListItems.ts
+++ b/src/Utilities/mergeListItems.ts
@@ -1,0 +1,11 @@
+export type MergedListItem = { value: string; required: boolean };
+
+export const mergeListItems = (
+  requiredItems: string[],
+  optionalItems: string[],
+): MergedListItem[] => [
+  ...requiredItems.map((item) => ({ value: item, required: true })),
+  ...optionalItems
+    .filter((item) => !requiredItems.includes(item))
+    .map((item) => ({ value: item, required: false })),
+];

--- a/src/store/slices/wizard/system/schemas.ts
+++ b/src/store/slices/wizard/system/schemas.ts
@@ -1,5 +1,7 @@
 import z from 'zod';
 
+import { uniqueArray } from '../utilities';
+
 export const hostnameSchema = z
   .string()
   .max(64, 'Hostname must be no more than 64 characters.')
@@ -20,3 +22,20 @@ export const hostnameSchema = z
         .every((label) => !label.startsWith('-') && !label.endsWith('-')),
     { error: 'Hostname labels cannot start or end with a hyphen.' },
   );
+
+export const kernelArgSchema = z
+  .string()
+  .max(256, 'Kernel argument must be no more than 256 characters.')
+  .regex(
+    // The allowlist intentionally permits bootloader/shell metacharacters
+    // (#, \, ", ', ;) because they are valid in kernel arguments. The backend
+    // is responsible for escaping these before writing them to the bootloader
+    // config to prevent grub/bootloader injection.
+    /^[a-zA-Z0-9=\-_,."'/:#+;\\]*$/,
+    'Kernel argument contains invalid characters',
+  );
+
+export const kernelSchema = z.object({
+  name: z.string(),
+  append: z.array(kernelArgSchema).superRefine(uniqueArray('kernel argument')),
+});

--- a/src/store/slices/wizard/system/tests/validation/hostname.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/hostname.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { hostnameSchema } from '../schemas';
-import { validateHostname } from '../validators';
+import { hostnameSchema } from '../../schemas';
+import { validateHostname } from '../../validators';
 
 describe('hostname validation', () => {
   describe('valid hostnames', () => {

--- a/src/store/slices/wizard/system/tests/validation/kernel.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/kernel.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import { isKernelArgumentValid } from '@/Components/CreateImageWizard/validators';
+
+describe('kernel validation', () => {
+  describe('valid kernel arguments', () => {
+    it('accepts a simple key=value argument', () => {
+      expect(isKernelArgumentValid('quiet')).toBe(true);
+    });
+
+    it('accepts an argument with equals sign', () => {
+      expect(isKernelArgumentValid('root=/dev/sda1')).toBe(true);
+    });
+
+    it('accepts an argument with hyphens', () => {
+      expect(isKernelArgumentValid('no-scroll')).toBe(true);
+    });
+
+    it('accepts an argument with underscores', () => {
+      expect(isKernelArgumentValid('net_ifnames=0')).toBe(true);
+    });
+
+    it('accepts an argument with dots', () => {
+      expect(isKernelArgumentValid('systemd.unit=rescue.target')).toBe(true);
+    });
+
+    it('accepts an argument with commas', () => {
+      expect(isKernelArgumentValid('console=ttyS0,115200')).toBe(true);
+    });
+
+    it('accepts an argument with quotes', () => {
+      expect(isKernelArgumentValid("key='value'")).toBe(true);
+    });
+
+    it('accepts an argument with double quotes', () => {
+      expect(isKernelArgumentValid('key="value"')).toBe(true);
+    });
+
+    it('accepts an argument with colons', () => {
+      expect(isKernelArgumentValid('rd.lvm.lv=vg/lv')).toBe(true);
+    });
+
+    it('accepts an argument with hash', () => {
+      expect(isKernelArgumentValid('arg#1')).toBe(true);
+    });
+
+    it('accepts an argument with plus', () => {
+      expect(isKernelArgumentValid('arg+1')).toBe(true);
+    });
+
+    it('accepts an argument with semicolon', () => {
+      expect(isKernelArgumentValid('arg;next')).toBe(true);
+    });
+
+    it('accepts an argument with backslash', () => {
+      expect(isKernelArgumentValid('path\\to')).toBe(true);
+    });
+
+    it('accepts an empty string', () => {
+      expect(isKernelArgumentValid('')).toBe(true);
+    });
+  });
+
+  describe('invalid kernel arguments', () => {
+    it('rejects an argument with spaces', () => {
+      expect(isKernelArgumentValid('key value')).toBe(false);
+    });
+
+    it('rejects an argument with exclamation mark', () => {
+      expect(isKernelArgumentValid('arg!')).toBe(false);
+    });
+
+    it('rejects an argument with ampersand', () => {
+      expect(isKernelArgumentValid('arg&next')).toBe(false);
+    });
+
+    it('rejects an argument with pipe', () => {
+      expect(isKernelArgumentValid('arg|next')).toBe(false);
+    });
+
+    it('rejects an argument with parentheses', () => {
+      expect(isKernelArgumentValid('arg(1)')).toBe(false);
+    });
+
+    it('rejects an argument with angle brackets', () => {
+      expect(isKernelArgumentValid('arg<1>')).toBe(false);
+    });
+  });
+});

--- a/src/store/slices/wizard/system/tests/validation/kernel.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/kernel.test.ts
@@ -1,89 +1,114 @@
 import { describe, expect, it } from 'vitest';
 
-import { isKernelArgumentValid } from '@/Components/CreateImageWizard/validators';
+import { validateKernelArgs } from '../../validators';
+
+const isValid = (arg: string) => validateKernelArgs([arg]).length === 0;
 
 describe('kernel validation', () => {
   describe('valid kernel arguments', () => {
     it('accepts a simple key=value argument', () => {
-      expect(isKernelArgumentValid('quiet')).toBe(true);
+      expect(isValid('quiet')).toBe(true);
     });
 
     it('accepts an argument with equals sign', () => {
-      expect(isKernelArgumentValid('root=/dev/sda1')).toBe(true);
+      expect(isValid('root=/dev/sda1')).toBe(true);
     });
 
     it('accepts an argument with hyphens', () => {
-      expect(isKernelArgumentValid('no-scroll')).toBe(true);
+      expect(isValid('no-scroll')).toBe(true);
     });
 
     it('accepts an argument with underscores', () => {
-      expect(isKernelArgumentValid('net_ifnames=0')).toBe(true);
+      expect(isValid('net_ifnames=0')).toBe(true);
     });
 
     it('accepts an argument with dots', () => {
-      expect(isKernelArgumentValid('systemd.unit=rescue.target')).toBe(true);
+      expect(isValid('systemd.unit=rescue.target')).toBe(true);
     });
 
     it('accepts an argument with commas', () => {
-      expect(isKernelArgumentValid('console=ttyS0,115200')).toBe(true);
+      expect(isValid('console=ttyS0,115200')).toBe(true);
     });
 
     it('accepts an argument with quotes', () => {
-      expect(isKernelArgumentValid("key='value'")).toBe(true);
+      expect(isValid("key='value'")).toBe(true);
     });
 
     it('accepts an argument with double quotes', () => {
-      expect(isKernelArgumentValid('key="value"')).toBe(true);
+      expect(isValid('key="value"')).toBe(true);
     });
 
     it('accepts an argument with colons', () => {
-      expect(isKernelArgumentValid('rd.lvm.lv=vg/lv')).toBe(true);
+      expect(isValid('rd.lvm.lv=vg/lv')).toBe(true);
     });
 
     it('accepts an argument with hash', () => {
-      expect(isKernelArgumentValid('arg#1')).toBe(true);
+      expect(isValid('arg#1')).toBe(true);
     });
 
     it('accepts an argument with plus', () => {
-      expect(isKernelArgumentValid('arg+1')).toBe(true);
+      expect(isValid('arg+1')).toBe(true);
     });
 
     it('accepts an argument with semicolon', () => {
-      expect(isKernelArgumentValid('arg;next')).toBe(true);
+      expect(isValid('arg;next')).toBe(true);
     });
 
     it('accepts an argument with backslash', () => {
-      expect(isKernelArgumentValid('path\\to')).toBe(true);
+      expect(isValid('path\\to')).toBe(true);
     });
 
-    it('accepts an empty string', () => {
-      expect(isKernelArgumentValid('')).toBe(true);
+    it('accepts an argument at the maximum length', () => {
+      expect(isValid('a'.repeat(256))).toBe(true);
+    });
+
+    it('returns no issues for an empty list', () => {
+      expect(validateKernelArgs([])).toEqual([]);
     });
   });
 
   describe('invalid kernel arguments', () => {
     it('rejects an argument with spaces', () => {
-      expect(isKernelArgumentValid('key value')).toBe(false);
+      expect(isValid('key value')).toBe(false);
     });
 
     it('rejects an argument with exclamation mark', () => {
-      expect(isKernelArgumentValid('arg!')).toBe(false);
+      expect(isValid('arg!')).toBe(false);
     });
 
     it('rejects an argument with ampersand', () => {
-      expect(isKernelArgumentValid('arg&next')).toBe(false);
+      expect(isValid('arg&next')).toBe(false);
     });
 
     it('rejects an argument with pipe', () => {
-      expect(isKernelArgumentValid('arg|next')).toBe(false);
+      expect(isValid('arg|next')).toBe(false);
     });
 
     it('rejects an argument with parentheses', () => {
-      expect(isKernelArgumentValid('arg(1)')).toBe(false);
+      expect(isValid('arg(1)')).toBe(false);
     });
 
     it('rejects an argument with angle brackets', () => {
-      expect(isKernelArgumentValid('arg<1>')).toBe(false);
+      expect(isValid('arg<1>')).toBe(false);
+    });
+
+    it('rejects an argument longer than the maximum length', () => {
+      expect(isValid('a'.repeat(257))).toBe(false);
+    });
+  });
+
+  describe('duplicate kernel arguments', () => {
+    it('accepts a list with no duplicates', () => {
+      expect(validateKernelArgs(['quiet', 'splash'])).toEqual([]);
+    });
+
+    it('rejects a list with a duplicate argument', () => {
+      const result = validateKernelArgs(['quiet', 'quiet']);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        kind: 'duplicate',
+        value: 'quiet',
+      });
     });
   });
 });

--- a/src/store/slices/wizard/system/types.ts
+++ b/src/store/slices/wizard/system/types.ts
@@ -1,4 +1,10 @@
+import z from 'zod';
+
 import { Locale, Timezone, User } from '@/store/api/backend';
+
+import { kernelSchema } from './schemas';
+
+export type Kernel = z.infer<typeof kernelSchema>;
 
 export type UserWithAdditionalInfo = {
   [K in keyof User]-?: NonNullable<User[K]>;

--- a/src/store/slices/wizard/system/validators.ts
+++ b/src/store/slices/wizard/system/validators.ts
@@ -1,7 +1,11 @@
-import { hostnameSchema } from './schemas';
+import { hostnameSchema, kernelSchema } from './schemas';
 
-import { validateSchema } from '../validators';
+import { validateSchema, validateList } from '../validators';
 
 export const validateHostname = (hostname: string) => {
   return validateSchema(hostnameSchema, hostname);
+};
+
+export const validateKernelArgs = (items: string[]) => {
+  return validateList(kernelSchema.shape.append, items);
 };

--- a/src/store/slices/wizard/system/validators.ts
+++ b/src/store/slices/wizard/system/validators.ts
@@ -1,16 +1,7 @@
 import { hostnameSchema } from './schemas';
 
-import type { ValidationResult } from '../types';
+import { validateSchema } from '../validators';
 
-export const validateHostname = (hostname: string): ValidationResult => {
-  if (!hostname) return [];
-
-  const result = hostnameSchema.safeParse(hostname);
-  if (result.success) return [];
-
-  return result.error.issues.map((issue) => ({
-    kind: 'format' as const,
-    message: issue.message,
-    value: hostname,
-  }));
+export const validateHostname = (hostname: string) => {
+  return validateSchema(hostnameSchema, hostname);
 };

--- a/src/store/slices/wizard/system/validators.ts
+++ b/src/store/slices/wizard/system/validators.ts
@@ -1,6 +1,7 @@
 import { hostnameSchema, kernelSchema } from './schemas';
+import { Kernel } from './types';
 
-import { validateSchema, validateList } from '../validators';
+import { validateList, validateSchema } from '../validators';
 
 export const validateHostname = (hostname: string) => {
   return validateSchema(hostnameSchema, hostname);
@@ -8,4 +9,8 @@ export const validateHostname = (hostname: string) => {
 
 export const validateKernelArgs = (items: string[]) => {
   return validateList(kernelSchema.shape.append, items);
+};
+
+export const validateKernel = (kernel: Kernel) => {
+  return validateSchema(kernelSchema, kernel);
 };

--- a/src/store/slices/wizard/tests/utilities.test.ts
+++ b/src/store/slices/wizard/tests/utilities.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import z from 'zod';
+
+import { uniqueArray } from '../utilities';
+
+const schema = z.array(z.string()).superRefine(uniqueArray('item'));
+
+describe('uniqueArray', () => {
+  it('accepts an empty array', () => {
+    const result = schema.safeParse([]);
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an array with no duplicates', () => {
+    const result = schema.safeParse(['a', 'b', 'c']);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an array with a duplicate', () => {
+    const result = schema.safeParse(['a', 'b', 'a']);
+    expect(result.success).toBe(false);
+  });
+
+  it('reports one issue per duplicate occurrence', () => {
+    const result = schema.safeParse(['a', 'a', 'a']);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues).toHaveLength(2);
+    }
+  });
+
+  it('includes the label and offending value in the message', () => {
+    const result = schema.safeParse(['dup', 'dup']);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0].message).toBe('Duplicate item: dup');
+    }
+  });
+
+  it('attaches the offending value under params', () => {
+    const result = schema.safeParse(['dup', 'dup']);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const issue = result.error.issues[0];
+      expect(issue.code).toBe('custom');
+      if (issue.code === 'custom') {
+        expect(issue.params?.value).toBe('dup');
+      }
+    }
+  });
+});

--- a/src/store/slices/wizard/tests/validators.test.ts
+++ b/src/store/slices/wizard/tests/validators.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import z from 'zod';
+
+import { uniqueArray } from '../utilities';
+import { validateList } from '../validators';
+
+const schema = z
+  .array(z.string().regex(/^[a-z]+$/, 'Only lowercase letters allowed'))
+  .superRefine(uniqueArray('item'));
+
+describe('validateList', () => {
+  it('returns no issues for a valid list', () => {
+    expect(validateList(schema, ['foo', 'bar'])).toEqual([]);
+  });
+
+  it('returns no issues for an empty list', () => {
+    expect(validateList(schema, [])).toEqual([]);
+  });
+
+  it('maps a schema violation to a format issue', () => {
+    const result = validateList(schema, ['FOO']);
+    expect(result).toEqual([
+      {
+        message: 'Only lowercase letters allowed',
+        kind: 'format',
+        value: 'FOO',
+      },
+    ]);
+  });
+
+  it('maps a duplicate to a duplicate issue', () => {
+    const result = validateList(schema, ['foo', 'foo']);
+    expect(result).toEqual([
+      {
+        message: 'Duplicate item: foo',
+        kind: 'duplicate',
+        value: 'foo',
+      },
+    ]);
+  });
+
+  it('reports one format issue per invalid element', () => {
+    const result = validateList(schema, ['FOO', 'BAR']);
+    expect(result).toHaveLength(2);
+    expect(result.every((issue) => issue.kind === 'format')).toBe(true);
+  });
+});

--- a/src/store/slices/wizard/utilities.ts
+++ b/src/store/slices/wizard/utilities.ts
@@ -1,0 +1,17 @@
+import z from 'zod';
+
+export const uniqueArray = <T extends string>(label: string) => {
+  return (items: T[], ctx: z.RefinementCtx) => {
+    const seen = new Set<string>();
+    items.forEach((item) => {
+      if (seen.has(item)) {
+        ctx.addIssue({
+          code: 'custom',
+          message: `Duplicate ${label}: ${item}`,
+          params: { type: 'duplicate', value: item },
+        });
+      }
+      seen.add(item);
+    });
+  };
+};

--- a/src/store/slices/wizard/validators.ts
+++ b/src/store/slices/wizard/validators.ts
@@ -1,0 +1,54 @@
+import type z from 'zod';
+
+import type { ValidationIssue, ValidationResult } from './types';
+
+export const validateSchema = <T>(
+  schema: z.ZodType<T>,
+  item?: T | undefined,
+): ValidationResult => {
+  if (!item) return [];
+
+  const result = schema.safeParse(item);
+  if (result.success) return [];
+
+  return result.error.issues.map((i): ValidationIssue => {
+    if (i.code === 'custom' && i.params?.type === 'duplicate') {
+      return {
+        message: i.message,
+        kind: 'duplicate',
+        value: i.params.value,
+      };
+    }
+
+    return {
+      message: i.message,
+      kind: 'format',
+      value: String(item),
+    };
+  });
+};
+
+export const validateList = <T>(
+  schema: z.ZodType<T[]>,
+  items: T[],
+): ValidationResult => {
+  const result = schema.safeParse(items);
+  if (result.success) return [];
+
+  return result.error.issues.map((i): ValidationIssue => {
+    if (i.code === 'custom' && i.params?.type === 'duplicate') {
+      return {
+        message: i.message,
+        kind: 'duplicate',
+        value: i.params.value,
+      };
+    }
+
+    const index = i.path[0];
+    return {
+      message: i.message,
+      kind: 'format',
+      ...(typeof index === 'number' ? { value: String(items[index]) } : {}),
+    };
+  });
+};


### PR DESCRIPTION
## Summary

Adds robust kernel argument validation using a Zod schema and a new reusable `ValidatedListInput` chip-input component, replacing the old `useKernelValidation` hook. Also migrates OpenSCAP-mandated kernel args to `useSecuritySummary` so required/user-added args are handled consistently.

## Changes

- Replace `useKernelValidation`/`isKernelArgumentValid` with a Zod-based `kernelArgSchema` + generic `validateList` helper, giving a single source of truth for the character allowlist and duplicate detection
- Add reusable `ValidatedListInput` component (chip input with add/remove, blueprint-restore validation, ARIA wiring, and required/locked chips) with full test coverage
- Migrate `KernelArguments` to `useSecuritySummary` and the new `ValidatedListInput`, distinguishing OSCAP-required args (non-removable) from user-added args
- Add `uniqueArray` Zod refinement factory for reusable duplicate-item validation across list schemas
- Fix duplicate/attributable error handling and add `aria-invalid` wiring based on review feedback


