### PR TITLE
Migrate Systemd Services step to schema-based validation (HMS-11268)

### DIFF
--- a/playwright/Customizations/OpenSCAP.spec.ts
+++ b/playwright/Customizations/OpenSCAP.spec.ts
@@ -116,7 +116,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await frame.getByPlaceholder('Add masked service').fill('nftables');
     await frame.getByPlaceholder('Add masked service').press('Enter');
     await expect(
-      frame.getByText('Masked service already exists'),
+      frame.getByText('Duplicate masked services: nftables'),
     ).toBeVisible();
     await expect(frame.getByText('cups')).toBeVisible();
     await expect(frame.getByText('nfs-server')).toBeVisible();
@@ -124,7 +124,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await expect(frame.getByText('avahi-daemon')).toBeVisible();
     await expect(frame.getByText('autofs')).toBeVisible();
     await expect(frame.getByText('bluetooth')).toBeVisible();
-    await expect(frame.getByText('nftables')).toBeVisible();
+    await expect(frame.getByText('nftables').last()).toBeVisible();
     await frame.getByRole('button', { name: 'Review image' }).click();
   });
 
@@ -180,7 +180,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await frame.getByPlaceholder('Add masked service').fill('nftables');
     await frame.getByPlaceholder('Add masked service').press('Enter');
     await expect(
-      frame.getByText('Masked service already exists'),
+      frame.getByText('Duplicate masked services: nftables'),
     ).toBeVisible();
     await expect(frame.getByText('cups')).toBeVisible();
     await expect(frame.getByText('nfs-server')).toBeVisible();
@@ -188,7 +188,7 @@ test('Create a blueprint with OpenSCAP customization', async ({
     await expect(frame.getByText('avahi-daemon')).toBeVisible();
     await expect(frame.getByText('autofs')).toBeVisible();
     await expect(frame.getByText('bluetooth')).toBeVisible();
-    await expect(frame.getByText('nftables')).toBeVisible();
+    await expect(frame.getByText('nftables').last()).toBeVisible();
     await frame.getByRole('button', { name: 'Review image' }).click();
     await frame
       .getByRole('button', { name: 'Save changes to blueprint' })

--- a/playwright/Customizations/Systemd.spec.ts
+++ b/playwright/Customizations/Systemd.spec.ts
@@ -239,21 +239,23 @@ test('Create a blueprint with Systemd customization', async ({
   await test.step('Select and incorrectly fill all of the service fields', async () => {
     await frame.getByPlaceholder('Add disabled service').fill('&&');
     await frame.getByPlaceholder('Add disabled service').press('Enter');
-    await expect(
-      frame.getByText('Expected format: <service-name>. Example: sshd').nth(0),
-    ).toBeVisible();
 
     await frame.getByPlaceholder('Add enabled service').fill('áá');
     await frame.getByPlaceholder('Add enabled service').press('Enter');
-    await expect(
-      frame.getByText('Expected format: <service-name>. Example: sshd').nth(1),
-    ).toBeVisible();
 
     await frame.getByPlaceholder('Add masked service').fill('78');
     await frame.getByPlaceholder('Add masked service').press('Enter');
+
+    // The schema reports the same messages for multiple fields, so assert the
+    // number of rendered errors instead of relying on their DOM order.
     await expect(
-      frame.getByText('Expected format: <service-name>. Example: sshd').nth(2),
-    ).toBeVisible();
+      frame.getByText(
+        'Service name may only contain letters, digits, and . - _ : @',
+      ),
+    ).toHaveCount(2);
+    await expect(
+      frame.getByText('Service name must contain at least one letter'),
+    ).toHaveCount(3);
   });
 
   await test.step('Navigate to review', async () => {

--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -117,12 +117,14 @@ test('Import a blueprint with invalid customization', async ({
       .getByRole('heading', { name: 'Systemd services' })
       .scrollIntoViewIfNeeded();
     await expect(
-      frame.getByText('Includes duplicate enabled services: auditd'),
+      frame.getByText('Duplicate enabled services: auditd'),
     ).toBeVisible();
     await expect(
-      frame.getByText('Includes duplicate disabled services: sssd'),
+      frame.getByText('Duplicate disabled services: sssd'),
     ).toBeVisible();
-    await expect(frame.getByText('Includes duplicate masked')).toBeVisible();
+    await expect(
+      frame.getByText('Duplicate masked services: masked'),
+    ).toBeVisible();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Remove auditd' }).first().click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -50,9 +50,11 @@ import {
   selectImageTypes,
   selectIsImageMode,
   selectKernel,
+  selectServices,
   selectTimezone,
   validateHostname,
   validateKernel,
+  validateServices,
 } from '@/store/slices/wizard';
 import {
   closeWizardModal,
@@ -108,7 +110,6 @@ import {
   useImagePullValidation,
   useLocaleValidation,
   useRegistrationValidation,
-  useServicesValidation,
   useSnapshotValidation,
   useTimezoneValidation,
   useUserGroupsValidation,
@@ -160,7 +161,6 @@ const CreateImageWizard = () => {
   const filesystemValidation = useFilesystemValidation();
   const timezoneValidation = useTimezoneValidation();
   const localeValidation = useLocaleValidation();
-  const servicesValidation = useServicesValidation();
   const firewallValidation = useFirewallValidation();
   const firstBootValidation = useFirstBootValidation();
   const usersValidation = useUsersValidation();
@@ -169,6 +169,7 @@ const CreateImageWizard = () => {
 
   const hostnameErrors = validateHostname(useAppSelector(selectHostname));
   const kernelErrors = validateKernel(useAppSelector(selectKernel));
+  const servicesErrors = validateServices(useAppSelector(selectServices));
 
   const { restrictions } = useCustomizationRestrictions({
     selectedImageTypes: targetEnvironments,
@@ -202,7 +203,7 @@ const CreateImageWizard = () => {
     localeValidation.disabledNext ||
     hostnameErrors.length > 0 ||
     kernelErrors.length > 0 ||
-    servicesValidation.disabledNext ||
+    servicesErrors.length > 0 ||
     firewallValidation.disabledNext ||
     firstBootValidation.disabledNext ||
     (!restrictions.users.shouldHide && usersHaveErrors);

--- a/src/Components/CreateImageWizard/ValidatedListInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedListInput.tsx
@@ -18,7 +18,7 @@ import type { ValidationResult } from '@/store/slices/wizard/types';
 import type { MergedListItem } from '@/Utilities/mergeListItems';
 
 const DEFAULT_TRUNCATE_LENGTH = 20;
-const DEFAULT_CHIP_COLLAPSE_THRESHOLD = 4;
+const DEFAULT_MAX_VISIBLE_ITEMS = 4;
 
 type ValidatedListInputProps = {
   ariaLabel: string;
@@ -29,7 +29,7 @@ type ValidatedListInputProps = {
   onRemove: (value: string) => void;
   truncateLength?: number;
   isCompact?: boolean;
-  chipCollapseThreshold?: number;
+  maxVisibleItems?: number;
   hideAddLabel?: boolean;
   helperText?: string;
   addButtonAriaLabel?: string;
@@ -44,7 +44,7 @@ const ValidatedListInput = ({
   onRemove,
   truncateLength = DEFAULT_TRUNCATE_LENGTH,
   isCompact = false,
-  chipCollapseThreshold = DEFAULT_CHIP_COLLAPSE_THRESHOLD,
+  maxVisibleItems = DEFAULT_MAX_VISIBLE_ITEMS,
   hideAddLabel = false,
   helperText,
   addButtonAriaLabel = 'Add',
@@ -131,11 +131,11 @@ const ValidatedListInput = ({
             {items.length > 0 && (
               <LabelGroup
                 isCompact={isCompact}
-                numLabels={chipCollapseThreshold}
+                numLabels={maxVisibleItems}
                 expandedText='Show less'
                 collapsedText={
-                  items.length > chipCollapseThreshold
-                    ? `${items.length - chipCollapseThreshold} more`
+                  items.length > maxVisibleItems
+                    ? `${items.length - maxVisibleItems} more`
                     : undefined
                 }
                 className='pf-v6-u-mr-sm'

--- a/src/Components/CreateImageWizard/steps/Services/components/ServicesInputs.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/components/ServicesInputs.tsx
@@ -1,12 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 
 import { FormGroup } from '@patternfly/react-core';
 
-import LabelInput from '@/Components/CreateImageWizard/LabelInput';
-import { useServicesValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
-import { isServiceValid } from '@/Components/CreateImageWizard/validators';
+import ValidatedListInput from '@/Components/CreateImageWizard/ValidatedListInput';
 import { useSecuritySummary } from '@/store/api/backend';
-import { useAppSelector } from '@/store/hooks';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   addDisabledService,
   addEnabledService,
@@ -15,82 +13,64 @@ import {
   removeEnabledService,
   removeMaskedService,
   selectServices,
+  validateDisabledServices,
+  validateEnabledServices,
+  validateMaskedServices,
 } from '@/store/slices/wizard';
+import { mergeListItems } from '@/Utilities/mergeListItems';
 
 const ServicesInput = () => {
+  const dispatch = useAppDispatch();
   const disabledServices = useAppSelector(selectServices).disabled;
   const maskedServices = useAppSelector(selectServices).masked;
   const enabledServices = useAppSelector(selectServices).enabled;
 
-  const stepValidation = useServicesValidation();
-
   const { services: requiredServices } = useSecuritySummary();
 
-  const disabledRequiredByProfile = disabledServices.filter((service) =>
-    requiredServices.disabled.includes(service),
-  );
-
-  const maskedRequiredByProfile = maskedServices.filter((service) =>
-    requiredServices.masked.includes(service),
-  );
-
-  const enabledRequiredByProfile = enabledServices.filter((service) =>
-    requiredServices.enabled.includes(service),
+  const { enabled, disabled, masked } = useMemo(
+    () => ({
+      enabled: mergeListItems(requiredServices.enabled, enabledServices),
+      disabled: mergeListItems(requiredServices.disabled, disabledServices),
+      masked: mergeListItems(requiredServices.masked, maskedServices),
+    }),
+    [enabledServices, disabledServices, maskedServices, requiredServices],
   );
 
   return (
     <>
       <FormGroup isRequired={false} label='Enabled services'>
-        <LabelInput
+        <ValidatedListInput
           ariaLabel='Add enabled systemd service'
           placeholder='Add enabled service'
-          validator={isServiceValid}
-          list={enabledServices.filter(
-            (service) => !enabledRequiredByProfile.includes(service),
-          )}
-          requiredList={enabledRequiredByProfile}
-          item='Enabled service'
-          addAction={addEnabledService}
-          removeAction={removeEnabledService}
-          stepValidation={stepValidation}
-          fieldName='enabledSystemdServices'
-          chipCollapseThreshold={8}
+          validator={validateEnabledServices}
+          items={enabled}
+          onAdd={(value) => dispatch(addEnabledService(value))}
+          onRemove={(value) => dispatch(removeEnabledService(value))}
+          maxVisibleItems={8}
           helperText='These services are currently active and set to start automatically at boot.'
         />
       </FormGroup>
       <FormGroup isRequired={false} label='Disabled services'>
-        <LabelInput
+        <ValidatedListInput
           ariaLabel='Add disabled systemd service'
           placeholder='Add disabled service'
-          validator={isServiceValid}
-          list={disabledServices.filter(
-            (service) => !disabledRequiredByProfile.includes(service),
-          )}
-          requiredList={disabledRequiredByProfile}
-          item='Disabled service'
-          addAction={addDisabledService}
-          removeAction={removeDisabledService}
-          stepValidation={stepValidation}
-          fieldName='disabledSystemdServices'
-          chipCollapseThreshold={8}
+          validator={validateDisabledServices}
+          items={disabled}
+          onAdd={(value) => dispatch(addDisabledService(value))}
+          onRemove={(value) => dispatch(removeDisabledService(value))}
+          maxVisibleItems={8}
           helperText='These services are installed but will not start automatically at boot.'
         />
       </FormGroup>
       <FormGroup isRequired={false} label='Masked services'>
-        <LabelInput
+        <ValidatedListInput
           ariaLabel='Add masked systemd service'
           placeholder='Add masked service'
-          validator={isServiceValid}
-          list={maskedServices.filter(
-            (service) => !maskedRequiredByProfile.includes(service),
-          )}
-          requiredList={maskedRequiredByProfile}
-          item='Masked service'
-          addAction={addMaskedService}
-          removeAction={removeMaskedService}
-          stepValidation={stepValidation}
-          fieldName='maskedSystemdServices'
-          chipCollapseThreshold={8}
+          validator={validateMaskedServices}
+          items={masked}
+          onAdd={(value) => dispatch(addMaskedService(value))}
+          onRemove={(value) => dispatch(removeMaskedService(value))}
+          maxVisibleItems={8}
           helperText='These services are completely blocked from being started manually or automatically.'
         />
       </FormGroup>

--- a/src/Components/CreateImageWizard/steps/Services/tests/Services.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Services/tests/Services.test.tsx
@@ -141,13 +141,13 @@ describe('Services Component', () => {
       await addEnabledService(user, '-------');
 
       expect(
-        screen.getByText('Expected format: <service-name>. Example: sshd'),
+        screen.getByText('Service name must contain at least one letter'),
       ).toBeInTheDocument();
 
       await clearEnabledServiceInput(user);
 
       expect(
-        screen.queryByText('Expected format: <service-name>. Example: sshd'),
+        screen.queryByText('Service name must contain at least one letter'),
       ).not.toBeInTheDocument();
     });
   });
@@ -181,13 +181,13 @@ describe('Services Component', () => {
       await addDisabledService(user, '-------');
 
       expect(
-        screen.getByText('Expected format: <service-name>. Example: sshd'),
+        screen.getByText('Service name must contain at least one letter'),
       ).toBeInTheDocument();
 
       await clearDisabledServiceInput(user);
 
       expect(
-        screen.queryByText('Expected format: <service-name>. Example: sshd'),
+        screen.queryByText('Service name must contain at least one letter'),
       ).not.toBeInTheDocument();
     });
   });
@@ -221,13 +221,13 @@ describe('Services Component', () => {
       await addMaskedService(user, '-------');
 
       expect(
-        screen.getByText('Expected format: <service-name>. Example: sshd'),
+        screen.getByText('Service name must contain at least one letter'),
       ).toBeInTheDocument();
 
       await clearMaskedServiceInput(user);
 
       expect(
-        screen.queryByText('Expected format: <service-name>. Example: sshd'),
+        screen.queryByText('Service name must contain at least one letter'),
       ).not.toBeInTheDocument();
     });
   });

--- a/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
+++ b/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
@@ -258,20 +258,15 @@ describe('ImportMode', () => {
 
     // Services
     expect(
-      await screen.findByText(
-        /Invalid enabled services: --invalid-enabled-service/,
+      await screen.findAllByText(
+        'Service name must start with a letter or digit',
       ),
-    ).toBeInTheDocument();
+    ).toHaveLength(3);
     expect(
-      await screen.findByText(
-        /Invalid disabled services: --invalid-disabled-service/,
+      await screen.findAllByText(
+        'Service name must not contain consecutive hyphens',
       ),
-    ).toBeInTheDocument();
-    expect(
-      await screen.findByText(
-        /Invalid masked services: --invalid-masked-service/,
-      ),
-    ).toBeInTheDocument();
+    ).toHaveLength(3);
 
     await clickWithWait(
       user,

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -71,6 +71,7 @@ import {
   UserWithAdditionalInfo,
   validateHostname,
   validateKernel,
+  validateServices,
 } from '@/store/slices/wizard';
 import useDebounce from '@/Utilities/useDebounce';
 
@@ -135,7 +136,6 @@ export function useIsBlueprintValid(): boolean {
   const timezone = useTimezoneValidation();
   const locale = useLocaleValidation();
   const firewall = useFirewallValidation();
-  const services = useServicesValidation();
   const firstBoot = useFirstBootValidation();
   const details = useDetailsValidation();
   const users = useUsersValidation();
@@ -146,6 +146,7 @@ export function useIsBlueprintValid(): boolean {
 
   const hostnameErrors = validateHostname(useAppSelector(selectHostname));
   const kernelErrors = validateKernel(useAppSelector(selectKernel));
+  const serviceErrors = validateServices(useAppSelector(selectServices));
 
   return (
     !aap.disabledNext &&
@@ -157,7 +158,7 @@ export function useIsBlueprintValid(): boolean {
     hostnameErrors.length === 0 &&
     kernelErrors.length === 0 &&
     !firewall.disabledNext &&
-    !services.disabledNext &&
+    serviceErrors.length === 0 &&
     !firstBoot.disabledNext &&
     !details.disabledNext &&
     !details.isPending &&
@@ -714,89 +715,6 @@ export function useFirewallValidation(): StepValidation {
       invalidEnabled.length > 0 ||
       duplicatePorts.length > 0 ||
       duplicateDisabledServices.length > 0 ||
-      duplicateEnabledServices.length > 0,
-  };
-}
-
-export function useServicesValidation(): StepValidation {
-  const services = useAppSelector(selectServices);
-
-  const invalidDisabled = [];
-  const invalidMasked = [];
-  const invalidEnabled = [];
-
-  if (services.disabled.length > 0) {
-    for (const s of services.disabled) {
-      if (!isServiceValid(s)) {
-        invalidDisabled.push(s);
-      }
-    }
-  }
-
-  if (services.masked.length > 0) {
-    for (const s of services.masked) {
-      if (!isServiceValid(s)) {
-        invalidMasked.push(s);
-      }
-    }
-  }
-
-  if (services.enabled.length > 0) {
-    for (const s of services.enabled) {
-      if (!isServiceValid(s)) {
-        invalidEnabled.push(s);
-      }
-    }
-  }
-
-  const duplicateDisabledServices = getListOfDuplicates(services.disabled);
-  const duplicateMaskedServices = getListOfDuplicates(services.masked);
-  const duplicateEnabledServices = getListOfDuplicates(services.enabled);
-
-  const disabledSystemdServicesError =
-    invalidDisabled.length > 0
-      ? `Invalid disabled services: ${invalidDisabled}`
-      : '';
-  const maskedSystemdServicesError =
-    invalidMasked.length > 0 ? `Invalid masked services: ${invalidMasked}` : '';
-  const enabledSystemdServicesError =
-    invalidEnabled.length > 0
-      ? `Invalid enabled services: ${invalidEnabled}`
-      : '';
-  const duplicateDisabledServicesError =
-    duplicateDisabledServices.length > 0
-      ? `Includes duplicate disabled services: ${duplicateDisabledServices.join(
-          ', ',
-        )}`
-      : '';
-  const duplicateMaskedServicesError =
-    duplicateMaskedServices.length > 0
-      ? `Includes duplicate masked services: ${duplicateMaskedServices.join(
-          ', ',
-        )}`
-      : '';
-  const duplicateEnabledServicesError =
-    duplicateEnabledServices.length > 0
-      ? `Includes duplicate enabled services: ${duplicateEnabledServices.join(
-          ', ',
-        )}`
-      : '';
-
-  return {
-    errors: {
-      disabledSystemdServices:
-        disabledSystemdServicesError + '|' + duplicateDisabledServicesError,
-      maskedSystemdServices:
-        maskedSystemdServicesError + '|' + duplicateMaskedServicesError,
-      enabledSystemdServices:
-        enabledSystemdServicesError + '|' + duplicateEnabledServicesError,
-    },
-    disabledNext:
-      invalidDisabled.length > 0 ||
-      invalidMasked.length > 0 ||
-      invalidEnabled.length > 0 ||
-      duplicateDisabledServices.length > 0 ||
-      duplicateMaskedServices.length > 0 ||
       duplicateEnabledServices.length > 0,
   };
 }

--- a/src/store/slices/wizard/system/schemas.ts
+++ b/src/store/slices/wizard/system/schemas.ts
@@ -39,3 +39,26 @@ export const kernelSchema = z.object({
   name: z.string(),
   append: z.array(kernelArgSchema).superRefine(uniqueArray('kernel argument')),
 });
+
+export const serviceSchema = z
+  .string()
+  .max(256, 'Service name must be 256 characters or fewer')
+  // see `man systemd.unit` for the exact specification. The character-set and
+  // start/end rules are checked separately so each failure names its own rule
+  // instead of collapsing into one generic message.
+  .regex(
+    /^[a-zA-Z0-9.\-_:@]*$/,
+    'Service name may only contain letters, digits, and . - _ : @',
+  )
+  .regex(/^[a-zA-Z0-9]/, 'Service name must start with a letter or digit')
+  .regex(/[a-zA-Z0-9]$/, 'Service name must end with a letter or digit')
+  .regex(/^(?!.*--)/, 'Service name must not contain consecutive hyphens')
+  .regex(/[a-zA-Z]+/, 'Service name must contain at least one letter');
+
+export const servicesSchema = z.object({
+  enabled: z.array(serviceSchema).superRefine(uniqueArray('enabled services')),
+  masked: z.array(serviceSchema).superRefine(uniqueArray('masked services')),
+  disabled: z
+    .array(serviceSchema)
+    .superRefine(uniqueArray('disabled services')),
+});

--- a/src/store/slices/wizard/system/tests/validation/services.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/services.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { isServiceValid } from '@/Components/CreateImageWizard/validators';
+
+// Services (systemd units) use the same validation rules as firewall services.
+// These tests cover the systemd-specific context (disabled, masked, enabled)
+// to ensure the validation function handles all three categories correctly.
+
+describe('systemd services validation', () => {
+  describe('valid services', () => {
+    it('accepts a systemd unit name', () => {
+      expect(isServiceValid('sshd.service')).toBe(true);
+    });
+
+    it('accepts a timer unit', () => {
+      expect(isServiceValid('dnf-makecache.timer')).toBe(true);
+    });
+
+    it('accepts a socket unit', () => {
+      expect(isServiceValid('cockpit.socket')).toBe(true);
+    });
+
+    it('accepts a template unit', () => {
+      expect(isServiceValid('getty@tty1')).toBe(true);
+    });
+
+    it('accepts a mount unit', () => {
+      expect(isServiceValid('home.mount')).toBe(true);
+    });
+
+    it('accepts a service with underscores', () => {
+      expect(isServiceValid('network_manager')).toBe(true);
+    });
+
+    it('accepts a service with mixed case', () => {
+      expect(isServiceValid('NetworkManager')).toBe(true);
+    });
+  });
+
+  describe('invalid services', () => {
+    it('rejects an empty string', () => {
+      expect(isServiceValid('')).toBe(false);
+    });
+
+    it('rejects a service with consecutive hyphens', () => {
+      expect(isServiceValid('my--service')).toBe(false);
+    });
+
+    it('rejects a service starting with a dot', () => {
+      expect(isServiceValid('.hidden')).toBe(false);
+    });
+
+    it('rejects a service ending with a dot', () => {
+      expect(isServiceValid('service.')).toBe(false);
+    });
+
+    it('rejects a service with spaces', () => {
+      expect(isServiceValid('my service')).toBe(false);
+    });
+
+    it('rejects a purely numeric service', () => {
+      expect(isServiceValid('12345')).toBe(false);
+    });
+
+    it('rejects a service over 256 characters', () => {
+      const service = 'a'.repeat(257);
+      expect(isServiceValid(service)).toBe(false);
+    });
+  });
+});

--- a/src/store/slices/wizard/system/tests/validation/services.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/services.test.ts
@@ -1,70 +1,124 @@
 import { describe, expect, it } from 'vitest';
 
-import { isServiceValid } from '@/Components/CreateImageWizard/validators';
+import {
+  validateDisabledServices,
+  validateEnabledServices,
+  validateMaskedServices,
+} from '../../validators';
 
-// Services (systemd units) use the same validation rules as firewall services.
-// These tests cover the systemd-specific context (disabled, masked, enabled)
-// to ensure the validation function handles all three categories correctly.
+// All three service categories (enabled, disabled, masked) share the same
+// `serviceSchema`, so the format rules are exercised once through
+// `validateEnabledServices`. The per-category behaviour (including duplicate
+// detection, which uses a category-specific label) is covered separately.
+const isValid = (service: string) =>
+  validateEnabledServices([service]).length === 0;
 
 describe('systemd services validation', () => {
   describe('valid services', () => {
     it('accepts a systemd unit name', () => {
-      expect(isServiceValid('sshd.service')).toBe(true);
+      expect(isValid('sshd.service')).toBe(true);
     });
 
     it('accepts a timer unit', () => {
-      expect(isServiceValid('dnf-makecache.timer')).toBe(true);
+      expect(isValid('dnf-makecache.timer')).toBe(true);
     });
 
     it('accepts a socket unit', () => {
-      expect(isServiceValid('cockpit.socket')).toBe(true);
+      expect(isValid('cockpit.socket')).toBe(true);
     });
 
     it('accepts a template unit', () => {
-      expect(isServiceValid('getty@tty1')).toBe(true);
+      expect(isValid('getty@tty1')).toBe(true);
     });
 
     it('accepts a mount unit', () => {
-      expect(isServiceValid('home.mount')).toBe(true);
+      expect(isValid('home.mount')).toBe(true);
     });
 
     it('accepts a service with underscores', () => {
-      expect(isServiceValid('network_manager')).toBe(true);
+      expect(isValid('network_manager')).toBe(true);
     });
 
     it('accepts a service with mixed case', () => {
-      expect(isServiceValid('NetworkManager')).toBe(true);
+      expect(isValid('NetworkManager')).toBe(true);
+    });
+
+    it('accepts a single-character name', () => {
+      expect(isValid('a')).toBe(true);
+    });
+
+    it('accepts a name at the 256-character limit', () => {
+      expect(isValid('a'.repeat(256))).toBe(true);
+    });
+
+    it('accepts a colon in the middle of a name', () => {
+      expect(isValid('foo:bar')).toBe(true);
+    });
+
+    it('returns no issues for an empty list', () => {
+      expect(validateEnabledServices([])).toEqual([]);
     });
   });
 
   describe('invalid services', () => {
     it('rejects an empty string', () => {
-      expect(isServiceValid('')).toBe(false);
+      expect(isValid('')).toBe(false);
     });
 
     it('rejects a service with consecutive hyphens', () => {
-      expect(isServiceValid('my--service')).toBe(false);
+      expect(isValid('my--service')).toBe(false);
     });
 
     it('rejects a service starting with a dot', () => {
-      expect(isServiceValid('.hidden')).toBe(false);
+      expect(isValid('.hidden')).toBe(false);
     });
 
     it('rejects a service ending with a dot', () => {
-      expect(isServiceValid('service.')).toBe(false);
+      expect(isValid('service.')).toBe(false);
+    });
+
+    it('rejects a service starting with a hyphen', () => {
+      expect(isValid('-foo')).toBe(false);
+    });
+
+    it('rejects a service ending with a hyphen', () => {
+      expect(isValid('foo-')).toBe(false);
     });
 
     it('rejects a service with spaces', () => {
-      expect(isServiceValid('my service')).toBe(false);
+      expect(isValid('my service')).toBe(false);
     });
 
     it('rejects a purely numeric service', () => {
-      expect(isServiceValid('12345')).toBe(false);
+      expect(isValid('12345')).toBe(false);
     });
 
     it('rejects a service over 256 characters', () => {
-      const service = 'a'.repeat(257);
-      expect(isServiceValid(service)).toBe(false);
+      expect(isValid('a'.repeat(257))).toBe(false);
+    });
+  });
+
+  describe.each([
+    ['enabled', validateEnabledServices, 'enabled services'],
+    ['disabled', validateDisabledServices, 'disabled services'],
+    ['masked', validateMaskedServices, 'masked services'],
+  ])('%s services validator', (_category, validate, label) => {
+    it('accepts a valid service', () => {
+      expect(validate(['sshd.service'])).toEqual([]);
+    });
+
+    it('rejects an invalid service', () => {
+      expect(validate(['my--service']).length).toBeGreaterThan(0);
+    });
+
+    it('flags a duplicate service', () => {
+      const result = validate(['sshd', 'sshd']);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        kind: 'duplicate',
+        value: 'sshd',
+      });
+      expect(result[0].message).toContain(label);
     });
   });
 });

--- a/src/store/slices/wizard/system/types.ts
+++ b/src/store/slices/wizard/system/types.ts
@@ -2,9 +2,11 @@ import z from 'zod';
 
 import { Locale, Timezone, User } from '@/store/api/backend';
 
-import { kernelSchema } from './schemas';
+import { kernelSchema, servicesSchema } from './schemas';
 
 export type Kernel = z.infer<typeof kernelSchema>;
+
+export type Services = z.infer<typeof servicesSchema>;
 
 export type UserWithAdditionalInfo = {
   [K in keyof User]-?: NonNullable<User[K]>;

--- a/src/store/slices/wizard/system/validators.ts
+++ b/src/store/slices/wizard/system/validators.ts
@@ -1,5 +1,5 @@
-import { hostnameSchema, kernelSchema } from './schemas';
-import { Kernel } from './types';
+import { hostnameSchema, kernelSchema, servicesSchema } from './schemas';
+import { Kernel, Services } from './types';
 
 import { validateList, validateSchema } from '../validators';
 
@@ -13,4 +13,20 @@ export const validateKernelArgs = (items: string[]) => {
 
 export const validateKernel = (kernel: Kernel) => {
   return validateSchema(kernelSchema, kernel);
+};
+
+export const validateEnabledServices = (items: string[]) => {
+  return validateList(servicesSchema.shape.enabled, items);
+};
+
+export const validateDisabledServices = (items: string[]) => {
+  return validateList(servicesSchema.shape.disabled, items);
+};
+
+export const validateMaskedServices = (items: string[]) => {
+  return validateList(servicesSchema.shape.masked, items);
+};
+
+export const validateServices = (services: Services) => {
+  return validateSchema(servicesSchema, services);
 };


### PR DESCRIPTION
# Migrate Systemd Services step to schema-based validation

## Summary

Migrates the Systemd Services wizard step to the shared `ValidatedListInput` component and Zod schema-based validation (building on the kernel-args groundwork). Service-name validation now lives in a single reusable schema instead of being duplicated across the component and a step-validation hook.

## Changes

- Add `serviceSchema`/`servicesSchema` Zod schemas with granular, per-rule error messages, plus `validateEnabledServices`/`validateDisabledServices`/`validateMaskedServices` and `validateServices` wrappers.
- Migrate `ServicesInput` to the shared `ValidatedListInput` component, replacing the manual `LabelInput` wiring and inline validation.
- Source OpenSCAP-required services via `useSecuritySummary` instead of manual query orchestration and inline filtering.
- Remove the legacy `useServicesValidation` hook and gate the Next button through `validateServices`, matching the existing `validateHostname`/`validateKernel` pattern (`isServiceValid` is retained for the Firewall step).
- Add schema and component test coverage for the services step.