### PR TITLE
Add @noble/hashes to devDeps to resolve issues with dependabot resolver (HMS-11271)

### DIFF
--- a/.github/actions/setup-node-cached/action.yml
+++ b/.github/actions/setup-node-cached/action.yml
@@ -9,11 +9,6 @@ runs:
       with:
         node-version: 24.20.0
 
-    - name: Fix dependabot lockfile
-      if: github.actor == 'dependabot[bot]'
-      run: npm install --package-lock-only
-      shell: bash
-
     - name: Restore npm cache
       id: cache-npm
       uses: actions/cache/restore@v6

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
         "@currents/playwright": "2.5.0",
         "@eslint/js": "9.39.2",
         "@jsdevtools/coverage-istanbul-loader": "3.0.5",
+        "@noble/hashes": "2.4.0",
         "@playwright/test": "1.56.1",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "3.3.3",
         "@redhat-cloud-services/frontend-components-config": "6.14.4",
@@ -3885,13 +3886,13 @@
       }
     },
     "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-2.4.0.tgz",
+      "integrity": "sha512-X5XaVWZIBCT7HHZGm5I7ZQXDwLG+bGXuSrMQAW+7Zvl87h1kmc1ZB1VSRJcpUfoUrGQp4Fkoxm5kZ+Ms+aW+eA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 16"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -17309,6 +17310,19 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/pkijs/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/playwright": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@currents/playwright": "2.5.0",
     "@eslint/js": "9.39.2",
     "@jsdevtools/coverage-istanbul-loader": "3.0.5",
+    "@noble/hashes": "2.4.0",
     "@playwright/test": "1.56.1",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "3.3.3",
     "@redhat-cloud-services/frontend-components-config": "6.14.4",


### PR DESCRIPTION
Dependabot's resolver has a bug where it drops nested optional peer deps. Meaning the lockfile gets out-of-sync with package.json, causing issues while running `npm ci`.

There are some options to go about this - we could add `npm i --package-lock-only`, add a github action that would add a fix commit to each and every dependabot PR or add the problematic dep to our direct dependencies.

The `npm i` route means adding the command in several places to address failures for schutzbot, konflux and testing-farm, but that felt kinda brittle. Also we'd have to open a PR directly in konflux as the build happens outside of this repo and I'm not honestly confident enough about the fix to shove it in each and every konflux build.

Going the github action route would mean letting github actions bot to push directly into dependabot PRs. Not super sure how secure would that be.

So since we currently have only one "problematic" dep, adding it to our devDeps might be the easiest/safest way to go about this. The cost is having one dependency that is not directly imported in the code in our package.json file, but we can easily iterate on this.

That being said - happy to discuss as this feels like a game of compromise.

JIRA: [HMS-11271](https://redhat.atlassian.net/browse/HMS-11271)

[HMS-11271]: https://redhat.atlassian.net/browse/HMS-11271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ