### PR TITLE
Wizard/Locale: migrate validation to schema validators (HMS-11317)

### DIFF
--- a/playwright/Import/Import.spec.ts
+++ b/playwright/Import/Import.spec.ts
@@ -74,8 +74,10 @@ test('Import a blueprint with invalid customization', async ({
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Remove ntp/' }).first().click();
 
-    await expect(frame.getByText('Unknown languages: random:')).toBeVisible();
-    await expect(frame.getByText('Duplicated languages: af_ZA.')).toBeVisible();
+    await expect(frame.getByText('Unknown language')).toBeVisible();
+    await expect(
+      frame.getByText('Duplicate languages: af_ZA.UTF-8'),
+    ).toBeVisible();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();
     await frame.getByRole('button', { name: 'Remove language' }).last().click();
     await expect(frame.getByRole('button', { name: 'Next' })).toBeEnabled();

--- a/src/Components/CreateImageWizard/CreateImageWizard.tsx
+++ b/src/Components/CreateImageWizard/CreateImageWizard.tsx
@@ -103,7 +103,6 @@ import {
   useFirstBootValidation,
   useGcpValidation,
   useImagePullValidation,
-  useLocaleValidation,
   useRegistrationValidation,
   useSnapshotValidation,
   useUserGroupsValidation,
@@ -153,7 +152,6 @@ const CreateImageWizard = () => {
   const registrationValidation = useRegistrationValidation();
   const snapshotValidation = useSnapshotValidation();
   const filesystemValidation = useFilesystemValidation();
-  const localeValidation = useLocaleValidation();
   const firstBootValidation = useFirstBootValidation();
   const usersValidation = useUsersValidation();
   const userGroupsValidation = useUserGroupsValidation();
@@ -190,7 +188,6 @@ const CreateImageWizard = () => {
 
   const advancedSettingsHasErrors =
     filesystemValidation.disabledNext ||
-    localeValidation.disabledNext ||
     systemErrors.length > 0 ||
     firstBootValidation.disabledNext ||
     (!restrictions.users.shouldHide && usersHaveErrors);

--- a/src/Components/CreateImageWizard/ValidatedInputHelperText.tsx
+++ b/src/Components/CreateImageWizard/ValidatedInputHelperText.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { HelperText, HelperTextItem } from '@patternfly/react-core';
+
+import type { ValidationResult } from '@/store/slices/wizard/types';
+
+type ValidatedInputHelperTextProps = {
+  errors: ValidationResult;
+  id?: string;
+  helperText?: React.ReactNode;
+};
+
+const ValidatedInputHelperText = ({
+  errors,
+  id,
+  helperText,
+}: ValidatedInputHelperTextProps) => {
+  if (errors.length === 0 && !helperText) {
+    return null;
+  }
+
+  return (
+    <HelperText {...(id !== undefined ? { id } : {})}>
+      {errors.length > 0 ? (
+        errors.map((issue, index) => (
+          <HelperTextItem
+            key={`${issue.value ?? ''}-${issue.message}-${index}`}
+            variant='error'
+          >
+            {issue.message}
+          </HelperTextItem>
+        ))
+      ) : (
+        <HelperTextItem>{helperText}</HelperTextItem>
+      )}
+    </HelperText>
+  );
+};
+
+export default ValidatedInputHelperText;

--- a/src/Components/CreateImageWizard/ValidatedListInput.tsx
+++ b/src/Components/CreateImageWizard/ValidatedListInput.tsx
@@ -4,8 +4,6 @@ import {
   Button,
   Flex,
   FlexItem,
-  HelperText,
-  HelperTextItem,
   Label,
   LabelGroup,
   TextInputGroup,
@@ -16,6 +14,8 @@ import { PlusCircleIcon } from '@patternfly/react-icons';
 
 import type { ValidationResult } from '@/store/slices/wizard/types';
 import type { MergedListItem } from '@/Utilities/mergeListItems';
+
+import ValidatedInputHelperText from './ValidatedInputHelperText';
 
 const DEFAULT_TRUNCATE_LENGTH = 20;
 const DEFAULT_MAX_VISIBLE_ITEMS = 4;
@@ -162,23 +162,16 @@ const ValidatedListInput = ({
             )}
           </TextInputGroupMain>
         </TextInputGroup>
-        <HelperText id={helperTextId}>
-          {allErrors.length > 0 ? (
-            allErrors.map((issue, index) => (
-              <HelperTextItem
-                key={`${issue.value ?? ''}-${issue.message}-${index}`}
-                variant='error'
-              >
-                {issue.message}
-              </HelperTextItem>
-            ))
-          ) : (
-            <HelperTextItem>
+        <ValidatedInputHelperText
+          errors={allErrors}
+          id={helperTextId}
+          helperText={
+            <>
               {helperText && `${helperText} `}
               Press Enter or click {hideAddLabel ? 'the add icon' : 'Add'}.
-            </HelperTextItem>
-          )}
-        </HelperText>
+            </>
+          }
+        />
       </FlexItem>
       <FlexItem alignSelf={{ default: 'alignSelfFlexStart' }}>
         <Button

--- a/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
@@ -5,9 +5,11 @@ import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
 import { useLocaleValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
 import SearchableSelect from '@/Components/sharedComponents/SearchableSelect';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
-import { changeKeyboard, selectKeyboard } from '@/store/slices/wizard';
-
-import { keyboardsList } from '../data/keyboardsList';
+import {
+  changeKeyboard,
+  keyboards,
+  selectKeyboard,
+} from '@/store/slices/wizard';
 
 const KeyboardDropDown = () => {
   const keyboard = useAppSelector(selectKeyboard);
@@ -18,7 +20,7 @@ const KeyboardDropDown = () => {
   const [errorText, setErrorText] = useState(stepValidation.errors['keyboard']);
 
   const options = useMemo(
-    () => keyboardsList.map((kb) => ({ value: kb, label: kb })),
+    () => keyboards.map((kb) => ({ value: kb, label: kb })),
     [],
   );
 

--- a/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/KeyboardDropDown.tsx
@@ -1,23 +1,21 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo } from 'react';
 
-import { FormGroup, HelperText, HelperTextItem } from '@patternfly/react-core';
+import { FormGroup } from '@patternfly/react-core';
 
-import { useLocaleValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
+import ValidatedInputHelperText from '@/Components/CreateImageWizard/ValidatedInputHelperText';
 import SearchableSelect from '@/Components/sharedComponents/SearchableSelect';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
   changeKeyboard,
   keyboards,
   selectKeyboard,
+  validateKeyboard,
 } from '@/store/slices/wizard';
 
 const KeyboardDropDown = () => {
-  const keyboard = useAppSelector(selectKeyboard);
   const dispatch = useAppDispatch();
-
-  const stepValidation = useLocaleValidation();
-
-  const [errorText, setErrorText] = useState(stepValidation.errors['keyboard']);
+  const keyboard = useAppSelector(selectKeyboard);
+  const errors = validateKeyboard(keyboard);
 
   const options = useMemo(
     () => keyboards.map((kb) => ({ value: kb, label: kb })),
@@ -26,7 +24,6 @@ const KeyboardDropDown = () => {
 
   const handleSelect = (value: string | undefined) => {
     dispatch(changeKeyboard(value ?? ''));
-    setErrorText('');
   };
 
   return (
@@ -37,11 +34,7 @@ const KeyboardDropDown = () => {
         placeholder='Select a keyboard'
         onSelect={handleSelect}
       />
-      {errorText && (
-        <HelperText>
-          <HelperTextItem variant={'error'}>{errorText}</HelperTextItem>
-        </HelperText>
-      )}
+      <ValidatedInputHelperText errors={errors} />
     </FormGroup>
   );
 };

--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -16,9 +16,8 @@ import {
   removeLanguage,
   replaceLanguage,
   selectLanguages,
+  languages as supportedLanguages,
 } from '@/store/slices/wizard';
-
-import { languagesList } from '../data/languagesList';
 
 const parseLanguageOption = (language: string) => {
   try {
@@ -39,7 +38,7 @@ const parseLanguageOption = (language: string) => {
 };
 
 const parsedLanguages: Record<string, string> = Object.fromEntries(
-  languagesList.map((lang) => [lang, parseLanguageOption(lang)]),
+  supportedLanguages.map((lang) => [lang, parseLanguageOption(lang)]),
 );
 
 type LanguageRowProps = {

--- a/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/components/LanguagesDropDown.tsx
@@ -8,7 +8,7 @@ import {
 } from '@patternfly/react-core';
 import { MinusCircleIcon, PlusCircleIcon } from '@patternfly/react-icons';
 
-import { useLocaleValidation } from '@/Components/CreateImageWizard/utilities/useValidation';
+import ValidatedInputHelperText from '@/Components/CreateImageWizard/ValidatedInputHelperText';
 import SearchableSelect from '@/Components/sharedComponents/SearchableSelect';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
@@ -17,6 +17,7 @@ import {
   replaceLanguage,
   selectLanguages,
   languages as supportedLanguages,
+  validateLanguages,
 } from '@/store/slices/wizard';
 
 const parseLanguageOption = (language: string) => {
@@ -91,17 +92,10 @@ const LanguageRow = ({
 };
 
 const LanguagesDropDown = () => {
-  const languages = useAppSelector(selectLanguages) ?? [];
   const dispatch = useAppDispatch();
   const [showNewRow, setShowNewRow] = useState(false);
-
-  const stepValidation = useLocaleValidation();
-  const unknownLanguages = stepValidation.errors['unknownLanguages']
-    ? stepValidation.errors['unknownLanguages'].split(' ')
-    : [];
-  const duplicateLanguages = stepValidation.errors['duplicateLanguages']
-    ? stepValidation.errors['duplicateLanguages'].split(' ')
-    : [];
+  const languages = useAppSelector(selectLanguages) ?? [];
+  const errors = validateLanguages(languages);
 
   const handleSelectNewLanguage = (language: string | undefined) => {
     if (language) {
@@ -152,20 +146,7 @@ const LanguagesDropDown = () => {
       <HelperText>
         <HelperTextItem>Search by country, language or UTF code</HelperTextItem>
       </HelperText>
-      {unknownLanguages.length > 0 && (
-        <HelperText>
-          <HelperTextItem variant='error'>{`Unknown languages: ${unknownLanguages.join(
-            ', ',
-          )}`}</HelperTextItem>
-        </HelperText>
-      )}
-      {duplicateLanguages.length > 0 && (
-        <HelperText>
-          <HelperTextItem variant='error'>{`Duplicated languages: ${duplicateLanguages.join(
-            ', ',
-          )}`}</HelperTextItem>
-        </HelperText>
-      )}
+      <ValidatedInputHelperText errors={errors} />
       <Button
         className='pf-v6-u-text-align-left pf-v6-u-mt-sm'
         variant='link'

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -16,8 +16,8 @@ import {
 } from './helpers';
 
 // Mock the large lists with smaller test data for faster tests
-vi.mock('../data/languagesList', () => ({
-  languagesList: [
+vi.mock('@/store/slices/wizard/system/constants', () => ({
+  languages: [
     'nl_AW.UTF-8',
     'nl_BE.UTF-8',
     'nl_NL.UTF-8',
@@ -28,18 +28,7 @@ vi.mock('../data/languagesList', () => ({
     'kw_GB.UTF-8',
     'C.UTF-8',
   ],
-}));
-
-vi.mock('../data/keyboardsList', () => ({
-  keyboardsList: [
-    'us',
-    'us-acentos',
-    'us-alt-intl',
-    'us-dvorak',
-    'de',
-    'gb',
-    'fr',
-  ],
+  keyboards: ['us', 'us-acentos', 'us-alt-intl', 'us-dvorak', 'de', 'gb', 'fr'],
 }));
 
 describe('Locale Component', () => {

--- a/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
+++ b/src/Components/CreateImageWizard/steps/Locale/tests/Locale.test.tsx
@@ -386,7 +386,7 @@ describe('Locale Component', () => {
       });
 
       expect(
-        await screen.findByText(/duplicated languages/i),
+        await screen.findByText(/duplicate languages: en_US\.UTF-8/i),
       ).toBeInTheDocument();
     });
 

--- a/src/Components/CreateImageWizard/steps/Timezone/components/TimezoneDropDown.tsx
+++ b/src/Components/CreateImageWizard/steps/Timezone/components/TimezoneDropDown.tsx
@@ -17,6 +17,7 @@ import {
   SearchInput,
 } from '@patternfly/react-core';
 
+import ValidatedInputHelperText from '@/Components/CreateImageWizard/ValidatedInputHelperText';
 import { DEFAULT_TIMEZONE } from '@/constants';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import {
@@ -148,17 +149,7 @@ const TimezoneDropDown = () => {
       <HelperText className='pf-v6-u-pt-sm'>
         <HelperTextItem>Search by city and continent.</HelperTextItem>
       </HelperText>
-      <HelperText>
-        {timezoneErrors.length > 0 &&
-          timezoneErrors.map((issue, index) => (
-            <HelperTextItem
-              variant={'error'}
-              key={`${issue.value ?? ''}-${issue.message}-${index}`}
-            >
-              {issue.message}
-            </HelperTextItem>
-          ))}
-      </HelperText>
+      <ValidatedInputHelperText errors={timezoneErrors} />
     </FormGroup>
   );
 };

--- a/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
+++ b/src/Components/CreateImageWizard/tests/ImportMode.test.tsx
@@ -181,9 +181,7 @@ describe('ImportMode', () => {
     );
 
     // Locale
-    expect(
-      await screen.findByText('Unknown languages: invalid-language'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText('Unknown language')).toBeInTheDocument();
     expect(await screen.findByText('Unknown keyboard')).toBeInTheDocument();
 
     await clickWithWait(

--- a/src/Components/CreateImageWizard/tests/ValidatedInputHelperText.test.tsx
+++ b/src/Components/CreateImageWizard/tests/ValidatedInputHelperText.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+
+import type { ValidationResult } from '@/store/slices/wizard/types';
+
+import ValidatedInputHelperText from '../ValidatedInputHelperText';
+
+describe('ValidatedInputHelperText', () => {
+  it('renders each validation error', () => {
+    const errors: ValidationResult = [
+      { kind: 'format', message: 'Invalid value', value: 'bad' },
+      { kind: 'duplicate', message: 'Duplicate value', value: 'bad' },
+    ];
+
+    render(<ValidatedInputHelperText errors={errors} />);
+
+    expect(screen.getByText('Invalid value')).toBeInTheDocument();
+    expect(screen.getByText('Duplicate value')).toBeInTheDocument();
+  });
+
+  it('renders the helper text when there are no errors', () => {
+    render(
+      <ValidatedInputHelperText
+        errors={[]}
+        helperText='Press Enter to add an item'
+      />,
+    );
+
+    expect(screen.getByText('Press Enter to add an item')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no errors or helper text', () => {
+    const { container } = render(<ValidatedInputHelperText errors={[]} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -24,6 +24,7 @@ import {
   convertToBytes,
   DiskPartition,
   FilesystemPartition,
+  keyboards,
   MAX_REGULAR_GID,
   MIN_REGULAR_GID,
   parseSizeUnit,
@@ -63,6 +64,7 @@ import {
   selectUseLatest,
   selectUserGroups,
   selectUsers,
+  languages as supportedLanguages,
   UserWithAdditionalInfo,
   validateSystemSlice,
 } from '@/store/slices/wizard';
@@ -70,8 +72,6 @@ import useDebounce from '@/Utilities/useDebounce';
 
 import { getListOfDuplicates } from './getListOfDuplicates';
 
-import { keyboardsList } from '../steps/Locale/data/keyboardsList';
-import { languagesList } from '../steps/Locale/data/languagesList';
 import {
   getDuplicateMountPoints,
   getDuplicateNames,
@@ -537,7 +537,7 @@ export function useLocaleValidation(): StepValidation {
 
   if (languages && languages.length > 0) {
     for (const lang of languages) {
-      if (!languagesList.includes(lang)) {
+      if (!supportedLanguages.includes(lang)) {
         unknownLanguages.push(lang);
       }
       if (languagesSet.has(lang)) {
@@ -552,7 +552,7 @@ export function useLocaleValidation(): StepValidation {
     unknownLanguages.length > 0 ? unknownLanguages.join(' ') : '';
   const duplicateLanguages = duplicates.length > 0 ? duplicates.join(' ') : '';
   const keyboardError =
-    keyboard && !keyboardsList.includes(keyboard) ? 'Unknown keyboard' : '';
+    keyboard && !keyboards.includes(keyboard) ? 'Unknown keyboard' : '';
 
   return {
     errors: {

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -122,7 +122,6 @@ export function useIsBlueprintValid(): boolean {
   const registration = useRegistrationValidation();
   const filesystem = useFilesystemValidation();
   const snapshot = useSnapshotValidation();
-  const locale = useLocaleValidation();
   const firstBoot = useFirstBootValidation();
   const details = useDetailsValidation();
   const users = useUsersValidation();
@@ -139,7 +138,6 @@ export function useIsBlueprintValid(): boolean {
     !registration.disabledNext &&
     !filesystem.disabledNext &&
     !snapshot.disabledNext &&
-    !locale.disabledNext &&
     systemErrors.length === 0 &&
     !firstBoot.disabledNext &&
     !details.disabledNext &&

--- a/src/Components/CreateImageWizard/utilities/useValidation.tsx
+++ b/src/Components/CreateImageWizard/utilities/useValidation.tsx
@@ -24,7 +24,6 @@ import {
   convertToBytes,
   DiskPartition,
   FilesystemPartition,
-  keyboards,
   MAX_REGULAR_GID,
   MIN_REGULAR_GID,
   parseSizeUnit,
@@ -52,8 +51,6 @@ import {
   selectImageTypes,
   selectIsOfficialImage,
   selectIsoPayloadReference,
-  selectKeyboard,
-  selectLanguages,
   selectOrgId,
   selectRegistrationType,
   selectSatelliteCaCertificate,
@@ -64,7 +61,6 @@ import {
   selectUseLatest,
   selectUserGroups,
   selectUsers,
-  languages as supportedLanguages,
   UserWithAdditionalInfo,
   validateSystemSlice,
 } from '@/store/slices/wizard';
@@ -522,47 +518,6 @@ export function useSnapshotValidation(): StepValidation {
     };
   }
   return { errors: {}, disabledNext: false };
-}
-
-export function useLocaleValidation(): StepValidation {
-  const languagesSet: Set<string> = new Set();
-  const duplicates: string[] = [];
-  const languages = useAppSelector(selectLanguages);
-  const keyboard = useAppSelector(selectKeyboard);
-
-  const errors = {};
-  const unknownLanguages = [];
-
-  if (languages && languages.length > 0) {
-    for (const lang of languages) {
-      if (!supportedLanguages.includes(lang)) {
-        unknownLanguages.push(lang);
-      }
-      if (languagesSet.has(lang)) {
-        duplicates.push(lang);
-      } else {
-        languagesSet.add(lang);
-      }
-    }
-  }
-
-  const languagesError =
-    unknownLanguages.length > 0 ? unknownLanguages.join(' ') : '';
-  const duplicateLanguages = duplicates.length > 0 ? duplicates.join(' ') : '';
-  const keyboardError =
-    keyboard && !keyboards.includes(keyboard) ? 'Unknown keyboard' : '';
-
-  return {
-    errors: {
-      unknownLanguages: languagesError,
-      duplicateLanguages: duplicateLanguages,
-      keyboard: keyboardError,
-    },
-    disabledNext:
-      unknownLanguages.length > 0 ||
-      duplicateLanguages.length > 0 ||
-      'keyboard' in errors,
-  };
 }
 
 export function useFirstBootValidation(): StepValidation {

--- a/src/store/slices/wizard/system/constants/index.ts
+++ b/src/store/slices/wizard/system/constants/index.ts
@@ -1,0 +1,6 @@
+// GID range for regular groups per LOGIN.DEFS(5) defaults
+export const MIN_REGULAR_GID = 1000;
+export const MAX_REGULAR_GID = 60000;
+export { keyboards } from './keyboards';
+export { languages } from './languages';
+export { timezones } from './timezones';

--- a/src/store/slices/wizard/system/constants/keyboards.ts
+++ b/src/store/slices/wizard/system/constants/keyboards.ts
@@ -1,4 +1,4 @@
-export const keyboardsList = [
+export const keyboards = [
   '3l',
   'adnw',
   'al',

--- a/src/store/slices/wizard/system/constants/languages.ts
+++ b/src/store/slices/wizard/system/constants/languages.ts
@@ -1,4 +1,4 @@
-export const languagesList = [
+export const languages = [
   'aa_DJ.UTF-8',
   'aa_ER.UTF-8',
   'aa_ET.UTF-8',

--- a/src/store/slices/wizard/system/constants/timezones.ts
+++ b/src/store/slices/wizard/system/constants/timezones.ts
@@ -1,6 +1,3 @@
-// GID range for regular groups per LOGIN.DEFS(5) defaults
-export const MIN_REGULAR_GID = 1000;
-export const MAX_REGULAR_GID = 60000;
 export const timezones = [
   'Africa/Abidjan',
   'Africa/Algiers',

--- a/src/store/slices/wizard/system/schemas.ts
+++ b/src/store/slices/wizard/system/schemas.ts
@@ -1,6 +1,6 @@
 import z from 'zod';
 
-import { timezones } from './constants';
+import { keyboards, languages, timezones } from './constants';
 
 import { uniqueArray } from '../utilities';
 
@@ -108,11 +108,33 @@ export const timezoneSchema = z.object({
   ntpservers: ntpServersSchema.optional(),
 });
 
+export const languageSchema = z
+  .string()
+  .refine((lg) => languages.includes(lg), {
+    error: 'Unknown language',
+  });
+
+export const languageListSchema = z
+  .array(languageSchema)
+  .superRefine(uniqueArray('languages'));
+
+export const keyboardSchema = z
+  .string()
+  .refine((kb) => !kb || keyboards.includes(kb), {
+    error: 'Unknown keyboard',
+  });
+
+export const localeSchema = z.object({
+  languages: languageListSchema.optional(),
+  keyboard: keyboardSchema.optional(),
+});
+
 export const systemSchema = z.object({
   services: servicesSchema,
   kernel: kernelSchema,
   hostname: hostnameSchema,
   firewall: firewallSchema,
   timezone: timezoneSchema,
+  locale: localeSchema,
   // the rest will follow
 });

--- a/src/store/slices/wizard/system/tests/validation/locale.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/locale.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { keyboardsList } from '@/Components/CreateImageWizard/steps/Locale/data/keyboardsList';
+import { languagesList } from '@/Components/CreateImageWizard/steps/Locale/data/languagesList';
+
+const isLanguageValid = (language: string) => languagesList.includes(language);
+const isKeyboardValid = (keyboard: string) =>
+  keyboard === '' || keyboardsList.includes(keyboard);
+
+const getDuplicateLanguages = (languages: string[]) => [
+  ...new Set(
+    languages.filter(
+      (language, index) => languages.indexOf(language) !== index,
+    ),
+  ),
+];
+
+describe('locale validation', () => {
+  describe('languages', () => {
+    it('accepts a supported language', () => {
+      expect(isLanguageValid('en_US.UTF-8')).toBe(true);
+    });
+
+    it('accepts the default C locale', () => {
+      expect(isLanguageValid('C.UTF-8')).toBe(true);
+    });
+
+    it('accepts multiple supported languages', () => {
+      expect(
+        ['en_US.UTF-8', 'de_DE.UTF-8', 'nl_NL.UTF-8'].every(isLanguageValid),
+      ).toBe(true);
+    });
+
+    it('rejects an unknown language', () => {
+      expect(isLanguageValid('xx_XX.UTF-8')).toBe(false);
+    });
+
+    it('allows an empty language list', () => {
+      expect([].every(isLanguageValid)).toBe(true);
+    });
+  });
+
+  describe('duplicate languages', () => {
+    it('returns no duplicates for unique languages', () => {
+      expect(getDuplicateLanguages(['en_US.UTF-8', 'de_DE.UTF-8'])).toEqual([]);
+    });
+
+    it('identifies a duplicate language', () => {
+      expect(getDuplicateLanguages(['en_US.UTF-8', 'en_US.UTF-8'])).toEqual([
+        'en_US.UTF-8',
+      ]);
+    });
+
+    it('reports each duplicate only once', () => {
+      expect(
+        getDuplicateLanguages(['en_US.UTF-8', 'en_US.UTF-8', 'en_US.UTF-8']),
+      ).toEqual(['en_US.UTF-8']);
+    });
+  });
+
+  describe('keyboards', () => {
+    it('accepts a supported keyboard', () => {
+      expect(isKeyboardValid('us')).toBe(true);
+    });
+
+    it('accepts a keyboard with a variant', () => {
+      expect(isKeyboardValid('us-dvorak')).toBe(true);
+    });
+
+    it('rejects an unknown keyboard', () => {
+      expect(isKeyboardValid('unknown-keyboard')).toBe(false);
+    });
+
+    it('allows an empty keyboard', () => {
+      expect(isKeyboardValid('')).toBe(true);
+    });
+  });
+});

--- a/src/store/slices/wizard/system/tests/validation/locale.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/locale.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
 
-import { keyboardsList } from '@/Components/CreateImageWizard/steps/Locale/data/keyboardsList';
-import { languagesList } from '@/Components/CreateImageWizard/steps/Locale/data/languagesList';
+import {
+  keyboards,
+  languages as supportedLanguages,
+} from '@/store/slices/wizard';
 
-const isLanguageValid = (language: string) => languagesList.includes(language);
+const isLanguageValid = (language: string) =>
+  supportedLanguages.includes(language);
 const isKeyboardValid = (keyboard: string) =>
-  keyboard === '' || keyboardsList.includes(keyboard);
+  keyboard === '' || keyboards.includes(keyboard);
 
 const getDuplicateLanguages = (languages: string[]) => [
   ...new Set(

--- a/src/store/slices/wizard/system/tests/validation/locale.test.ts
+++ b/src/store/slices/wizard/system/tests/validation/locale.test.ts
@@ -1,81 +1,103 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  keyboards,
-  languages as supportedLanguages,
+  validateKeyboard,
+  validateLanguages,
+  validateLocale,
 } from '@/store/slices/wizard';
-
-const isLanguageValid = (language: string) =>
-  supportedLanguages.includes(language);
-const isKeyboardValid = (keyboard: string) =>
-  keyboard === '' || keyboards.includes(keyboard);
-
-const getDuplicateLanguages = (languages: string[]) => [
-  ...new Set(
-    languages.filter(
-      (language, index) => languages.indexOf(language) !== index,
-    ),
-  ),
-];
 
 describe('locale validation', () => {
   describe('languages', () => {
     it('accepts a supported language', () => {
-      expect(isLanguageValid('en_US.UTF-8')).toBe(true);
+      expect(validateLanguages(['en_US.UTF-8'])).toEqual([]);
     });
 
     it('accepts the default C locale', () => {
-      expect(isLanguageValid('C.UTF-8')).toBe(true);
+      expect(validateLanguages(['C.UTF-8'])).toEqual([]);
     });
 
     it('accepts multiple supported languages', () => {
       expect(
-        ['en_US.UTF-8', 'de_DE.UTF-8', 'nl_NL.UTF-8'].every(isLanguageValid),
-      ).toBe(true);
+        validateLanguages(['en_US.UTF-8', 'de_DE.UTF-8', 'nl_NL.UTF-8']),
+      ).toEqual([]);
     });
 
     it('rejects an unknown language', () => {
-      expect(isLanguageValid('xx_XX.UTF-8')).toBe(false);
-    });
-
-    it('allows an empty language list', () => {
-      expect([].every(isLanguageValid)).toBe(true);
-    });
-  });
-
-  describe('duplicate languages', () => {
-    it('returns no duplicates for unique languages', () => {
-      expect(getDuplicateLanguages(['en_US.UTF-8', 'de_DE.UTF-8'])).toEqual([]);
-    });
-
-    it('identifies a duplicate language', () => {
-      expect(getDuplicateLanguages(['en_US.UTF-8', 'en_US.UTF-8'])).toEqual([
-        'en_US.UTF-8',
+      expect(validateLanguages(['xx_XX.UTF-8'])).toEqual([
+        {
+          kind: 'format',
+          message: 'Unknown language',
+          value: 'xx_XX.UTF-8',
+        },
       ]);
     });
 
-    it('reports each duplicate only once', () => {
-      expect(
-        getDuplicateLanguages(['en_US.UTF-8', 'en_US.UTF-8', 'en_US.UTF-8']),
-      ).toEqual(['en_US.UTF-8']);
+    it('accepts an empty or omitted language list', () => {
+      expect(validateLanguages([])).toEqual([]);
+      expect(validateLanguages()).toEqual([]);
+    });
+
+    it('flags duplicate languages', () => {
+      expect(validateLanguages(['en_US.UTF-8', 'en_US.UTF-8'])).toEqual([
+        {
+          kind: 'duplicate',
+          message: 'Duplicate languages: en_US.UTF-8',
+          value: 'en_US.UTF-8',
+        },
+      ]);
     });
   });
 
   describe('keyboards', () => {
     it('accepts a supported keyboard', () => {
-      expect(isKeyboardValid('us')).toBe(true);
+      expect(validateKeyboard('us')).toEqual([]);
     });
 
     it('accepts a keyboard with a variant', () => {
-      expect(isKeyboardValid('us-dvorak')).toBe(true);
+      expect(validateKeyboard('us-dvorak')).toEqual([]);
     });
 
     it('rejects an unknown keyboard', () => {
-      expect(isKeyboardValid('unknown-keyboard')).toBe(false);
+      expect(validateKeyboard('unknown-keyboard')).toEqual([
+        {
+          kind: 'format',
+          message: 'Unknown keyboard',
+          value: 'unknown-keyboard',
+        },
+      ]);
     });
 
-    it('allows an empty keyboard', () => {
-      expect(isKeyboardValid('')).toBe(true);
+    it('accepts an empty or omitted keyboard', () => {
+      expect(validateKeyboard('')).toEqual([]);
+      expect(validateKeyboard()).toEqual([]);
+    });
+  });
+
+  describe('locale objects', () => {
+    it('accepts an empty locale object', () => {
+      expect(validateLocale({})).toEqual([]);
+    });
+
+    it('accepts a locale with languages and a keyboard', () => {
+      expect(
+        validateLocale({
+          languages: ['en_US.UTF-8', 'de_DE.UTF-8'],
+          keyboard: 'us',
+        }),
+      ).toEqual([]);
+    });
+
+    it('reports invalid languages and keyboard values', () => {
+      const result = validateLocale({
+        languages: ['xx_XX.UTF-8'],
+        keyboard: 'unknown-keyboard',
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result.map(({ message }) => message)).toEqual([
+        'Unknown language',
+        'Unknown keyboard',
+      ]);
     });
   });
 });

--- a/src/store/slices/wizard/system/types.ts
+++ b/src/store/slices/wizard/system/types.ts
@@ -1,10 +1,11 @@
 import z from 'zod';
 
-import { Locale, User } from '@/store/api/backend';
+import { User } from '@/store/api/backend';
 
 import {
   firewallSchema,
   kernelSchema,
+  localeSchema,
   servicesSchema,
   systemSchema,
   timezoneSchema,
@@ -14,6 +15,7 @@ export type Kernel = z.infer<typeof kernelSchema>;
 export type Services = z.infer<typeof servicesSchema>;
 export type Firewall = z.infer<typeof firewallSchema>;
 export type Timezone = z.infer<typeof timezoneSchema>;
+export type Locale = z.infer<typeof localeSchema>;
 
 export type UserWithAdditionalInfo = {
   [K in keyof User]-?: NonNullable<User[K]>;
@@ -63,7 +65,6 @@ export type UserGroup = {
 };
 
 export type SystemSlice = z.infer<typeof systemSchema> & {
-  locale: Locale;
   firstBoot: {
     script: string;
   };

--- a/src/store/slices/wizard/system/validators.ts
+++ b/src/store/slices/wizard/system/validators.ts
@@ -4,13 +4,16 @@ import {
   firewallSchema,
   hostnameSchema,
   kernelSchema,
+  keyboardSchema,
+  languageListSchema,
+  localeSchema,
   ntpServersSchema,
   servicesSchema,
   systemSchema,
   timezoneSchema,
   timezoneValueSchema,
 } from './schemas';
-import { Firewall, Kernel, Services, Timezone } from './types';
+import { Firewall, Kernel, Locale, Services, Timezone } from './types';
 
 import { validateList, validateSchema } from '../validators';
 
@@ -68,6 +71,18 @@ export const validateNtpServers = (servers?: string[] | undefined) => {
 
 export const validateTimezone = (timezone: Timezone) => {
   return validateSchema(timezoneSchema, timezone);
+};
+
+export const validateLanguages = (languages?: string[] | undefined) => {
+  return validateList(languageListSchema, languages);
+};
+
+export const validateKeyboard = (keyboard?: string | undefined) => {
+  return validateSchema(keyboardSchema, keyboard);
+};
+
+export const validateLocale = (locale: Locale) => {
+  return validateSchema(localeSchema, locale);
 };
 
 // TODO: change this to the proper type once all the subslice elements


### PR DESCRIPTION
## Summary

Migrate Locale validation to the shared system Zod schema and validator flow, matching the existing Timezone validation approach. This makes the schema the source of truth for supported languages and keyboards while keeping validation feedback in the wizard UI.

## Changes

- Move the language and keyboard allowlists into `store/wizard/system` constants alongside the timezone list.
- Add Locale schemas, schema-derived types, and reusable validators for languages, keyboards, and Locale objects.
- Remove the duplicated Locale validation from the wizard-level validation hooks and rely on `validateSystemSlice`.
- Add `ValidatedInputHelperText` and use it for validation messages in the Locale/Timezone controls and validated list inputs.
- Update Locale, ImportMode, and system validation tests to cover the schema-based validators.
