### PR TITLE
Wizard/Packages: Keep package search open after selection (HMS-11309)

### DIFF
--- a/playwright/Customizations/Packages.spec.ts
+++ b/playwright/Customizations/Packages.spec.ts
@@ -82,6 +82,7 @@ test('Create a blueprint with Packages customization', async ({
     await frame.getByRole('option', { name: /vim-minimal/i }).click();
     await frame.getByRole('textbox', { name: 'Search packages' }).fill('bash');
     await frame.getByRole('option', { name: /bash/i }).first().click();
+    await frame.getByRole('textbox', { name: 'Search packages' }).press('Tab');
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
   });
 
@@ -120,6 +121,7 @@ test('Create a blueprint with Packages customization', async ({
 
     await frame.getByRole('textbox', { name: 'Search packages' }).fill('tmux');
     await frame.getByRole('option', { name: /tmux/i }).first().click();
+    await frame.getByRole('textbox', { name: 'Search packages' }).press('Tab');
 
     await frame.getByRole('button', { name: 'Review image' }).click();
     await frame

--- a/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
+++ b/src/Components/CreateImageWizard/steps/Packages/components/PackageSearch.tsx
@@ -981,8 +981,6 @@ const PackageSearch = ({
         }
       }
     }
-
-    setIsOpen(false);
   };
 
   const toggle = (toggleRef: React.Ref<MenuToggleElement>) => (


### PR DESCRIPTION
This keeps the package search dropdown open after a packages was selected, allowing the user to select multiple packages.

JIRA: [HMS-11309](https://issues.redhat.com/browse/HMS-11309)

[HMS-11309]: https://redhat.atlassian.net/browse/HMS-11309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ