### PR TITLE
Show users in advanced settings consistently

### DIFF
--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -191,10 +191,7 @@ const CreateImageWizard = () => {
     registrationValidation.disabledNext ||
     aapValidation.disabledNext ||
     snapshotValidation.disabledNext ||
-    imagePullValidation.disabledNext ||
-    (!restrictions.users.shouldHide &&
-      restrictions.users.isStandalone &&
-      usersHaveErrors);
+    imagePullValidation.disabledNext;
 
   const baseSettingsIsPending = !!detailsValidation.isPending;
 
@@ -207,8 +204,7 @@ const CreateImageWizard = () => {
     servicesValidation.disabledNext ||
     firewallValidation.disabledNext ||
     firstBootValidation.disabledNext ||
-    (!(restrictions.users.shouldHide || restrictions.users.isStandalone) &&
-      usersHaveErrors);
+    (!restrictions.users.shouldHide && usersHaveErrors);
 
   useEffect(() => {
     const hasUrlParams =
@@ -532,12 +528,6 @@ const CreateImageWizard = () => {
               !(
                 restrictions.openscap.shouldHide && restrictions.fips.shouldHide
               ) && <OscapStep key='oscap' />,
-              !restrictions.users.shouldHide &&
-                restrictions.users.isStandalone && <UsersStep key='users' />,
-              !restrictions.users.shouldHide &&
-                restrictions.users.isStandalone && (
-                  <UserGroupsStep key='groups' />
-                ),
             ]
               .filter(Boolean)
               .flatMap((component, index, array) =>
@@ -597,8 +587,7 @@ const CreateImageWizard = () => {
             restrictions.kernel.shouldHide &&
             restrictions.services.shouldHide &&
             restrictions.firewall.shouldHide &&
-            (restrictions.users.shouldHide ||
-              restrictions.users.isStandalone) &&
+            restrictions.users.shouldHide &&
             restrictions.firstBoot.shouldHide
           }
           footer={
@@ -639,12 +628,8 @@ const CreateImageWizard = () => {
               !restrictions.firewall.shouldHide && (
                 <FirewallStep key='firewall' />
               ),
-              !(
-                restrictions.users.shouldHide || restrictions.users.isStandalone
-              ) && <UsersStep key='users' />,
-              !(
-                restrictions.users.shouldHide || restrictions.users.isStandalone
-              ) && <UserGroupsStep key='groups' />,
+              !restrictions.users.shouldHide && <UsersStep key='users' />,
+              !restrictions.users.shouldHide && <UserGroupsStep key='groups' />,
               !restrictions.firstBoot.shouldHide && (
                 <FirstBootStep key='firstboot' />
               ),

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/index.tsx
@@ -37,8 +37,7 @@ const AdvancedSettingsOverview = ({
   oscapKernelArgs = [],
   oscapServices,
 }: AdvancedSettingsOverviewProps) => {
-  const usersHidden =
-    restrictions.users.shouldHide || restrictions.users.isStandalone;
+  const usersHidden = restrictions.users.shouldHide;
   const hasUsers = useAppSelector(selectHasUsers);
   const hasUserGroups = useAppSelector(selectHasUserGroups);
 

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -1280,11 +1280,11 @@ echo 'Hello there, General Kenobi!'`;
       expect(screen.getByText('User groups')).toBeInTheDocument();
     });
 
-    test('renders users section when users are standalone', () => {
+    test('does not render users section when users are hidden', () => {
       renderWithRedux(
         <AdvancedSettingsOverview
           restrictions={createDefaultRestrictions({
-            users: { isStandalone: true },
+            users: { shouldHide: true },
           })}
         />,
         {
@@ -1300,8 +1300,8 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.getAllByText('Users').length).toBeGreaterThan(0);
-      expect(screen.getByText('User groups')).toBeInTheDocument();
+      expect(screen.queryByText('Users')).not.toBeInTheDocument();
+      expect(screen.queryByText('User groups')).not.toBeInTheDocument();
     });
   });
 

--- a/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/AdvancedSettings/tests/AdvancedSettings.test.tsx
@@ -1260,7 +1260,7 @@ echo 'Hello there, General Kenobi!'`;
       expect(screen.getAllByText('*****')).toHaveLength(3);
     });
 
-    test('renders users section when users are not required', () => {
+    test('renders users section when users are supported', () => {
       renderWithRedux(
         <AdvancedSettingsOverview restrictions={createDefaultRestrictions()} />,
         {
@@ -1280,7 +1280,7 @@ echo 'Hello there, General Kenobi!'`;
       expect(screen.getByText('User groups')).toBeInTheDocument();
     });
 
-    test('does not render users section when users are standalone', () => {
+    test('renders users section when users are standalone', () => {
       renderWithRedux(
         <AdvancedSettingsOverview
           restrictions={createDefaultRestrictions({
@@ -1300,8 +1300,8 @@ echo 'Hello there, General Kenobi!'`;
         },
       );
 
-      expect(screen.queryByText('Users')).not.toBeInTheDocument();
-      expect(screen.queryByText('User groups')).not.toBeInTheDocument();
+      expect(screen.getAllByText('Users').length).toBeGreaterThan(0);
+      expect(screen.getByText('User groups')).toBeInTheDocument();
     });
   });
 

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/index.tsx
@@ -18,12 +18,9 @@ import {
 
 import { MiscFormats, PrivateClouds, PublicClouds } from './components';
 
-import { Users } from '../AdvancedSettings/components';
-import { UserGroups } from '../AdvancedSettings/components/UserGroups';
 import { ReviewCardHeader, ReviewGroup, ReviewList } from '../shared';
-import { ReviewCardProps } from '../types';
 
-const ImageOverview = ({ restrictions }: ReviewCardProps) => {
+const ImageOverview = () => {
   const imageName = useAppSelector(selectBlueprintName);
   const description = useAppSelector(selectBlueprintDescription);
   const isOnPremise = useAppSelector(selectIsOnPremise);
@@ -76,16 +73,6 @@ const ImageOverview = ({ restrictions }: ReviewCardProps) => {
           <PublicClouds environments={publicClouds} />
           <PrivateClouds environments={privateClouds} />
           <MiscFormats environments={miscFormats} />
-          <Users
-            shouldHide={
-              restrictions.users.shouldHide || !restrictions.users.isStandalone
-            }
-          />
-          <UserGroups
-            shouldHide={
-              restrictions.users.shouldHide || !restrictions.users.isStandalone
-            }
-          />
         </ReviewList>
       </CardBody>
     </Card>

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -269,30 +269,6 @@ describe('ImageOverview', () => {
   });
 
   describe('Users', () => {
-    test('does not render users + groups section when users are standalone', () => {
-      renderWithRedux(
-        <ImageOverview
-          restrictions={createDefaultRestrictions({
-            users: { isStandalone: true },
-          })}
-        />,
-        {
-          output: {
-            ...initialState.output,
-            imageTypes: ['guest-image'],
-          },
-          system: {
-            ...initialState.system,
-            users: [adminUser],
-            groups: userGroups,
-          },
-        },
-      );
-
-      expect(screen.queryByText('Custom users')).not.toBeInTheDocument();
-      expect(screen.queryByText('User groups')).not.toBeInTheDocument();
-    });
-
     test('does not render users section from image overview', () => {
       renderWithRedux(<ImageOverview />, {
         output: {

--- a/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/ImageOverview/tests/ImageOverview.test.tsx
@@ -7,69 +7,57 @@ import { initialState } from '@/store/slices/wizard';
 import { renderWithRedux } from '@/test/testUtils';
 
 import { adminUser, userGroups } from '../../AdvancedSettings/tests/mocks';
-import { createDefaultRestrictions } from '../../tests/helpers';
 import ImageOverview from '../index';
 
 describe('ImageOverview', () => {
   test('renders the card with image overview title', () => {
-    renderWithRedux(
-      <ImageOverview restrictions={createDefaultRestrictions()} />,
-    );
+    renderWithRedux(<ImageOverview />);
 
     expect(screen.getByText('Image overview')).toBeInTheDocument();
   });
 
   test('displays the blueprint name', () => {
-    renderWithRedux(
-      <ImageOverview restrictions={createDefaultRestrictions()} />,
-      {
-        details: {
-          ...initialState.details,
-          blueprint: {
-            ...initialState.details.blueprint,
-            name: 'my-test-blueprint',
-            description: '',
-            isCustomName: true,
-          },
+    renderWithRedux(<ImageOverview />, {
+      details: {
+        ...initialState.details,
+        blueprint: {
+          ...initialState.details.blueprint,
+          name: 'my-test-blueprint',
+          description: '',
+          isCustomName: true,
         },
       },
-    );
+    });
 
     expect(screen.getByText('Name')).toBeInTheDocument();
     expect(screen.getByText('my-test-blueprint')).toBeInTheDocument();
   });
 
   test('displays the blueprint description', () => {
-    renderWithRedux(
-      <ImageOverview restrictions={createDefaultRestrictions()} />,
-      {
-        details: {
-          ...initialState.details,
-          blueprint: {
-            ...initialState.details.blueprint,
-            name: 'test-blueprint',
-            description: 'This is a test description',
-            isCustomName: true,
-          },
+    renderWithRedux(<ImageOverview />, {
+      details: {
+        ...initialState.details,
+        blueprint: {
+          ...initialState.details.blueprint,
+          name: 'test-blueprint',
+          description: 'This is a test description',
+          isCustomName: true,
         },
       },
-    );
+    });
 
     expect(screen.getByText('Details')).toBeInTheDocument();
     expect(screen.getByText('This is a test description')).toBeInTheDocument();
   });
 
   test('displays the base release for package mode', () => {
-    renderWithRedux(
-      <ImageOverview restrictions={createDefaultRestrictions()} />,
-      {
-        output: { ...initialState.output, distribution: RHEL_10 },
-        details: {
-          ...initialState.details,
-          blueprint: { ...initialState.details.blueprint, mode: 'package' },
-        },
+    renderWithRedux(<ImageOverview />, {
+      output: { ...initialState.output, distribution: RHEL_10 },
+      details: {
+        ...initialState.details,
+        blueprint: { ...initialState.details.blueprint, mode: 'package' },
       },
-    );
+    });
 
     expect(screen.getByText('Base release')).toBeInTheDocument();
     expect(
@@ -78,75 +66,58 @@ describe('ImageOverview', () => {
   });
 
   test('displays the architecture', () => {
-    renderWithRedux(
-      <ImageOverview restrictions={createDefaultRestrictions()} />,
-      {
-        output: { ...initialState.output, architecture: X86_64 },
-      },
-    );
+    renderWithRedux(<ImageOverview />, {
+      output: { ...initialState.output, architecture: X86_64 },
+    });
 
     expect(screen.getByText('Architecture')).toBeInTheDocument();
     expect(screen.getByText(X86_64)).toBeInTheDocument();
   });
 
   test('displays target environments heading', () => {
-    renderWithRedux(
-      <ImageOverview restrictions={createDefaultRestrictions()} />,
-    );
+    renderWithRedux(<ImageOverview />);
 
     expect(screen.getByText('Target environments')).toBeInTheDocument();
   });
 
   describe('Private clouds', () => {
     test('displays vsphere when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: { ...initialState.output, imageTypes: ['vsphere'] },
-        },
-      );
+      renderWithRedux(<ImageOverview />, {
+        output: { ...initialState.output, imageTypes: ['vsphere'] },
+      });
 
       expect(screen.getByText('Private cloud')).toBeInTheDocument();
       expect(screen.getByText('VMware vSphere (.vmdk)')).toBeInTheDocument();
     });
 
     test('displays vsphere-ova when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: {
-            ...initialState.output,
-            imageTypes: ['vsphere-ova'],
-          },
+      renderWithRedux(<ImageOverview />, {
+        output: {
+          ...initialState.output,
+          imageTypes: ['vsphere-ova'],
         },
-      );
+      });
 
       expect(screen.getByText('Private cloud')).toBeInTheDocument();
       expect(screen.getByText('VMware vSphere (.ova)')).toBeInTheDocument();
     });
 
     test('displays multiple private clouds when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: {
-            ...initialState.output,
-            imageTypes: ['vsphere', 'vsphere-ova'],
-          },
+      renderWithRedux(<ImageOverview />, {
+        output: {
+          ...initialState.output,
+          imageTypes: ['vsphere', 'vsphere-ova'],
         },
-      );
+      });
 
       expect(screen.getByText('VMware vSphere (.vmdk)')).toBeInTheDocument();
       expect(screen.getByText('VMware vSphere (.ova)')).toBeInTheDocument();
     });
 
     test('does not display private cloud section when none selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: { ...initialState.output, imageTypes: ['aws'] },
-        },
-      );
+      renderWithRedux(<ImageOverview />, {
+        output: { ...initialState.output, imageTypes: ['aws'] },
+      });
 
       expect(screen.queryByText('Private cloud')).not.toBeInTheDocument();
     });
@@ -154,21 +125,18 @@ describe('ImageOverview', () => {
 
   describe('Public clouds', () => {
     test('displays AWS details when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: { ...initialState.output, imageTypes: ['aws'] },
-          cloudProviders: {
-            ...initialState.cloudProviders,
-            aws: {
-              accountId: '123456789012',
-              shareMethod: 'manual',
-              source: undefined,
-              region: 'us-west-2',
-            },
+      renderWithRedux(<ImageOverview />, {
+        output: { ...initialState.output, imageTypes: ['aws'] },
+        cloudProviders: {
+          ...initialState.cloudProviders,
+          aws: {
+            accountId: '123456789012',
+            shareMethod: 'manual',
+            source: undefined,
+            region: 'us-west-2',
           },
         },
-      );
+      });
 
       expect(screen.getByText('Public cloud')).toBeInTheDocument();
       expect(screen.getByText('Amazon Web Services')).toBeInTheDocument();
@@ -179,19 +147,16 @@ describe('ImageOverview', () => {
     });
 
     test('displays GCP details when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: { ...initialState.output, imageTypes: ['gcp'] },
-          cloudProviders: {
-            ...initialState.cloudProviders,
-            gcp: {
-              accountType: 'user',
-              email: 'test@example.com',
-            },
+      renderWithRedux(<ImageOverview />, {
+        output: { ...initialState.output, imageTypes: ['gcp'] },
+        cloudProviders: {
+          ...initialState.cloudProviders,
+          gcp: {
+            accountType: 'user',
+            email: 'test@example.com',
           },
         },
-      );
+      });
 
       expect(screen.getByText('Google Cloud')).toBeInTheDocument();
       expect(
@@ -203,21 +168,18 @@ describe('ImageOverview', () => {
     });
 
     test('displays Azure details when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: { ...initialState.output, imageTypes: ['azure'] },
-          cloudProviders: {
-            ...initialState.cloudProviders,
-            azure: {
-              tenantId: 'tenant-123',
-              subscriptionId: 'sub-456',
-              resourceGroup: 'my-resource-group',
-              hyperVGeneration: 'V2',
-            },
+      renderWithRedux(<ImageOverview />, {
+        output: { ...initialState.output, imageTypes: ['azure'] },
+        cloudProviders: {
+          ...initialState.cloudProviders,
+          azure: {
+            tenantId: 'tenant-123',
+            subscriptionId: 'sub-456',
+            resourceGroup: 'my-resource-group',
+            hyperVGeneration: 'V2',
           },
         },
-      );
+      });
 
       expect(screen.getByText('Microsoft Azure')).toBeInTheDocument();
       expect(screen.getByText(/Tenant ID: tenant-123/)).toBeInTheDocument();
@@ -228,12 +190,9 @@ describe('ImageOverview', () => {
     });
 
     test('displays OCI when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: { ...initialState.output, imageTypes: ['oci'] },
-        },
-      );
+      renderWithRedux(<ImageOverview />, {
+        output: { ...initialState.output, imageTypes: ['oci'] },
+      });
 
       expect(
         screen.getByText('Oracle Cloud Infrastructure'),
@@ -241,12 +200,9 @@ describe('ImageOverview', () => {
     });
 
     test('does not display public cloud section when none selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: { ...initialState.output, imageTypes: ['vsphere'] },
-        },
-      );
+      renderWithRedux(<ImageOverview />, {
+        output: { ...initialState.output, imageTypes: ['vsphere'] },
+      });
 
       expect(screen.queryByText('Public cloud')).not.toBeInTheDocument();
     });
@@ -254,41 +210,32 @@ describe('ImageOverview', () => {
 
   describe('Miscellaneous formats', () => {
     test('displays guest-image when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: {
-            ...initialState.output,
-            imageTypes: ['guest-image'],
-          },
+      renderWithRedux(<ImageOverview />, {
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
         },
-      );
+      });
 
       expect(screen.getByText('Miscellaneous formats')).toBeInTheDocument();
       expect(screen.getByText('Virtualization (.qcow2)')).toBeInTheDocument();
     });
 
     test('displays image-installer when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: {
-            ...initialState.output,
-            imageTypes: ['image-installer'],
-          },
+      renderWithRedux(<ImageOverview />, {
+        output: {
+          ...initialState.output,
+          imageTypes: ['image-installer'],
         },
-      );
+      });
 
       expect(screen.getByText('Baremetal (.iso)')).toBeInTheDocument();
     });
 
     test('displays wsl when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: { ...initialState.output, imageTypes: ['wsl'] },
-        },
-      );
+      renderWithRedux(<ImageOverview />, {
+        output: { ...initialState.output, imageTypes: ['wsl'] },
+      });
 
       expect(
         screen.getByText('Windows Subsystem for Linux (.tar.gz)'),
@@ -296,15 +243,12 @@ describe('ImageOverview', () => {
     });
 
     test('displays multiple misc formats when selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: {
-            ...initialState.output,
-            imageTypes: ['guest-image', 'image-installer', 'wsl'],
-          },
+      renderWithRedux(<ImageOverview />, {
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image', 'image-installer', 'wsl'],
         },
-      );
+      });
 
       expect(screen.getByText('Virtualization (.qcow2)')).toBeInTheDocument();
       expect(screen.getByText('Baremetal (.iso)')).toBeInTheDocument();
@@ -314,12 +258,9 @@ describe('ImageOverview', () => {
     });
 
     test('does not display misc formats section when none selected', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: { ...initialState.output, imageTypes: ['aws'] },
-        },
-      );
+      renderWithRedux(<ImageOverview />, {
+        output: { ...initialState.output, imageTypes: ['aws'] },
+      });
 
       expect(
         screen.queryByText('Miscellaneous formats'),
@@ -328,7 +269,7 @@ describe('ImageOverview', () => {
   });
 
   describe('Users', () => {
-    test('renders users + groups section when users are standalone', () => {
+    test('does not render users + groups section when users are standalone', () => {
       renderWithRedux(
         <ImageOverview
           restrictions={createDefaultRestrictions({
@@ -348,27 +289,22 @@ describe('ImageOverview', () => {
         },
       );
 
-      expect(screen.getByText('Custom users')).toBeInTheDocument();
-      expect(screen.getByText('admin')).toBeInTheDocument();
-      expect(screen.getByText('User groups')).toBeInTheDocument();
-      expect(screen.getByText('developers')).toBeInTheDocument();
+      expect(screen.queryByText('Custom users')).not.toBeInTheDocument();
+      expect(screen.queryByText('User groups')).not.toBeInTheDocument();
     });
 
-    test('does not render users section when users are not required', () => {
-      renderWithRedux(
-        <ImageOverview restrictions={createDefaultRestrictions()} />,
-        {
-          output: {
-            ...initialState.output,
-            imageTypes: ['guest-image'],
-          },
-          system: {
-            ...initialState.system,
-            users: [adminUser],
-            groups: userGroups,
-          },
+    test('does not render users section from image overview', () => {
+      renderWithRedux(<ImageOverview />, {
+        output: {
+          ...initialState.output,
+          imageTypes: ['guest-image'],
         },
-      );
+        system: {
+          ...initialState.system,
+          users: [adminUser],
+          groups: userGroups,
+        },
+      });
 
       expect(screen.queryByText('Custom users')).not.toBeInTheDocument();
       expect(screen.queryByText('User groups')).not.toBeInTheDocument();

--- a/src/Components/CreateImageWizard/steps/Review/components/tests/helpers.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/components/tests/helpers.tsx
@@ -13,7 +13,6 @@ export const createDefaultRestrictions = (
   for (const key of ALL_CUSTOMIZATIONS) {
     restrictions[key] = {
       shouldHide: false,
-      isStandalone: false,
       ...overrides[key],
     };
   }

--- a/src/Components/CreateImageWizard/steps/Review/index.tsx
+++ b/src/Components/CreateImageWizard/steps/Review/index.tsx
@@ -35,7 +35,7 @@ const ReviewStep = () => {
     <>
       <FormHeader />
       <NoUsersAlert />
-      <ImageOverview restrictions={restrictions} />
+      <ImageOverview />
       <Registration restrictions={restrictions} />
       <RepeatableBuild restrictions={restrictions} />
       <Security restrictions={restrictions} security={security} />

--- a/src/store/api/distributions/hooks.tsx
+++ b/src/store/api/distributions/hooks.tsx
@@ -172,8 +172,6 @@ export const computeRestrictions = ({
 
     result[customization] = {
       shouldHide: !supportedOptions.has(customization),
-      isStandalone:
-        ctx.isImageMode && ctx.isOnPremise && customization === 'users',
     };
   }
 

--- a/src/store/api/distributions/tests/hooks.test.tsx
+++ b/src/store/api/distributions/tests/hooks.test.tsx
@@ -30,7 +30,6 @@ describe('useCustomizationRestrictions hook logic', () => {
 
       for (const customization of getAllCustomizationTypes()) {
         expect(result[customization].shouldHide).toBe(false);
-        expect(result[customization].isStandalone).toBe(false);
       }
     });
   });
@@ -53,33 +52,6 @@ describe('useCustomizationRestrictions hook logic', () => {
       );
       for (const customization of hiddenTypes) {
         expect(result[customization].shouldHide).toBe(true);
-      }
-    });
-
-    it('should not mark users as standalone in hosted image mode', () => {
-      const result = computeRestrictionStrategy({
-        isImageMode: true,
-        isOnPremise: false,
-      });
-
-      for (const customization of getAllCustomizationTypes()) {
-        expect(result[customization].isStandalone).toBe(false);
-      }
-    });
-
-    it('should mark users as standalone in on-premise image mode', () => {
-      const result = computeRestrictionStrategy({
-        isImageMode: true,
-        isOnPremise: true,
-      });
-
-      expect(result.users.isStandalone).toBe(true);
-
-      const nonUserTypes = getAllCustomizationTypes().filter(
-        (c) => c !== 'users',
-      );
-      for (const customization of nonUserTypes) {
-        expect(result[customization].isStandalone).toBe(false);
       }
     });
   });
@@ -168,7 +140,6 @@ describe('useCustomizationRestrictions hook logic', () => {
       });
 
       expect(result.registration.shouldHide).toBe(true);
-      expect(result.registration.isStandalone).toBe(false);
     });
 
     it('should not hide registration for RHEL distributions', () => {
@@ -209,9 +180,6 @@ describe('useCustomizationRestrictions hook logic', () => {
       expect(result.packages.shouldHide).toBe(true);
       expect(result.repositories.shouldHide).toBe(true);
       expect(result.firstBoot.shouldHide).toBe(true);
-
-      // Users should be standalone on-premise
-      expect(result.users.isStandalone).toBe(true);
     });
   });
 
@@ -226,7 +194,6 @@ describe('useCustomizationRestrictions hook logic', () => {
       for (const customization of getAllCustomizationTypes()) {
         expect(result[customization]).toBeDefined();
         expect(result[customization]).toHaveProperty('shouldHide');
-        expect(result[customization]).toHaveProperty('isStandalone');
       }
     });
   });
@@ -325,7 +292,6 @@ describe('useCustomizationRestrictions hook logic', () => {
 
       for (const customization of getAllCustomizationTypes()) {
         expect(result[customization].shouldHide).toBe(false);
-        expect(result[customization].isStandalone).toBe(false);
       }
     });
   });
@@ -335,11 +301,9 @@ describe('RestrictionStrategy type', () => {
   it('should have correct structure', () => {
     const strategy: RestrictionStrategy = {
       shouldHide: false,
-      isStandalone: false,
     };
 
     expect(strategy).toHaveProperty('shouldHide');
-    expect(strategy).toHaveProperty('isStandalone');
   });
 });
 

--- a/src/store/api/distributions/types.ts
+++ b/src/store/api/distributions/types.ts
@@ -23,5 +23,4 @@ export type CustomizationRestrictions = Partial<
 
 export type RestrictionStrategy = {
   shouldHide: boolean;
-  isStandalone: boolean;
 };


### PR DESCRIPTION
## Summary

Move user and group customizations back into Advanced settings for all image-mode builds, removing the old on-prem standalone user model now that users are optional everywhere.

## Changes

- Render Users and Groups from Advanced settings whenever user customizations are supported.
- Remove user validation from Base settings and keep it with the Advanced settings step.
- Stop showing user/group details in the Image overview review card.
- Remove the obsolete `isStandalone` restriction metadata and related tests.
