### PR TITLE
Fix dependabot PRs by re-resolving lockfile (HMS-11333)

### DIFF
--- a/.github/actions/setup-node-cached/action.yml
+++ b/.github/actions/setup-node-cached/action.yml
@@ -9,6 +9,11 @@ runs:
       with:
         node-version: 24.20.0
 
+    - name: Fix dependabot lockfile
+      if: github.actor == 'dependabot[bot]'
+      run: npm install --package-lock-only
+      shell: bash
+
     - name: Restore npm cache
       id: cache-npm
       uses: actions/cache/restore@v6

--- a/.github/workflows/dev-checks.yml
+++ b/.github/workflows/dev-checks.yml
@@ -64,7 +64,7 @@ jobs:
     - name: Check for manual changes to API
       run: |
         npm run api
-        if [ -n "$(git status --porcelain)" ]; then
+        if [ -n "$(git status --porcelain -- src/store/api/)" ]; then
           echo
           echo "✗ API manually changed, please refer to the README for the procedure to follow for programmatically generated API endpoints."
           exit 1


### PR DESCRIPTION
Dependabot resolver has a gap when handling optional peer-dependencies, making the result different from npm. This re-resolves the lockfile after running dependabot's resolver to restore potentially missing deps.

JIRA: [HMS-11333](https://issues.redhat.com/browse/HMS-11333)

[HMS-11333]: https://redhat.atlassian.net/browse/HMS-11333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ