### PR TITLE
Validate firewall customization inputs (HMS-11269)

### DIFF
--- a/playwright/Customizations/Firewall.spec.ts
+++ b/playwright/Customizations/Firewall.spec.ts
@@ -65,19 +65,15 @@ test('Create a blueprint with Firewall customization', async ({
     await expect(frame.getByText('443:udp', { exact: true })).toBeVisible();
   });
 
-  await test.step('Select and correctly fill the disabled services in Firewall step', async () => {
-    await frame
-      .getByPlaceholder('Enter firewalld service')
-      .nth(0)
-      .fill('cloud-init');
+  await test.step('Select and correctly fill the enabled services in Firewall step', async () => {
+    await frame.getByLabel('Add enabled firewall service').fill('cloud-init');
     await page.keyboard.press('Enter');
     await expect(frame.getByText('cloud-init')).toBeVisible();
   });
 
-  await test.step('Select and correctly fill the enabled services in Firewall step', async () => {
+  await test.step('Select and correctly fill the disabled services in Firewall step', async () => {
     await frame
-      .getByPlaceholder('Enter firewalld service')
-      .nth(1)
+      .getByLabel('Add disabled firewall service')
       .fill('telnet.socket');
     await page.keyboard.press('Enter');
     await expect(frame.getByText('telnet.socket')).toBeVisible();
@@ -86,24 +82,22 @@ test('Create a blueprint with Firewall customization', async ({
   await test.step('Prevent adding duplicate ports and services', async () => {
     await frame.getByPlaceholder('Enter port').fill('80:tcp');
     await page.keyboard.press('Enter');
-    await expect(frame.getByText('Port already exists.')).toBeVisible();
+    await expect(
+      frame.getByText('Duplicate firewall ports: 80:tcp'),
+    ).toBeVisible();
 
-    await frame
-      .getByPlaceholder('Enter firewalld service')
-      .nth(0)
-      .fill('cloud-init');
+    await frame.getByLabel('Add enabled firewall service').fill('cloud-init');
     await page.keyboard.press('Enter');
     await expect(
-      frame.getByText('Enabled service already exists.'),
+      frame.getByText('Duplicate enabled firewall services: cloud-init'),
     ).toBeVisible();
 
     await frame
-      .getByPlaceholder('Enter firewalld service')
-      .nth(1)
+      .getByLabel('Add disabled firewall service')
       .fill('telnet.socket');
     await page.keyboard.press('Enter');
     await expect(
-      frame.getByText('Disabled service already exists.'),
+      frame.getByText('Duplicate disabled firewall services: telnet.socket'),
     ).toBeVisible();
   });
 
@@ -111,34 +105,27 @@ test('Create a blueprint with Firewall customization', async ({
     await frame.getByPlaceholder('Enter port').fill('00:wrongFormat');
     await page.keyboard.press('Enter');
     await expect(
-      frame
-        .getByText(
-          'Expected format: <port/port-name>:<protocol>. Example: 8080:tcp, ssh:tcp',
-        )
-        .nth(0),
-    ).toBeVisible();
-  });
-
-  await test.step('Select and incorrectly fill the disabled services in Firewall step', async () => {
-    await frame.getByPlaceholder('Enter firewalld service').nth(0).fill('1');
-    await page.keyboard.press('Enter');
-    await expect(
-      frame
-        .getByText('Expected format: <firewalld-service-name>. Example: ssh.')
-        .nth(0),
+      frame.getByText(
+        'Expected format: <port/port-name>:<protocol>. Example: 8080:tcp, ssh:tcp',
+      ),
     ).toBeVisible();
   });
 
   await test.step('Select and incorrectly fill the enabled services in Firewall step', async () => {
+    await frame.getByLabel('Add enabled firewall service').fill('1');
+    await page.keyboard.press('Enter');
+    await expect(
+      frame.getByText('Service name must contain at least one letter'),
+    ).toBeVisible();
+  });
+
+  await test.step('Select and incorrectly fill the disabled services in Firewall step', async () => {
     await frame
-      .getByPlaceholder('Enter firewalld service')
-      .nth(1)
+      .getByLabel('Add disabled firewall service')
       .fill('wrong--service');
     await page.keyboard.press('Enter');
     await expect(
-      frame
-        .getByText('Expected format: <firewalld-service-name>. Example: ssh.')
-        .nth(1),
+      frame.getByText('Service name must not contain consecutive hyphens'),
     ).toBeVisible();
   });
 
@@ -173,9 +160,9 @@ test('Create a blueprint with Firewall customization', async ({
 
     await frame.getByPlaceholder('Enter port').fill('90:tcp');
     await page.keyboard.press('Enter');
-    await frame.getByPlaceholder('Enter firewalld service').nth(0).fill('x');
+    await frame.getByLabel('Add enabled firewall service').fill('x');
     await page.keyboard.press('Enter');
-    await frame.getByPlaceholder('Enter firewalld service').nth(1).fill('y');
+    await frame.getByLabel('Add disabled firewall service').fill('y');
     await page.keyboard.press('Enter');
 
     await frame.getByRole('button', { name: 'Remove 80:tcp' }).click();
@@ -184,8 +171,8 @@ test('Create a blueprint with Firewall customization', async ({
     await frame.getByRole('button', { name: 'Remove telnet.socket' }).click();
 
     await expect(frame.getByText('90:tcp')).toBeVisible();
-    await expect(frame.getByText('x').nth(0)).toBeVisible();
-    await expect(frame.getByText('y').nth(0)).toBeVisible();
+    await expect(frame.getByText('x', { exact: true })).toBeVisible();
+    await expect(frame.getByText('y', { exact: true })).toBeVisible();
 
     await expect(frame.getByText('80:tcp', { exact: true })).toBeHidden();
     await expect(frame.getByText('443:udp', { exact: true })).toBeHidden();
@@ -228,8 +215,8 @@ test('Create a blueprint with Firewall customization', async ({
     await frame.getByRole('button', { name: 'Advanced settings' }).click();
 
     await expect(frame.getByText('90:tcp')).toBeVisible();
-    await expect(frame.getByText('x').nth(0)).toBeVisible();
-    await expect(frame.getByText('y').nth(0)).toBeVisible();
+    await expect(frame.getByText('x', { exact: true })).toBeVisible();
+    await expect(frame.getByText('y', { exact: true })).toBeVisible();
 
     await expect(frame.getByText('80:tcp', { exact: true })).toBeHidden();
     await expect(frame.getByText('443:udp', { exact: true })).toBeHidden();
@@ -327,9 +314,7 @@ test('Firewall fields collapse chips with show less / more', async ({
   });
 
   await test.step('Enabled services: collapses and shows "X more" when more than 4', async () => {
-    const enabledInput = frame
-      .getByPlaceholder('Enter firewalld service')
-      .nth(0);
+    const enabledInput = frame.getByLabel('Add enabled firewall service');
     for (const service of ['ssh', 'http', 'https', 'dhcp', 'dns']) {
       await enabledInput.fill(service);
       await page.keyboard.press('Enter');
@@ -344,9 +329,7 @@ test('Firewall fields collapse chips with show less / more', async ({
   });
 
   await test.step('Disabled services: collapses and shows "X more" when more than 4', async () => {
-    const disabledInput = frame
-      .getByPlaceholder('Enter firewalld service')
-      .nth(1);
+    const disabledInput = frame.getByLabel('Add disabled firewall service');
     for (const service of ['telnet', 'ftp', 'nfs', 'samba', 'cups']) {
       await disabledInput.fill(service);
       await page.keyboard.press('Enter');
@@ -357,6 +340,6 @@ test('Firewall fields collapse chips with show less / more', async ({
     await expect(frame.getByText('nfs')).toBeVisible();
     await expect(frame.getByText('samba')).toBeVisible();
     await expect(frame.getByText('cups')).toBeHidden();
-    await expect(frame.getByText('1 more').nth(1)).toBeVisible();
+    await expect(frame.getByText('1 more').last()).toBeVisible();
   });
 });

--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -85,14 +85,14 @@ test('Import a blueprint with invalid customization', async ({
     await frame
       .getByRole('heading', { name: 'Firewall' })
       .scrollIntoViewIfNeeded();
-    await expect(frame.getByText('Includes duplicate ports:')).toBeVisible();
     await expect(
-      frame.getByText(
-        'Includes duplicate enabled services: service1: error status',
-      ),
+      frame.getByText('Duplicate firewall ports: 2020:port'),
     ).toBeVisible();
     await expect(
-      frame.getByText('Includes duplicate disabled services: service2'),
+      frame.getByText('Duplicate enabled firewall services: service1'),
+    ).toBeVisible();
+    await expect(
+      frame.getByText('Duplicate disabled firewall services: service2'),
     ).toBeVisible();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -44,6 +44,7 @@ import {
   loadWizardState,
   parseStateFromRequest,
   selectDistribution,
+  selectFirewall,
   selectHostname,
   selectImageSource,
   selectImageSourceType,
@@ -52,6 +53,7 @@ import {
   selectKernel,
   selectServices,
   selectTimezone,
+  validateFirewall,
   validateHostname,
   validateKernel,
   validateServices,
@@ -104,7 +106,6 @@ import {
   useAzureValidation,
   useDetailsValidation,
   useFilesystemValidation,
-  useFirewallValidation,
   useFirstBootValidation,
   useGcpValidation,
   useImagePullValidation,
@@ -161,7 +162,6 @@ const CreateImageWizard = () => {
   const filesystemValidation = useFilesystemValidation();
   const timezoneValidation = useTimezoneValidation();
   const localeValidation = useLocaleValidation();
-  const firewallValidation = useFirewallValidation();
   const firstBootValidation = useFirstBootValidation();
   const usersValidation = useUsersValidation();
   const userGroupsValidation = useUserGroupsValidation();
@@ -170,6 +170,7 @@ const CreateImageWizard = () => {
   const hostnameErrors = validateHostname(useAppSelector(selectHostname));
   const kernelErrors = validateKernel(useAppSelector(selectKernel));
   const servicesErrors = validateServices(useAppSelector(selectServices));
+  const firewallErrors = validateFirewall(useAppSelector(selectFirewall));
 
   const { restrictions } = useCustomizationRestrictions({
     selectedImageTypes: targetEnvironments,
@@ -204,7 +205,7 @@ const CreateImageWizard = () => {
     hostnameErrors.length > 0 ||
     kernelErrors.length > 0 ||
     servicesErrors.length > 0 ||
-    firewallValidation.disabledNext ||
+    firewallErrors.length > 0 ||
     firstBootValidation.disabledNext ||
     (!restrictions.users.shouldHide && usersHaveErrors);
 

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -44,19 +44,13 @@ import {
   loadWizardState,
   parseStateFromRequest,
   selectDistribution,
-  selectFirewall,
-  selectHostname,
   selectImageSource,
   selectImageSourceType,
   selectImageTypes,
   selectIsImageMode,
-  selectKernel,
-  selectServices,
+  selectSystem,
   selectTimezone,
-  validateFirewall,
-  validateHostname,
-  validateKernel,
-  validateServices,
+  validateSystemSlice,
 } from '@/store/slices/wizard';
 import {
   closeWizardModal,
@@ -167,10 +161,8 @@ const CreateImageWizard = () => {
   const userGroupsValidation = useUserGroupsValidation();
   const imagePullValidation = useImagePullValidation();
 
-  const hostnameErrors = validateHostname(useAppSelector(selectHostname));
-  const kernelErrors = validateKernel(useAppSelector(selectKernel));
-  const servicesErrors = validateServices(useAppSelector(selectServices));
-  const firewallErrors = validateFirewall(useAppSelector(selectFirewall));
+  const system = useAppSelector(selectSystem);
+  const systemErrors = validateSystemSlice(system);
 
   const { restrictions } = useCustomizationRestrictions({
     selectedImageTypes: targetEnvironments,
@@ -202,10 +194,7 @@ const CreateImageWizard = () => {
     filesystemValidation.disabledNext ||
     timezoneValidation.disabledNext ||
     localeValidation.disabledNext ||
-    hostnameErrors.length > 0 ||
-    kernelErrors.length > 0 ||
-    servicesErrors.length > 0 ||
-    firewallErrors.length > 0 ||
+    systemErrors.length > 0 ||
     firstBootValidation.disabledNext ||
     (!restrictions.users.shouldHide && usersHaveErrors);
 

--- a/src/Components/CreateImageWizard/steps/Firewall/components/PortsInput.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/components/PortsInput.tsx
@@ -2,29 +2,28 @@ import React from 'react';
 
 import { FormGroup } from '@patternfly/react-core';
 
-import LabelInput from '@/Components/CreateImageWizard/LabelInput';
-import { useFirewallValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
-import { isPortValid } from '@/Components/CreateImageWizard/validators';
-import { useAppSelector } from '@/store/hooks';
-import { addPort, removePort, selectFirewall } from '@/store/slices/wizard';
+import ValidatedListInput from '@/Components/CreateImageWizard/ValidatedListInput';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import {
+  addPort,
+  removePort,
+  selectFirewall,
+  validateFirewallPorts,
+} from '@/store/slices/wizard';
 
 const PortsInput = () => {
+  const dispatch = useAppDispatch();
   const ports = useAppSelector(selectFirewall).ports;
-
-  const stepValidation = useFirewallValidation();
 
   return (
     <FormGroup label='Ports'>
-      <LabelInput
+      <ValidatedListInput
         ariaLabel='Add ports'
         placeholder='Enter port'
-        validator={isPortValid}
-        list={ports}
-        item='Port'
-        addAction={addPort}
-        removeAction={removePort}
-        stepValidation={stepValidation}
-        fieldName='ports'
+        validator={validateFirewallPorts}
+        items={ports.map((port) => ({ value: port, required: false }))}
+        onAdd={(value) => dispatch(addPort(value))}
+        onRemove={(value) => dispatch(removePort(value))}
         helperText='Examples: 8080:tcp, 443:udp.'
       />
     </FormGroup>

--- a/src/Components/CreateImageWizard/steps/Firewall/components/Services.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/components/Services.tsx
@@ -2,50 +2,49 @@ import React from 'react';
 
 import { FormGroup } from '@patternfly/react-core';
 
-import LabelInput from '@/Components/CreateImageWizard/LabelInput';
-import { useFirewallValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
-import { isServiceValid } from '@/Components/CreateImageWizard/validators';
-import { useAppSelector } from '@/store/hooks';
+import ValidatedListInput from '@/Components/CreateImageWizard/ValidatedListInput';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   addDisabledFirewallService,
   addEnabledFirewallService,
   removeDisabledFirewallService,
   removeEnabledFirewallService,
   selectFirewall,
+  validateFirewallDisabledServices,
+  validateFirewallEnabledServices,
 } from '@/store/slices/wizard';
 
 const Services = () => {
+  const dispatch = useAppDispatch();
   const disabledServices = useAppSelector(selectFirewall).services.disabled;
   const enabledServices = useAppSelector(selectFirewall).services.enabled;
-
-  const stepValidation = useFirewallValidation();
 
   return (
     <>
       <FormGroup label='Enabled services'>
-        <LabelInput
+        <ValidatedListInput
           ariaLabel='Add enabled firewall service'
           placeholder='Enter firewalld service'
-          validator={isServiceValid}
-          list={enabledServices}
-          item='Enabled service'
-          addAction={addEnabledFirewallService}
-          removeAction={removeEnabledFirewallService}
-          stepValidation={stepValidation}
-          fieldName='enabledServices'
+          validator={validateFirewallEnabledServices}
+          items={enabledServices.map((service) => ({
+            value: service,
+            required: false,
+          }))}
+          onAdd={(value) => dispatch(addEnabledFirewallService(value))}
+          onRemove={(value) => dispatch(removeEnabledFirewallService(value))}
         />
       </FormGroup>
       <FormGroup label='Disabled services'>
-        <LabelInput
+        <ValidatedListInput
           ariaLabel='Add disabled firewall service'
           placeholder='Enter firewalld service'
-          validator={isServiceValid}
-          list={disabledServices}
-          item='Disabled service'
-          addAction={addDisabledFirewallService}
-          removeAction={removeDisabledFirewallService}
-          stepValidation={stepValidation}
-          fieldName='disabledServices'
+          validator={validateFirewallDisabledServices}
+          items={disabledServices.map((service) => ({
+            value: service,
+            required: false,
+          }))}
+          onAdd={(value) => dispatch(addDisabledFirewallService(value))}
+          onRemove={(value) => dispatch(removeDisabledFirewallService(value))}
         />
       </FormGroup>
     </>

--- a/src/Components/CreateImageWizard/steps/Firewall/tests/Firewall.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Firewall/tests/Firewall.test.tsx
@@ -102,7 +102,9 @@ describe('Firewall Component', () => {
       await addPort(user, '80:tcp');
       await addPort(user, '80:tcp');
 
-      expect(screen.getByText('Port already exists.')).toBeInTheDocument();
+      expect(
+        screen.getByText('Duplicate firewall ports: 80:tcp'),
+      ).toBeInTheDocument();
     });
   });
 
@@ -135,17 +137,13 @@ describe('Firewall Component', () => {
       await addEnabledService(user, '-------');
 
       expect(
-        screen.getByText(
-          'Expected format: <firewalld-service-name>. Example: ssh.',
-        ),
+        screen.getByText('Service name must start with a letter or digit'),
       ).toBeInTheDocument();
 
       await clearEnabledServiceInput(user);
 
       expect(
-        screen.queryByText(
-          'Expected format: <firewalld-service-name>. Example: ssh.',
-        ),
+        screen.queryByText('Service name must start with a letter or digit'),
       ).not.toBeInTheDocument();
     });
 
@@ -157,7 +155,7 @@ describe('Firewall Component', () => {
       await addEnabledService(user, 'ssh');
 
       expect(
-        screen.getByText('Enabled service already exists.'),
+        screen.getByText('Duplicate enabled firewall services: ssh'),
       ).toBeInTheDocument();
     });
   });
@@ -191,17 +189,13 @@ describe('Firewall Component', () => {
       await addDisabledService(user, '-------');
 
       expect(
-        screen.getByText(
-          'Expected format: <firewalld-service-name>. Example: ssh.',
-        ),
+        screen.getByText('Service name must start with a letter or digit'),
       ).toBeInTheDocument();
 
       await clearDisabledServiceInput(user);
 
       expect(
-        screen.queryByText(
-          'Expected format: <firewalld-service-name>. Example: ssh.',
-        ),
+        screen.queryByText('Service name must start with a letter or digit'),
       ).not.toBeInTheDocument();
     });
 
@@ -213,7 +207,7 @@ describe('Firewall Component', () => {
       await addDisabledService(user, 'telnet');
 
       expect(
-        screen.getByText('Disabled service already exists.'),
+        screen.getByText('Duplicate disabled firewall services: telnet'),
       ).toBeInTheDocument();
     });
   });

--- a/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
+++ b/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
@@ -226,18 +226,22 @@ describe('ImportMode', () => {
 
     // Firewall
     expect(
-      await screen.findByText(/Invalid ports: invalid-port/),
-    ).toBeInTheDocument();
-    expect(
       await screen.findByText(
-        /Invalid disabled services: --invalid-firewall-disabled-service/,
+        'Expected format: <port/port-name>:<protocol>. Example: 8080:tcp, ssh:tcp',
       ),
     ).toBeInTheDocument();
+    // Firewall and systemd inputs share these schema messages while both
+    // customization groups still contain invalid values.
     expect(
-      await screen.findByText(
-        /Invalid enabled services: --invalid-firewall-enabled-service/,
+      await screen.findAllByText(
+        'Service name must start with a letter or digit',
       ),
-    ).toBeInTheDocument();
+    ).toHaveLength(5);
+    expect(
+      await screen.findAllByText(
+        'Service name must not contain consecutive hyphens',
+      ),
+    ).toHaveLength(5);
 
     await clickWithWait(
       user,

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -69,6 +69,7 @@ import {
   selectUserGroups,
   selectUsers,
   UserWithAdditionalInfo,
+  validateFirewall,
   validateHostname,
   validateKernel,
   validateServices,
@@ -95,8 +96,6 @@ import {
   isMountpointMinSizeValid,
   isNtpServerValid,
   isPartitionNameValid,
-  isPortValid,
-  isServiceValid,
   isSnapshotValid,
   isSshKeyValid,
   isUserGroupValid,
@@ -135,7 +134,6 @@ export function useIsBlueprintValid(): boolean {
   const snapshot = useSnapshotValidation();
   const timezone = useTimezoneValidation();
   const locale = useLocaleValidation();
-  const firewall = useFirewallValidation();
   const firstBoot = useFirstBootValidation();
   const details = useDetailsValidation();
   const users = useUsersValidation();
@@ -147,6 +145,7 @@ export function useIsBlueprintValid(): boolean {
   const hostnameErrors = validateHostname(useAppSelector(selectHostname));
   const kernelErrors = validateKernel(useAppSelector(selectKernel));
   const serviceErrors = validateServices(useAppSelector(selectServices));
+  const firewallErrors = validateFirewall(useAppSelector(selectFirewall));
 
   return (
     !aap.disabledNext &&
@@ -157,7 +156,7 @@ export function useIsBlueprintValid(): boolean {
     !locale.disabledNext &&
     hostnameErrors.length === 0 &&
     kernelErrors.length === 0 &&
-    !firewall.disabledNext &&
+    firewallErrors.length === 0 &&
     serviceErrors.length === 0 &&
     !firstBoot.disabledNext &&
     !details.disabledNext &&
@@ -633,89 +632,6 @@ export function useFirstBootValidation(): StepValidation {
       script: valid ? '' : 'Missing shebang at first line, e.g. #!/bin/bash',
     },
     disabledNext: !valid,
-  };
-}
-
-export function useFirewallValidation(): StepValidation {
-  const firewall = useAppSelector(selectFirewall);
-  const invalidPorts = [];
-  const invalidDisabled = [];
-  const invalidEnabled = [];
-
-  if (firewall.ports.length > 0) {
-    for (const port of firewall.ports) {
-      if (!isPortValid(port)) {
-        invalidPorts.push(port);
-      }
-    }
-  }
-
-  if (firewall.services.disabled.length > 0) {
-    for (const s of firewall.services.disabled) {
-      if (!isServiceValid(s)) {
-        invalidDisabled.push(s);
-      }
-    }
-  }
-
-  if (firewall.services.enabled.length > 0) {
-    for (const s of firewall.services.enabled) {
-      if (!isServiceValid(s)) {
-        invalidEnabled.push(s);
-      }
-    }
-  }
-
-  const duplicatePorts = getListOfDuplicates(firewall.ports);
-  const duplicateDisabledServices = getListOfDuplicates(
-    firewall.services.disabled,
-  );
-  const duplicateEnabledServices = getListOfDuplicates(
-    firewall.services.enabled,
-  );
-
-  const portsError =
-    invalidPorts.length > 0 ? `Invalid ports: ${invalidPorts}` : '';
-  const duplicatePortsError =
-    duplicatePorts.length > 0
-      ? `Includes duplicate ports: ${duplicatePorts.join(', ')}`
-      : '';
-  const duplicateDisabledServicesError =
-    duplicateDisabledServices.length > 0
-      ? `Includes duplicate disabled services: ${duplicateDisabledServices.join(
-          ', ',
-        )}`
-      : '';
-  const duplicateEnabledServicesError =
-    duplicateEnabledServices.length > 0
-      ? `Includes duplicate enabled services: ${duplicateEnabledServices.join(
-          ', ',
-        )}`
-      : '';
-  const disabledServicesError =
-    invalidDisabled.length > 0
-      ? `Invalid disabled services: ${invalidDisabled}`
-      : '';
-  const enabledServicesError =
-    invalidEnabled.length > 0
-      ? `Invalid enabled services: ${invalidEnabled}`
-      : '';
-
-  return {
-    errors: {
-      ports: portsError + '|' + duplicatePortsError,
-      disabledServices:
-        disabledServicesError + '|' + duplicateDisabledServicesError,
-      enabledServices:
-        enabledServicesError + '|' + duplicateEnabledServicesError,
-    },
-    disabledNext:
-      invalidPorts.length > 0 ||
-      invalidDisabled.length > 0 ||
-      invalidEnabled.length > 0 ||
-      duplicatePorts.length > 0 ||
-      duplicateDisabledServices.length > 0 ||
-      duplicateEnabledServices.length > 0,
   };
 }
 

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -43,17 +43,14 @@ import {
   selectDiskMinsize,
   selectDiskPartitions,
   selectFilesystemPartitions,
-  selectFirewall,
   selectFirstBootScript,
   selectFscMode,
   selectGcpAccountType,
   selectGcpEmail,
-  selectHostname,
   selectImageSource,
   selectImageTypes,
   selectIsOfficialImage,
   selectIsoPayloadReference,
-  selectKernel,
   selectKeyboard,
   selectLanguages,
   selectNtpServers,
@@ -61,18 +58,15 @@ import {
   selectRegistrationType,
   selectSatelliteCaCertificate,
   selectSatelliteRegistrationCommand,
-  selectServices,
   selectSnapshotDate,
+  selectSystem,
   selectTemplate,
   selectTimezone,
   selectUseLatest,
   selectUserGroups,
   selectUsers,
   UserWithAdditionalInfo,
-  validateFirewall,
-  validateHostname,
-  validateKernel,
-  validateServices,
+  validateSystemSlice,
 } from '@/store/slices/wizard';
 import useDebounce from '@/Utilities/useDebounce';
 
@@ -142,10 +136,8 @@ export function useIsBlueprintValid(): boolean {
   const gcpTarget = useGcpValidation();
   const awsTarget = useAwsValidation();
 
-  const hostnameErrors = validateHostname(useAppSelector(selectHostname));
-  const kernelErrors = validateKernel(useAppSelector(selectKernel));
-  const serviceErrors = validateServices(useAppSelector(selectServices));
-  const firewallErrors = validateFirewall(useAppSelector(selectFirewall));
+  const system = useAppSelector(selectSystem);
+  const systemErrors = validateSystemSlice(system);
 
   return (
     !aap.disabledNext &&
@@ -154,10 +146,7 @@ export function useIsBlueprintValid(): boolean {
     !snapshot.disabledNext &&
     !timezone.disabledNext &&
     !locale.disabledNext &&
-    hostnameErrors.length === 0 &&
-    kernelErrors.length === 0 &&
-    firewallErrors.length === 0 &&
-    serviceErrors.length === 0 &&
+    systemErrors.length === 0 &&
     !firstBoot.disabledNext &&
     !details.disabledNext &&
     !details.isPending &&

--- a/src/Components/CreateImageWizard/validators.ts
+++ b/src/Components/CreateImageWizard/validators.ts
@@ -254,20 +254,6 @@ export const isNtpServerValid = (ntpServer: string) => {
   return /^([a-z0-9-]+)?(([.:/]{1,3}[a-z0-9-]+)){1,}$/.test(ntpServer);
 };
 
-export const isPortValid = (port: string) => {
-  return /^(\d{1,5}|[a-z]{1,6})(-\d{1,5})?[:][a-z]{1,6}$/.test(port);
-};
-
-export const isServiceValid = (service: string) => {
-  // see `man systemd.unit` for the exact specification
-  return (
-    service.length <= 256 &&
-    /^[a-zA-Z0-9]([a-zA-Z0-9.\-_:@]*[a-zA-Z0-9])?$/.test(service) &&
-    !/--/.test(service) && // does not contain more hyphens in a row
-    /[a-zA-Z]+/.test(service) // contains at least one letter
-  );
-};
-
 export const isValidUrl = (url: string): boolean => {
   try {
     const parsedUrl = new URL(url);

--- a/src/store/slices/wizard/system/schemas.ts
+++ b/src/store/slices/wizard/system/schemas.ts
@@ -81,3 +81,11 @@ export const firewallSchema = z.object({
       .superRefine(uniqueArray('disabled firewall services')),
   }),
 });
+
+export const systemSchema = z.object({
+  services: servicesSchema,
+  kernel: kernelSchema,
+  hostname: hostnameSchema,
+  firewall: firewallSchema,
+  // the rest will follow
+});

--- a/src/store/slices/wizard/system/schemas.ts
+++ b/src/store/slices/wizard/system/schemas.ts
@@ -62,3 +62,22 @@ export const servicesSchema = z.object({
     .array(serviceSchema)
     .superRefine(uniqueArray('disabled services')),
 });
+
+export const firewallPortSchema = z
+  .string()
+  .regex(
+    /^(\d{1,5}|[a-z]{1,6})(-\d{1,5})?[:][a-z]{1,6}$/,
+    'Expected format: <port/port-name>:<protocol>. Example: 8080:tcp, ssh:tcp',
+  );
+
+export const firewallSchema = z.object({
+  ports: z.array(firewallPortSchema).superRefine(uniqueArray('firewall ports')),
+  services: z.object({
+    enabled: z
+      .array(serviceSchema)
+      .superRefine(uniqueArray('enabled firewall services')),
+    disabled: z
+      .array(serviceSchema)
+      .superRefine(uniqueArray('disabled firewall services')),
+  }),
+});

--- a/src/store/slices/wizard/system/selectors.ts
+++ b/src/store/slices/wizard/system/selectors.ts
@@ -96,3 +96,7 @@ export const selectFirewallEnabled = createSelector(
     return false;
   },
 );
+
+// export the whole subslice. this is quite useful for validating
+// against a zod schema
+export const selectSystem = (state: RootState) => state.wizard.system;

--- a/src/store/slices/wizard/system/tests/validation/firewall.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/firewall.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isPortValid,
+  isServiceValid,
+} from '@/Components/CreateImageWizard/validators';
+
+describe('firewall validation', () => {
+  describe('ports', () => {
+    describe('valid ports', () => {
+      it('accepts a numeric port with protocol', () => {
+        expect(isPortValid('8080:tcp')).toBe(true);
+      });
+
+      it('accepts a port range with protocol', () => {
+        expect(isPortValid('8080-8090:tcp')).toBe(true);
+      });
+
+      it('accepts a named port with protocol', () => {
+        expect(isPortValid('https:tcp')).toBe(true);
+      });
+
+      it('accepts udp protocol', () => {
+        expect(isPortValid('53:udp')).toBe(true);
+      });
+
+      it('accepts a single digit port', () => {
+        expect(isPortValid('1:tcp')).toBe(true);
+      });
+
+      it('accepts a five digit port', () => {
+        expect(isPortValid('65535:tcp')).toBe(true);
+      });
+    });
+
+    describe('invalid ports', () => {
+      it('rejects a port without protocol', () => {
+        expect(isPortValid('8080')).toBe(false);
+      });
+
+      it('rejects a port with invalid protocol', () => {
+        expect(isPortValid('8080:TCP')).toBe(false);
+      });
+
+      it('rejects an empty string', () => {
+        expect(isPortValid('')).toBe(false);
+      });
+
+      it('rejects just a protocol', () => {
+        expect(isPortValid(':tcp')).toBe(false);
+      });
+
+      it('rejects a port with spaces', () => {
+        expect(isPortValid('80 :tcp')).toBe(false);
+      });
+
+      it('rejects a port exceeding five digits', () => {
+        expect(isPortValid('123456:tcp')).toBe(false);
+      });
+    });
+  });
+
+  describe('firewall services', () => {
+    describe('valid services', () => {
+      it('accepts a simple service name', () => {
+        expect(isServiceValid('ssh')).toBe(true);
+      });
+
+      it('accepts a service with hyphens', () => {
+        expect(isServiceValid('cockpit-ws')).toBe(true);
+      });
+
+      it('accepts a service with dots', () => {
+        expect(isServiceValid('sshd.service')).toBe(true);
+      });
+
+      it('accepts a service with underscores', () => {
+        expect(isServiceValid('my_service')).toBe(true);
+      });
+
+      it('accepts a service with at sign', () => {
+        expect(isServiceValid('getty@tty1')).toBe(true);
+      });
+
+      it('accepts a service with colons', () => {
+        expect(isServiceValid('dbus:org.freedesktop')).toBe(true);
+      });
+
+      it('accepts a single character service', () => {
+        expect(isServiceValid('a')).toBe(true);
+      });
+
+      it('accepts a service at max length (256 characters)', () => {
+        const service = 'a'.repeat(256);
+        expect(isServiceValid(service)).toBe(true);
+      });
+    });
+
+    describe('invalid services', () => {
+      it('rejects an empty string', () => {
+        expect(isServiceValid('')).toBe(false);
+      });
+
+      it('rejects a service exceeding 256 characters', () => {
+        const service = 'a'.repeat(257);
+        expect(isServiceValid(service)).toBe(false);
+      });
+
+      it('rejects a service starting with a hyphen', () => {
+        expect(isServiceValid('-service')).toBe(false);
+      });
+
+      it('rejects a service ending with a hyphen', () => {
+        expect(isServiceValid('service-')).toBe(false);
+      });
+
+      it('rejects a service with consecutive hyphens', () => {
+        expect(isServiceValid('my--service')).toBe(false);
+      });
+
+      it('rejects a service with spaces', () => {
+        expect(isServiceValid('my service')).toBe(false);
+      });
+
+      it('rejects a purely numeric service', () => {
+        expect(isServiceValid('12345')).toBe(false);
+      });
+
+      it('rejects a service with special characters', () => {
+        expect(isServiceValid('service!')).toBe(false);
+      });
+    });
+  });
+});

--- a/src/store/slices/wizard/system/tests/validation/firewall.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/firewall.test.ts
@@ -1,9 +1,20 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  isPortValid,
-  isServiceValid,
-} from '@/Components/CreateImageWizard/validators';
+  validateFirewall,
+  validateFirewallDisabledServices,
+  validateFirewallEnabledServices,
+  validateFirewallPorts,
+} from '../../validators';
+
+const isPortValid = (port: string) =>
+  validateFirewallPorts([port]).length === 0;
+
+// Firewall services share the same service schema as systemd services. The
+// format rules are exercised once through enabled services; per-category
+// behaviour, including duplicate labels, is covered separately.
+const isServiceValid = (service: string) =>
+  validateFirewallEnabledServices([service]).length === 0;
 
 describe('firewall validation', () => {
   describe('ports', () => {
@@ -31,6 +42,10 @@ describe('firewall validation', () => {
       it('accepts a five digit port', () => {
         expect(isPortValid('65535:tcp')).toBe(true);
       });
+
+      it('returns no issues for an empty list', () => {
+        expect(validateFirewallPorts([])).toEqual([]);
+      });
     });
 
     describe('invalid ports', () => {
@@ -56,6 +71,16 @@ describe('firewall validation', () => {
 
       it('rejects a port exceeding five digits', () => {
         expect(isPortValid('123456:tcp')).toBe(false);
+      });
+
+      it('flags a duplicate port', () => {
+        const result = validateFirewallPorts(['8080:tcp', '8080:tcp']);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          kind: 'duplicate',
+          value: '8080:tcp',
+        });
+        expect(result[0].message).toContain('firewall ports');
       });
     });
   });
@@ -91,8 +116,11 @@ describe('firewall validation', () => {
       });
 
       it('accepts a service at max length (256 characters)', () => {
-        const service = 'a'.repeat(256);
-        expect(isServiceValid(service)).toBe(true);
+        expect(isServiceValid('a'.repeat(256))).toBe(true);
+      });
+
+      it('returns no issues for an empty list', () => {
+        expect(validateFirewallEnabledServices([])).toEqual([]);
       });
     });
 
@@ -102,8 +130,7 @@ describe('firewall validation', () => {
       });
 
       it('rejects a service exceeding 256 characters', () => {
-        const service = 'a'.repeat(257);
-        expect(isServiceValid(service)).toBe(false);
+        expect(isServiceValid('a'.repeat(257))).toBe(false);
       });
 
       it('rejects a service starting with a hyphen', () => {
@@ -129,6 +156,47 @@ describe('firewall validation', () => {
       it('rejects a service with special characters', () => {
         expect(isServiceValid('service!')).toBe(false);
       });
+    });
+
+    describe.each([
+      ['enabled', validateFirewallEnabledServices, 'enabled firewall services'],
+      [
+        'disabled',
+        validateFirewallDisabledServices,
+        'disabled firewall services',
+      ],
+    ])('%s firewall services validator', (_category, validate, label) => {
+      it('accepts a valid service', () => {
+        expect(validate(['ssh'])).toEqual([]);
+      });
+
+      it('rejects an invalid service', () => {
+        expect(validate(['my--service']).length).toBeGreaterThan(0);
+      });
+
+      it('flags a duplicate service', () => {
+        const result = validate(['ssh', 'ssh']);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toMatchObject({
+          kind: 'duplicate',
+          value: 'ssh',
+        });
+        expect(result[0].message).toContain(label);
+      });
+    });
+  });
+
+  describe('firewall customization validator', () => {
+    it('accepts a valid firewall customization', () => {
+      expect(
+        validateFirewall({
+          ports: ['8080:tcp'],
+          services: {
+            enabled: ['ssh'],
+            disabled: ['cockpit'],
+          },
+        }),
+      ).toEqual([]);
     });
   });
 });

--- a/src/store/slices/wizard/system/types.ts
+++ b/src/store/slices/wizard/system/types.ts
@@ -2,11 +2,11 @@ import z from 'zod';
 
 import { Locale, Timezone, User } from '@/store/api/backend';
 
-import { kernelSchema, servicesSchema } from './schemas';
+import { firewallSchema, kernelSchema, servicesSchema } from './schemas';
 
 export type Kernel = z.infer<typeof kernelSchema>;
-
 export type Services = z.infer<typeof servicesSchema>;
+export type Firewall = z.infer<typeof firewallSchema>;
 
 export type UserWithAdditionalInfo = {
   [K in keyof User]-?: NonNullable<User[K]>;

--- a/src/store/slices/wizard/system/types.ts
+++ b/src/store/slices/wizard/system/types.ts
@@ -2,7 +2,12 @@ import z from 'zod';
 
 import { Locale, Timezone, User } from '@/store/api/backend';
 
-import { firewallSchema, kernelSchema, servicesSchema } from './schemas';
+import {
+  firewallSchema,
+  kernelSchema,
+  servicesSchema,
+  systemSchema,
+} from './schemas';
 
 export type Kernel = z.infer<typeof kernelSchema>;
 export type Services = z.infer<typeof servicesSchema>;
@@ -55,26 +60,9 @@ export type UserGroup = {
   gid?: number;
 };
 
-export type SystemSlice = {
-  services: {
-    enabled: string[];
-    masked: string[];
-    disabled: string[];
-  };
-  kernel: {
-    name: string;
-    append: string[];
-  };
+export type SystemSlice = z.infer<typeof systemSchema> & {
   locale: Locale;
   timezone: Timezone;
-  hostname: string;
-  firewall: {
-    ports: string[];
-    services: {
-      enabled: string[];
-      disabled: string[];
-    };
-  };
   firstBoot: {
     script: string;
   };

--- a/src/store/slices/wizard/system/validators.ts
+++ b/src/store/slices/wizard/system/validators.ts
@@ -1,8 +1,11 @@
+import z from 'zod';
+
 import {
   firewallSchema,
   hostnameSchema,
   kernelSchema,
   servicesSchema,
+  systemSchema,
 } from './schemas';
 import { Firewall, Kernel, Services } from './types';
 
@@ -50,4 +53,10 @@ export const validateFirewallDisabledServices = (items: string[]) => {
 
 export const validateFirewall = (firewall: Firewall) => {
   return validateSchema(firewallSchema, firewall);
+};
+
+// TODO: change this to the proper type once all the subslice elements
+// have been migrated to zod schemas
+export const validateSystemSlice = (system: z.infer<typeof systemSchema>) => {
+  return validateSchema(systemSchema, system);
 };

--- a/src/store/slices/wizard/system/validators.ts
+++ b/src/store/slices/wizard/system/validators.ts
@@ -1,5 +1,10 @@
-import { hostnameSchema, kernelSchema, servicesSchema } from './schemas';
-import { Kernel, Services } from './types';
+import {
+  firewallSchema,
+  hostnameSchema,
+  kernelSchema,
+  servicesSchema,
+} from './schemas';
+import { Firewall, Kernel, Services } from './types';
 
 import { validateList, validateSchema } from '../validators';
 
@@ -29,4 +34,20 @@ export const validateMaskedServices = (items: string[]) => {
 
 export const validateServices = (services: Services) => {
   return validateSchema(servicesSchema, services);
+};
+
+export const validateFirewallPorts = (items: string[]) => {
+  return validateList(firewallSchema.shape.ports, items);
+};
+
+export const validateFirewallEnabledServices = (items: string[]) => {
+  return validateList(firewallSchema.shape.services.shape.enabled, items);
+};
+
+export const validateFirewallDisabledServices = (items: string[]) => {
+  return validateList(firewallSchema.shape.services.shape.disabled, items);
+};
+
+export const validateFirewall = (firewall: Firewall) => {
+  return validateSchema(firewallSchema, firewall);
 };


### PR DESCRIPTION
## Summary

Move firewall customization validation onto shared Zod schemas and the common validated list input flow. This keeps inline feedback and wizard-level blocking consistent for firewall ports and services.

## Changes

- Add Zod schemas and validator wrappers for firewall ports and firewall services.
- Replace legacy firewall label inputs with `ValidatedListInput` for ports, enabled services, and disabled services.
- Wire overall wizard validity to the shared firewall validator.
- Add tests covering firewall port, service, duplicate, and wizard validation behavior.
